### PR TITLE
Emit instrumentation events

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   setupTestFrameworkScriptFile: '<rootDir>/testHelpers/setup.js',
   testResultsProcessor: './node_modules/jest-junit',
   testPathIgnorePatterns: ['/node_modules/'],
+  testEnvironment: 'node',
 }

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -7,7 +7,7 @@ const { KafkaJSError } = require('../errors')
 
 const eventNames = Object.values(events)
 const eventKeys = Object.keys(events)
-  .map(key => `Consumer.${key}`)
+  .map(key => `consumer.events.${key}`)
   .join(', ')
 
 module.exports = ({

--- a/src/consumer/index.spec.js
+++ b/src/consumer/index.spec.js
@@ -37,7 +37,6 @@ describe('Consumer', () => {
       groupId,
       maxWaitTimeInMs: 1,
       logger: newLogger(),
-      heartbeatInterval: 100,
     })
   })
 

--- a/src/consumer/index.spec.js
+++ b/src/consumer/index.spec.js
@@ -1,6 +1,7 @@
 const createProducer = require('../producer')
 const createConsumer = require('./index')
 const { Types } = require('../protocol/message/compression')
+const { KafkaJSError } = require('../errors')
 
 const {
   secureRandom,
@@ -36,12 +37,20 @@ describe('Consumer', () => {
       groupId,
       maxWaitTimeInMs: 1,
       logger: newLogger(),
+      heartbeatInterval: 100,
     })
   })
 
   afterEach(async () => {
     await consumer.disconnect()
     await producer.disconnect()
+  })
+
+  test('on throws an error when provided with an invalid event name', () => {
+    expect(() => consumer.on('NON_EXISTENT_EVENT', () => {})).toThrow(
+      KafkaJSError,
+      /Event name should be one of/
+    )
   })
 
   test('support SSL connections', async () => {

--- a/src/consumer/instrumentationEvents.js
+++ b/src/consumer/instrumentationEvents.js
@@ -1,0 +1,7 @@
+const InstrumentationEventType = require('../instrumentation/eventType')
+const consumerType = InstrumentationEventType('consumer')
+
+module.exports = {
+  HEARTBEAT: consumerType('heartbeat'),
+  COMMIT_OFFSETS: consumerType('commit_offsets'),
+}

--- a/src/consumer/instrumentationEvents.spec.js
+++ b/src/consumer/instrumentationEvents.spec.js
@@ -70,11 +70,10 @@ describe('Consumer > Instrumentation Events', () => {
     })
   })
 
