### PR TITLE
Improve user API

### DIFF
--- a/src/consumer/batch.js
+++ b/src/consumer/batch.js
@@ -25,11 +25,12 @@ module.exports = class Batch {
   }
 
   offsetLag() {
-    return this.isEmpty()
-      ? '0'
-      : Long.fromValue(this.highWatermark)
-          .add(-1)
-          .add(-1 * Long.fromValue(this.lastOffset()))
-          .toString()
+    if (this.isEmpty()) {
+      return '0'
+    }
+
+    const lastOffsetOfPartition = Long.fromValue(this.highWatermark).add(-1)
+    const lastConsumedOffset = Long.fromValue(this.lastOffset())
+    return lastOffsetOfPartition.add(lastConsumedOffset.multiply(-1)).toString()
   }
 }

--- a/src/consumer/batch.js
+++ b/src/consumer/batch.js
@@ -23,4 +23,13 @@ module.exports = class Batch {
           .toString()
       : this.messages[this.messages.length - 1].offset
   }
+
+  offsetLag() {
+    return this.isEmpty()
+      ? '0'
+      : Long.fromValue(this.highWatermark)
+          .add(-1)
+          .add(-1 * Long.fromValue(this.lastOffset()))
+          .toString()
+  }
 }

--- a/src/consumer/batch.spec.js
+++ b/src/consumer/batch.spec.js
@@ -1,0 +1,93 @@
+const Batch = require('./batch')
+
+describe('Consumer > Batch', () => {
+  const topic = 'topic-name'
+
+  describe('#isEmpty', () => {
+    it('returns true when empty', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [],
+      })
+
+      expect(batch.isEmpty()).toEqual(true)
+    })
+
+    it('returns false when it has messages', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{}, {}],
+      })
+
+      expect(batch.isEmpty()).toEqual(false)
+    })
+  })
+
+  describe('#firstOffset', () => {
+    it('returns the offset of the first message', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{ offset: '1' }, { offset: '2' }],
+      })
+
+      expect(batch.firstOffset()).toEqual('1')
+    })
+
+    it('returns null when the batch is empty', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [],
+      })
+
+      expect(batch.firstOffset()).toEqual(null)
+    })
+  })
+
+  describe('#lastOffset', () => {
+    it('returns the offset of the last message', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{ offset: '1' }, { offset: '2' }],
+      })
+
+      expect(batch.lastOffset()).toEqual('2')
+    })
+
+    it('returns highWatermark - 1 when the batch is empty', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [],
+      })
+
+      expect(batch.lastOffset()).toEqual('99')
+    })
+  })
+
+  describe('#offsetLag', () => {
+    it('returns the difference between highWatermark - 1 and the last offset', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{ offset: '3' }, { offset: '4' }],
+      })
+
+      expect(batch.offsetLag()).toEqual('95')
+    })
+
+    it('returns 0 when the batch is empty', () => {
+      const batch = new Batch(topic, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [],
+      })
+
+      expect(batch.offsetLag()).toEqual('0')
+    })
+  })
+})

--- a/src/consumer/index.spec.js
+++ b/src/consumer/index.spec.js
@@ -187,9 +187,9 @@ describe('Consumer', () => {
     const batchesConsumed = []
     const functionsExposed = []
     consumer.run({
-      eachBatch: async ({ batch, resolveOffset, heartbeat }) => {
+      eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning }) => {
         batchesConsumed.push(batch)
-        functionsExposed.push(resolveOffset, heartbeat)
+        functionsExposed.push(resolveOffset, heartbeat, isRunning)
       },
     })
 
@@ -220,7 +220,11 @@ describe('Consumer', () => {
       },
     ])
 
-    expect(functionsExposed).toEqual([expect.any(Function), expect.any(Function)])
+    expect(functionsExposed).toEqual([
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+    ])
   })
 
   it('stops consuming messages when running = false', async () => {

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -107,6 +107,7 @@ module.exports = class Runner {
         heartbeat: async () => {
           await this.consumerGroup.heartbeat({ interval: this.heartbeatInterval })
         },
+        isRunning: () => this.running,
       })
     } catch (e) {
       // eachBatch has a special resolveOffset which can be used


### PR DESCRIPTION
* Add `offsetLag` to consumer batch
* Expose to `eachBatch` if the consumer is running (`isRunning`), which allow users to stop processing the batch when the consumer is shutting down

@Nevon ^