### PR TITLE
Don't rely on seed broker for finding group coordinator

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "test:local:watch": "yarn test:local --watch",
     "test:local": "./node_modules/.bin/jest",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch",
     "test": "yarn lint && JEST_JUNIT_OUTPUT=test-report.xml ./scripts/testWithKafka.sh './node_modules/.bin/jest --coverage --forceExit'",
     "lint": "./node_modules/.bin/eslint example.js \"{src,testHelpers}/**/*.js\""
   },

--- a/src/cluster/findGroupCoordinator.spec.js
+++ b/src/cluster/findGroupCoordinator.spec.js
@@ -1,5 +1,8 @@
+jest.mock('../utils/shuffle')
+const shuffle = require('../utils/shuffle')
+shuffle.mockImplementation(brokers => brokers.sort((a, b) => a > b))
 const { createCluster, secureRandom } = require('../../testHelpers')
-const { KafkaJSBrokerNotFound } = require('../errors')
+const { KafkaJSBrokerNotFound, KafkaJSConnectionError } = require('../errors')
 
 describe('Cluster > findGroupCoordinator', () => {
   let cluster, groupId
@@ -30,8 +33,23 @@ describe('Cluster > findGroupCoordinator', () => {
         throw new KafkaJSBrokerNotFound('Not found')
       })
       .mockImplementationOnce(() => firstNode)
+      .mockImplementationOnce(() => firstNode)
 
     await expect(cluster.findGroupCoordinator({ groupId })).resolves.toEqual(firstNode)
-    expect(cluster.findBroker).toHaveBeenCalledTimes(2)
+    expect(cluster.findBroker).toHaveBeenCalledTimes(3)
+  })
+
+  test('attempt to find coordinator across all brokers until one is found', async () => {
+    jest.spyOn(cluster.brokerPool[0], 'findGroupCoordinator').mockImplementation(() => {
+      throw new KafkaJSConnectionError('Something went wrong')
+    })
+    jest.spyOn(cluster.brokerPool[1], 'findGroupCoordinator').mockImplementation(() => {
+      throw new KafkaJSConnectionError('Something went wrong')
+    })
+    jest
+      .spyOn(cluster.brokerPool[2], 'findGroupCoordinator')
+      .mockImplementation(() => ({ coordinator: { nodeId: 2 } }))
+
+    await expect(cluster.findGroupCoordinator({ groupId })).resolves.toEqual(cluster.brokerPool[2])
   })
 })

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -8,7 +8,7 @@ const {
 } = require('../errors')
 const flatten = require('../utils/flatten')
 const shuffle = require('../utils/shuffle')
-const { keys, values } = Object
+const { keys } = Object
 
 const EARLIEST_OFFSET = -2
 const LATEST_OFFSET = -1

--- a/src/errors.js
+++ b/src/errors.js
@@ -42,6 +42,7 @@ class KafkaJSPartialMessageError extends KafkaJSNonRetriableError {}
 class KafkaJSSASLAuthenticationError extends KafkaJSNonRetriableError {}
 class KafkaJSConnectionError extends KafkaJSError {}
 class KafkaJSBrokerNotFound extends KafkaJSError {}
+class KafkaJSGroupCoordinatorNotFound extends KafkaJSNonRetriableError {}
 class KafkaJSNotImplemented extends KafkaJSNonRetriableError {}
 
 module.exports = {
@@ -53,5 +54,6 @@ module.exports = {
   KafkaJSSASLAuthenticationError,
   KafkaJSNumberOfRetriesExceeded,
   KafkaJSOffsetOutOfRange,
+  KafkaJSGroupCoordinatorNotFound,
   KafkaJSNotImplemented,
 }

--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -1,0 +1,1 @@
+module.exports = array => [...array].sort(() => Math.random() - 0.5)

--- a/src/utils/shuffle.spec.js
+++ b/src/utils/shuffle.spec.js
@@ -1,0 +1,19 @@
+const shuffle = require('./shuffle')
+
+describe('Utils > shuffle', () => {
+  it('shuffles', () => {
+    const array = [1, 2, 3]
+    jest
+      .spyOn(Math, 'random')
+      .mockImplementationOnce(() => 0.4)
+      .mockImplementationOnce(() => 0.7)
+      .mockImplementationOnce(() => 0.4)
+      .mockImplementationOnce(() => 0.6)
+      .mockImplementationOnce(() => 0.6)
+      .mockImplementationOnce(() => 0.6)
+
+    expect(shuffle(array)).toEqual([1, 3, 2])
+    expect(shuffle(array)).toEqual([3, 2, 1])
+    expect(Math.random).toHaveBeenCalledTimes(6)
+  })
+})


### PR DESCRIPTION
Since the connection to the seed broker may have been broken, or the seed broker may even be gone, when trying to find the group coordinator, we ask each broker in the broker pool until we find the coordinator.

Shuffles the broker pool to make sure that we don't ask the same brokers in the same order on each retry.