-  it.only('emits commit offsets', async () => {
+  it('emits commit offsets', async () => {
     const onCommitOffsets = jest.fn()
     let commitOffsets = 0
     consumer.on(consumer.events.COMMIT_OFFSETS, async event => {
-      console.log('Committed offsets', event)
       onCommitOffsets(event)
       commitOffsets++
     })
@@ -82,10 +81,8 @@ describe('Consumer > Instrumentation Events', () => {
     await consumer.connect()
     await producer.connect()
     await consumer.subscribe({ topic: topicName, fromBeginning: true })
-    console.log('Starting run')
     consumer.run({ eachMessage: () => true })
     await producer.send({ topic: topicName, messages: [message] })
-    console.log('Has sent')
 
     await waitFor(() => commitOffsets > 0)
     expect(onCommitOffsets).toHaveBeenCalledWith({

--- a/src/consumer/instrumentationEvents.spec.js
+++ b/src/consumer/instrumentationEvents.spec.js
@@ -1,0 +1,113 @@
+const createProducer = require('../producer')
+const createConsumer = require('./index')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  createModPartitioner,
+  newLogger,
+  waitFor,
+} = require('testHelpers')
+
+describe('Consumer > Instrumentation Events', () => {
+  let topicName, groupId, cluster, producer, consumer, message
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    createTopic({ topic: topicName })
+
+    cluster = createCluster()
+    producer = createProducer({
+      cluster,
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      maxWaitTimeInMs: 1,
+      logger: newLogger(),
+      heartbeatInterval: 100,
+    })
+
+    message = { key: `key-${secureRandom()}`, value: `value-${secureRandom()}` }
+  })
+
+  afterEach(async () => {
+    await consumer.disconnect()
+    await producer.disconnect()
+  })
+
+  it('emits heartbeat', async () => {
+    const onHeartbeat = jest.fn()
+    let heartbeats = 0
+    consumer.on(consumer.events.HEARTBEAT, async event => {
+      onHeartbeat(event)
+      heartbeats++
+    })
+
+    await consumer.connect()
+    await producer.connect()
+    await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+    consumer.run({ eachMessage: () => true })
+    await producer.send({ topic: topicName, messages: [message] })
+
+    await waitFor(() => heartbeats > 0)
+    expect(onHeartbeat).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'consumer.heartbeat',
+      payload: {
+        groupId,
+        memberId: expect.any(String),
+        groupGenerationId: expect.any(Number),
+      },
+    })
+  })
+
+  it.only('emits commit offsets', async () => {
+    const onCommitOffsets = jest.fn()
+    let commitOffsets = 0
+    consumer.on(consumer.events.COMMIT_OFFSETS, async event => {
+      console.log('Committed offsets', event)
+      onCommitOffsets(event)
+      commitOffsets++
+    })
+
+    await consumer.connect()
+    await producer.connect()
+    await consumer.subscribe({ topic: topicName, fromBeginning: true })
+    console.log('Starting run')
+    consumer.run({ eachMessage: () => true })
+    await producer.send({ topic: topicName, messages: [message] })
+    console.log('Has sent')
+
+    await waitFor(() => commitOffsets > 0)
+    expect(onCommitOffsets).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'consumer.commit_offsets',
+      payload: {
+        groupId,
+        memberId: expect.any(String),
+        groupGenerationId: expect.any(Number),
+        topics: [
+          {
+            topic: topicName,
+            partitions: [
+              {
+                offset: '1',
+                partition: '0',
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+})

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -144,7 +144,6 @@ module.exports = class OffsetManager {
     }
 
     await this.coordinator.offsetCommit(payload)
-
     this.instrumentationEmitter.emit(COMMIT_OFFSETS, payload)
 
     // Update local reference of committed offsets

--- a/src/instrumentation/emitter.js
+++ b/src/instrumentation/emitter.js
@@ -18,7 +18,6 @@ module.exports = class InstrumentationEventEmitter {
 
   addListener(eventName, listener) {
     this.emitter.addListener(eventName, listener)
-
     return () => this.emitter.removeListener(eventName, listener)
   }
 }

--- a/src/instrumentation/emitter.js
+++ b/src/instrumentation/emitter.js
@@ -1,0 +1,24 @@
+const EventEmitter = require('events')
+const InstrumentationEvent = require('./event')
+const { KafkaJSError } = require('../errors')
+
+module.exports = class InstrumentationEventEmitter {
+  constructor() {
+    this.emitter = new EventEmitter()
+  }
+
+  emit(eventName, payload) {
+    if (!eventName) {
+      throw new KafkaJSError('Invalid event name', { retriable: false })
+    }
+
+    const event = new InstrumentationEvent(eventName, payload)
+    this.emitter.emit(eventName, event)
+  }
+
+  addListener(eventName, listener) {
+    this.emitter.addListener(eventName, listener)
+
+    return () => this.emitter.removeListener(eventName, listener)
+  }
+}

--- a/src/instrumentation/event.js
+++ b/src/instrumentation/event.js
@@ -9,7 +9,6 @@ const nextId = () => {
 
 class InstrumentationEvent {
   /**
-   * 
    * @param {String} type 
    * @param {Object} payload 
    */

--- a/src/instrumentation/event.js
+++ b/src/instrumentation/event.js
@@ -1,0 +1,24 @@
+let id = 0
+const nextId = () => {
+  if (id === Number.MAX_VALUE) {
+    id = 0
+  }
+
+  return id++
+}
+
+class InstrumentationEvent {
+  /**
+   * 
+   * @param {String} type 
+   * @param {Object} payload 
+   */
+  constructor(type, payload) {
+    this.id = nextId()
+    this.type = type
+    this.timestamp = Date.now()
+    this.payload = payload
+  }
+}
+
+module.exports = InstrumentationEvent

--- a/src/instrumentation/eventType.js
+++ b/src/instrumentation/eventType.js
@@ -1,0 +1,1 @@
+module.exports = namespace => type => `${namespace}.${type}`


### PR DESCRIPTION
Allows the user to subscribe to instrumentation events.

Currently supported events:

* `consumer.heartbeat`
* `consumer.commit_offsets`

Undocumented on purpose, as it will likely change later.