### PR TITLE
Add consumer seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ or
 # This will run a kafka cluster configured with your current IP
 ./scripts/dockerComposeUp.sh
 yarn test:local
+
+# To run with logs
+# LOG_LEVEL=debug yarn test:local
 ```
 
 Password for test keystore and certificates: `testtest`  

--- a/src/consumer/index.spec.js
+++ b/src/consumer/index.spec.js
@@ -1,7 +1,7 @@
 const createProducer = require('../producer')
 const createConsumer = require('./index')
 const { Types } = require('../protocol/message/compression')
-const { KafkaJSError } = require('../errors')
+const { KafkaJSNonRetriableError } = require('../errors')
 
 const {
   secureRandom,
@@ -47,7 +47,7 @@ describe('Consumer', () => {
 
   test('on throws an error when provided with an invalid event name', () => {
     expect(() => consumer.on('NON_EXISTENT_EVENT', () => {})).toThrow(
-      KafkaJSError,
+      KafkaJSNonRetriableError,
       /Event name should be one of/
     )
   })
@@ -416,6 +416,127 @@ describe('Consumer', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('when seek offset', () => {
+    it('throws an error if the topic is invalid', () => {
+      expect(() => consumer.seek({ topic: null })).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid topic null'
+      )
+    })
+
+    it('throws an error if the partition is not a number', () => {
+      expect(() => consumer.seek({ topic: topicName, partition: 'ABC' })).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid partition, expected a number received ABC'
+      )
+    })
+
+    it('throws an error if the offset is not a number', () => {
+      expect(() => consumer.seek({ topic: topicName, partition: 0, offset: 'ABC' })).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid offset, expected a long received ABC'
+      )
+    })
+
+    it('throws an error if the offset is negative', () => {
+      expect(() => consumer.seek({ topic: topicName, partition: 0, offset: '-1' })).toThrow(
+        KafkaJSNonRetriableError,
+        'Offset must not be a negative number'
+      )
+    })
+
+    it('throws an error if called before consumer run', () => {
+      expect(() => consumer.seek({ topic: topicName, partition: 0, offset: '1' })).toThrow(
+        KafkaJSNonRetriableError,
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    })
+
+    it('updates the partition offset to the given offset', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key1 = secureRandom()
+      const message1 = { key: `key-${key1}`, value: `value-${key1}` }
+      const key2 = secureRandom()
+      const message2 = { key: `key-${key2}`, value: `value-${key2}` }
+      const key3 = secureRandom()
+      const message3 = { key: `key-${key3}`, value: `value-${key3}` }
+
+      await producer.send({ topic: topicName, messages: [message1, message2, message3] })
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+      const messagesConsumed = []
+      consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+      consumer.seek({ topic: topicName, partition: 0, offset: 1 })
+
+      await expect(waitForMessages(messagesConsumed, { number: 2 })).resolves.toEqual([
+        {
+          topic: topicName,
+          partition: 0,
+          message: expect.objectContaining({ offset: '1' }),
+        },
+        {
+          topic: topicName,
+          partition: 0,
+          message: expect.objectContaining({ offset: '2' }),
+        },
+      ])
+    })
+
+    it('uses the last seek for a given topic/partition', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key1 = secureRandom()
+      const message1 = { key: `key-${key1}`, value: `value-${key1}` }
+      const key2 = secureRandom()
+      const message2 = { key: `key-${key2}`, value: `value-${key2}` }
+      const key3 = secureRandom()
+      const message3 = { key: `key-${key3}`, value: `value-${key3}` }
+
+      await producer.send({ topic: topicName, messages: [message1, message2, message3] })
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+      const messagesConsumed = []
+      consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+      consumer.seek({ topic: topicName, partition: 0, offset: 0 })
+      consumer.seek({ topic: topicName, partition: 0, offset: 1 })
+      consumer.seek({ topic: topicName, partition: 0, offset: 2 })
+
+      await expect(waitForMessages(messagesConsumed, { number: 1 })).resolves.toEqual([
+        {
+          topic: topicName,
+          partition: 0,
+          message: expect.objectContaining({ offset: '2' }),
+        },
+      ])
+    })
+
+    it('recovers from offset out of range', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key1 = secureRandom()
+      const message1 = { key: `key-${key1}`, value: `value-${key1}` }
+
+      await producer.send({ topic: topicName, messages: [message1] })
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+      const messagesConsumed = []
+      consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+      consumer.seek({ topic: topicName, partition: 0, offset: 100 })
+
+      await expect(waitForMessages(messagesConsumed, { number: 1 })).resolves.toEqual([
+        {
+          topic: topicName,
+          partition: 0,
+          message: expect.objectContaining({ offset: '0' }),
+        },
+      ])
     })
   })
 })

--- a/src/consumer/offsetManager/seek.spec.js
+++ b/src/consumer/offsetManager/seek.spec.js
@@ -1,0 +1,27 @@
+const OffsetManager = require('./index')
+
+describe('Consumer > OffsetMananger > seek', () => {
+  let offsetManager, coordinator
+  beforeEach(() => {
+    const memberAssignment = {
+      topic1: [0, 1, 2, 3],
+      topic2: [0, 1, 2, 3, 4, 5],
+    }
+
+    coordinator = { offsetCommit: jest.fn() }
+    offsetManager = new OffsetManager({ memberAssignment })
+    offsetManager.getCoordinator = jest.fn(() => coordinator)
+  })
+
+  it('ignores the seek when the consumer is not assigned to the topic', async () => {
+    await offsetManager.seek({ topic: 'topic3', partition: 0, offset: '100' })
+    expect(offsetManager.getCoordinator).not.toHaveBeenCalled()
+    expect(coordinator.offsetCommit).not.toHaveBeenCalled()
+  })
+
+  it('ignores the seek when the consumer is not assigned to the partition', async () => {
+    await offsetManager.seek({ topic: 'topic1', partition: 4, offset: '101' })
+    expect(offsetManager.getCoordinator).not.toHaveBeenCalled()
+    expect(coordinator.offsetCommit).not.toHaveBeenCalled()
+  })
+})

--- a/src/consumer/seekOffsets.js
+++ b/src/consumer/seekOffsets.js
@@ -1,0 +1,18 @@
+module.exports = class SeekOffsets extends Map {
+  set(topic, partition, offset) {
+    super.set([topic, partition], offset)
+  }
+
+  pop() {
+    if (this.size === 0) {
+      return
+    }
+
+    const [key, offset] = Array.from(this.entries())
+      .reverse()
+      .pop()
+    this.delete(key)
+    const [topic, partition] = key
+    return { topic, partition, offset }
+  }
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -53,6 +53,7 @@ class KafkaJSNotImplemented extends KafkaJSNonRetriableError {}
 
 module.exports = {
   KafkaJSError,
+  KafkaJSNonRetriableError,
   KafkaJSPartialMessageError,
   KafkaJSBrokerNotFound,
   KafkaJSProtocolError,

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -6,10 +6,13 @@ const crypto = require('crypto')
 const Cluster = require('../src/cluster')
 const connectionBuilder = require('../src/cluster/connectionBuilder')
 const Connection = require('../src/network/connection')
-const { createLogger, LEVELS: { NOTHING } } = require('../src/loggers')
+const { createLogger, LEVELS } = require('../src/loggers')
 const logFunctionConsole = require('../src/loggers/console')
 
-const newLogger = () => createLogger({ level: NOTHING, logFunction: logFunctionConsole })
+const envLogLevel = (process.env.LOG_LEVEL || '').toUpperCase()
+const logLevel = LEVELS[envLogLevel] || LEVELS.NOTHING
+
+const newLogger = () => createLogger({ level: logLevel, logFunction: logFunctionConsole })
 const getHost = () => process.env.HOST_IP || ip.address()
 const secureRandom = (length = 10) => crypto.randomBytes(length).toString('hex')
 const plainTextBrokers = (host = getHost()) => [`${host}:9092`, `${host}:9095`, `${host}:9098`]

--- a/testHelpers/setup.js
+++ b/testHelpers/setup.js
@@ -1,2 +1,2 @@
 /* global jasmine */
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 45000


### PR DESCRIPTION
This PR exposes a new function to allow consumers to seek offsets for a given topic/partition. This feature is supported by the java client and it's quite useful for error handling.

The proposed API is:

```javascript
await consumer.subscribe({ topic: 'topic-1' })
consumer.run({ eachMessage: async () => true })
consumer.seek({ topic: 'topic-1', partition: 1, offset: '123854' })
consumer.seek({ topic: 'topic-1', partition: 2, offset: '59839' })
consumer.seek({ topic: 'topic-1', partition: 3, offset: '983412' })
```

`consumer#seek` must be called after `run` because the `ConsumerGroup` must be initialized but the seek only happens in the fetch loop of the consumer assigned to the topic/partition after the join/sync.