### PR TITLE
Improve logger and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,30 +3,233 @@
 
 # KafkaJS
 
-A modern Apache Kafka client for node.js
+A modern Apache Kafka client for node.js. This library is compatible with Kafka `0.10+`.
 
-__In active development - early alpha__
+__In active development - alpha__
 
-- Fully working producer compatible with 0.10.x (0.9.x will be possible soon)
-- Fully working consumer groups compatible with 0.10.x (0.9.x will be possible soon)
+## Features
+
+- Producer
+- Consumer groups
 - GZIP compression
 - Plain, SSL and SASL_SSL implementations
 
-## Usage
+## Table of Contents
 
-### Setting up the Client
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Setting up the Client](#setup-client)
+    - [SSL](#setup-client-ssl)
+    - [SASL](#setup-client-sasl)
+    - [Connection timeout](#setup-client-connection-timeout)
+    - [Default retry](#setup-client-default-retry)
+    - [Logger](#setup-client-logger)
+  - [Producing Messages to Kafka](#producing-messages)
+    - [Custom partitioner](#producing-messages-custom-partitioner)
+    - [Retry](#producing-messages-retry)
+  - [Consuming messages from Kafka](consuming-messages)
+    - [Options](consuming-messages-options)
+    - [Custom assigner](#consuming-messages-custom-assigner)
+  - [Instrumentation](#instrumentation)
+  - [Development](#development)
+
+## <a name="installation"></a> Installation
+
+```sh
+npm install kafkajs
+# yarn add kafkajs
+```
+
+## <a name="usage"></a> Usage
+
+### <a name="setup-client"></a> Setting up the Client
+
+The client must be configured with at least one broker. The brokers on the list are considered seed brokers and are only used to bootstrap the client and load initial metadata.
 
 ```javascript
 const { Kafka } = require('kafkajs')
 
-// Create the client with broker list
+// Create the client with the broker list
 const kafka = new Kafka({
   clientId: 'my-app',
   brokers: ['kafka1:9092', 'kafka2:9092']
 })
 ```
 
-### Producing Messages to Kafka
+#### <a name="setup-client-ssl"></a> SSL
+
+The `ssl` option can be used to configure the TLS sockets. The options are passed directly to `tls.connect` and used to create the TLS Secure Context, all options are accepted.
+
+```javascript
+const fs = require('fs')
+
+new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  ssl: {
+    rejectUnauthorized: false,
+    ca: [fs.readFileSync('/my/custom/ca.crt', 'utf-8')],
+    key: fs.readFileSync('/my/custom/client-key.pem', 'utf-8'),
+    cert: fs.readFileSync('/my/custom/client-cert.pem', 'utf-8')
+  },
+})
+```
+
+Take a look at [TLS create secure context](https://nodejs.org/dist/latest-v8.x/docs/api/tls.html#tls_tls_createsecurecontext_options) for more information.
+
+#### <a name="setup-client-sasl"></a> SASL
+
+Kafka has support for using SASL to authenticate clients. The `sasl` option can be used to configure the authentication mechanism. Currently, KafkaJS only supports the `PLAIN` mechanism.
+
+```javascript
+new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  sasl: {
+    mechanism: 'plain',
+    username: 'my-username',
+    password: 'my-password'
+  },
+})
+```
+
+It is __highly recommended__ that you use SSL for encryption when using `PLAIN`.
+
+#### <a name="setup-client-connection-timeout"></a> Connection Timeout
+
+Time in milliseconds to wait for a successful connection. The default value is: `1000`.
+
+```javascript
+new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  connectionTimeout: 3000
+})
+```
+
+#### <a name="setup-client-default-retry"></a> Default Retry
+
+The `retry` option can be used to set the default configuration. The retry mechanism uses a randomization function that grows exponentially.
+
+Available options:
+
+* __maxRetryTime__ - Maximum wait time for a retry in milliseconds. Default: `30000`
+* __initialRetryTime__ - Initial value used to calculate the retry in milliseconds (This is still randomized following the randomization factor). Default: `300`
+* __factor__ - Randomization factor. Default: `0.2`
+* __multiplier__ - Exponential factor. Default: `2`
+* __retries__ - Max number of retries per call. Default: `5`
+
+```javascript
+new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  retry: {
+    initialRetryTime: 100,
+    retries: 8
+  }
+})
+```
+
+#### <a name="setup-client-logger"></a> Logger
+
+KafkaJS has a built-in `STDOUT` logger which outputs JSON. It also accepts a custom log creator which allows you to integrate your favorite logger library.
+There are 5 log levels available: `NOTHING`, `ERROR`, `WARN`, `INFO`, and `DEBUG`. `INFO` is configured by default.
+
+__How to configure the log level?__
+
+```javascript
+const { Kafka, logLevel } = require('kafkajs')
+
+// Create the client with the broker list
+const kafka = new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  logLevel: logLevel.ERROR
+})
+```
+
+The environment variable `KAFKAJS_LOG_LEVEL` can also be used and it has precedence over the configuration in code, example:
+
+```sh
+KAFKAJS_LOG_LEVEL=info node code.js
+```
+
+__How to create a log creator?___
+
+A log creator is a function which receives a log level and returns a log function. The log function receives two arguments: namespace and log.
+
+`namespace` identifies the component which is performing the log, for example, connection or consumer.
+
+`log` is an object with the following keys: `level`, `timestamp`, 'logger', and `message`
+
+```javascript
+{
+  level: 'INFO', // NOTHING, ERROR, WARN, INFO, or DEBUG
+  timestamp: '2017-12-29T13:39:54.575Z',
+  logger: 'kafkajs',
+  message: 'Started',
+  // ... any other extra key provided to the log function
+}
+```
+
+The general structure looks like this:
+
+```javascript
+const MyLogCreator = logLevel => (namespace, log) => {
+  // Example:
+  // const { level, timestamp, logger, message, ...others } = log
+  // console.log(`${level} [${namespace}] ${message} ${JSON.stringify(others)}`)
+}
+```
+
+Example using [winston](https://github.com/winstonjs/winston):
+
+```javascript
+const winstom = require('winston')
+const toWinstomLogLevel = level => switch(level) {
+  case 'NOTHING':
+    return 'error'
+  default:
+    return level.toLowerCase()
+}
+
+const WinstomLogCreator = logLevel => {
+  const logger = winston.createLogger({
+    level: toWinstomLogLevel(logLevel),
+    transports: [
+      new winston.transports.Console(),
+      new winston.transports.File({ filename: 'myapp.log' })
+    ]
+  })
+
+  return (namespace, { level, message, ...extra }) => {
+    logger.log({
+      level: toWinstomLogLevel(level),
+      message,
+      extra
+    })
+  }
+}
+```
+
+Once you have your log creator you can use the `logCreator` option to configure the client:
+
+```javascript
+const kafka = new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  logLevel: logLevel.ERROR,
+  logCreator: WinstomLogCreator
+})
+```
+
+### <a name="producing-messages"></a> Producing Messages to Kafka
+
+To publish messages to Kafka you have to create a producer. By default the producer is configured to distribute the messages with the following logic:
+
+- If a partition is specified in the message, use it
+- If no partition is specified but a key is present choose a partition based on a hash (murmur2) of the key
+- If no partition or key is present choose a partition in a round-robin fashion
 
 ```javascript
 const producer = kafka.producer()
@@ -46,7 +249,48 @@ async () => {
 }
 ```
 
-### Consuming messages with consumer groups
+#### <a name="producing-messages-custom-partitioner"></a> Custom partitioner
+
+It's possible to assign a custom partitioner to the consumer. A partitioner is a function which returns another function responsible for the partition selection, something like this:
+
+```javascript
+const MyPartitioner = () => {
+  // some initialization
+  return ({ topic, partitionMetadata, message }) => {
+    // select a partition based on some logic
+    // return the partition number
+    return 0
+  }
+}
+```
+
+`partitionMetadata` is an array of partitions with the following structure:
+
+```javascript
+[
+  { partitionId: 1, leader: 1 },
+  { partitionId: 2, leader: 2 },
+  { partitionId: 0, leader: 0 }
+]
+```
+
+To Configure your partitioner use the option `createPartitioner`.
+
+```javascript
+kafka.producer({ createPartitioner: MyPartitioner })
+```
+
+#### <a name="producing-messages-retry"></a> Retry
+
+The option `retry` can be used to customize the configurations for the producer.
+
+Take a look at [Retry](#setup-client-default-retry) for more information.
+
+### <a name="consuming-messages"></a> Consuming messages from Kafka
+
+KafkaJS only supports consumer groups.
+
+Consumer groups allow a group of machines or processes to coordinate access to a list of topics, distributing the load among the consumers. When a consumer fails the load is automatically distributed to other members of the group. Consumer groups must have unique group ids.
 
 ```javascript
 const consumer = kafka.consumer({ groupId: 'my-group' })
@@ -93,35 +337,36 @@ await consumer.run({
         }
       })
 
-      resolveOffset(message.offset)
+      await resolveOffset(message.offset)
+      await heartbeat()
     }
   },
 })
 
 // remember to close your consumer when you leave
+await consumer.disconnect()
 ```
 
-### Configure SSL and SASL
+#### <a name="consuming-messages-options"></a> Options
 
-```javascript
-const fs = require('fs')
-const kafka = new Kafka({
-  clientId: 'my-app',
-  brokers: ['kafka1:9092', 'kafka2:9092']
-  ssl: {
-    cert: fs.readFileSync('<path/to>/client_cert.pem', 'utf-8'),
-    key: fs.readFileSync('<path/to>/client_key.pem', 'utf-8'),
-    ca: [fs.readFileSync('<path/to>/ca_cert.pem', 'utf-8')],
-  },
-  sasl: {
-    mechanism: 'plain',
-    username: 'my-username',
-    password: 'my-password',
-  },
-})
-```
+- __createPartitionAssigner__ - default: `round robin`
+- __sessionTimeout__ - Timeout in milliseconds used to detect failures. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this consumer from the group and initiate a rebalance. default: `30000`
+- __heartbeatInterval__ - The expected time in milliseconds between heartbeats to the consumer coordinator. Heartbeats are used to ensure that the consumer's session stays active. The value must be set lower than session timeout. default: `3000`
+- __maxBytesPerPartition__ - The maximum amount of data per-partition the server will return. This size must be at least as large as the maximum message size the server allows or else it is possible for the producer to send messages larger than the consumer can fetch. If that happens, the consumer can get stuck trying to fetch a large message on a certain partition. default: `1048576` (1MB)
+- __minBytes__ - Minimum amount of data the server should return for a fetch request, otherwise wait up to `maxWaitTimeInMs` for more data to accumulate. default: `1`
+- __maxBytes__ - default: `10485760` (10MB)
+- __maxWaitTimeInMs__ - The maximum amount of time in milliseconds the server will block before answering the fetch request if there isn’t sufficient data to immediately satisfy the requirement given by `minBytes`. default: `5000`,
+- __retry__ - default: `{ retries: 10 }`
 
-## Development
+#### <a name="consuming-messages-custom-assigner"></a> Custom assigner
+
+TODO: write
+
+## <a name="instrumentation"></a> Instrumentation
+
+TODO: write
+
+## <a name="development"></a> Development
 
 https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol  
 http://kafka.apache.org/protocol.html

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jest": "^20.0.4",
     "jest-junit": "^1.5.1",
     "lint-staged": "^6.0.0",
+    "mockdate": "^2.0.2",
     "prettier": "^1.7.0"
   },
   "dependencies": {

--- a/src/loggers/console.js
+++ b/src/loggers/console.js
@@ -1,4 +1,4 @@
-module.exports = (namespace, log) => {
+module.exports = level => (namespace, log) => {
   const label = namespace ? `[${namespace}] ` : ''
   const message = JSON.stringify(Object.assign(log, { message: `${label}${log.message}` }))
 

--- a/src/loggers/console.js
+++ b/src/loggers/console.js
@@ -1,15 +1,21 @@
-module.exports = level => (namespace, log) => {
-  const label = namespace ? `[${namespace}] ` : ''
-  const message = JSON.stringify(Object.assign(log, { message: `${label}${log.message}` }))
+const { LEVELS: logLevel } = require('./index')
 
-  switch (log.level) {
-    case 'INFO':
+module.exports = () => ({ namespace, level, label, log }) => {
+  const prefix = namespace ? `[${namespace}] ` : ''
+  const message = JSON.stringify(
+    Object.assign({ level: label }, log, {
+      message: `${prefix}${log.message}`,
+    })
+  )
+
+  switch (level) {
+    case logLevel.INFO:
       return console.info(message)
-    case 'ERROR':
+    case logLevel.ERROR:
       return console.error(message)
-    case 'WARN':
+    case logLevel.WARN:
       return console.warn(message)
-    case 'DEBUG':
+    case logLevel.DEBUG:
       return console.log(message)
   }
 }

--- a/src/loggers/console.spec.js
+++ b/src/loggers/console.spec.js
@@ -1,0 +1,151 @@
+const MockDate = require('mockdate')
+
+const { createLogger, LEVELS } = require('./index')
+const LoggerConsole = require('./console')
+
+describe('Loggers > Console', () => {
+  let logger, timeNow
+
+  beforeEach(() => {
+    jest.spyOn(global.console, 'info').mockImplementation(() => true)
+    jest.spyOn(global.console, 'error').mockImplementation(() => true)
+    jest.spyOn(global.console, 'warn').mockImplementation(() => true)
+    jest.spyOn(global.console, 'log').mockImplementation(() => true)
+
+    timeNow = new Date('2017-12-29T14:15:38.572Z')
+    MockDate.set(timeNow.getTime())
+
+    logger = createLogger({ level: LEVELS.DEBUG, logCreator: LoggerConsole })
+  })
+
+  afterEach(() => {
+    global.console.info.mockRestore()
+    global.console.error.mockRestore()
+    global.console.warn.mockRestore()
+    global.console.log.mockRestore()
+  })
+
+  it('logs INFO', () => {
+    logger.info('<info message>', { extra1: true })
+    expect(console.info).toHaveBeenCalledWith(
+      JSON.stringify({
+        level: 'INFO',
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<info message>',
+        extra1: true,
+      })
+    )
+  })
+
+  it('logs ERROR', () => {
+    logger.error('<error message>', { extra1: true })
+    expect(console.error).toHaveBeenCalledWith(
+      JSON.stringify({
+        level: 'ERROR',
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<error message>',
+        extra1: true,
+      })
+    )
+  })
+
+  it('logs WARN', () => {
+    logger.warn('<warn message>', { extra1: true })
+    expect(console.warn).toHaveBeenCalledWith(
+      JSON.stringify({
+        level: 'WARN',
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<warn message>',
+        extra1: true,
+      })
+    )
+  })
+
+  it('logs DEBUG', () => {
+    logger.debug('<debug message>', { extra1: true })
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify({
+        level: 'DEBUG',
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<debug message>',
+        extra1: true,
+      })
+    )
+  })
+
+  describe('when the log level is NOTHING', () => {
+    beforeEach(() => {
+      logger = createLogger({ level: LEVELS.NOTHING, logCreator: LoggerConsole })
+    })
+
+    it('does not log', () => {
+      logger.info('<do not log info>', { extra1: true })
+      logger.error('<do not log error>', { extra1: true })
+      logger.warn('<do not log warn>', { extra1: true })
+      logger.debug('<do not log debug>', { extra1: true })
+
+      expect(console.info).not.toHaveBeenCalled()
+      expect(console.error).not.toHaveBeenCalled()
+      expect(console.warn).not.toHaveBeenCalled()
+      expect(console.log).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when namespace is present', () => {
+    beforeEach(() => {
+      const rootLogger = createLogger({ level: LEVELS.DEBUG, logCreator: LoggerConsole })
+      logger = rootLogger.namespace('MyNamespace')
+    })
+
+    it('includes the namespace into the message', () => {
+      logger.info('<namespace info>', { extra1: true })
+      logger.error('<namespace error>', { extra1: true })
+      logger.warn('<namespace warn>', { extra1: true })
+      logger.debug('<namespace debug>', { extra1: true })
+
+      expect(console.info).toHaveBeenCalledWith(
+        JSON.stringify({
+          level: 'INFO',
+          timestamp: timeNow.toISOString(),
+          logger: 'kafkajs',
+          message: '[MyNamespace] <namespace info>',
+          extra1: true,
+        })
+      )
+
+      expect(console.error).toHaveBeenCalledWith(
+        JSON.stringify({
+          level: 'ERROR',
+          timestamp: timeNow.toISOString(),
+          logger: 'kafkajs',
+          message: '[MyNamespace] <namespace error>',
+          extra1: true,
+        })
+      )
+
+      expect(console.warn).toHaveBeenCalledWith(
+        JSON.stringify({
+          level: 'WARN',
+          timestamp: timeNow.toISOString(),
+          logger: 'kafkajs',
+          message: '[MyNamespace] <namespace warn>',
+          extra1: true,
+        })
+      )
+
+      expect(console.log).toHaveBeenCalledWith(
+        JSON.stringify({
+          level: 'DEBUG',
+          timestamp: timeNow.toISOString(),
+          logger: 'kafkajs',
+          message: '[MyNamespace] <namespace debug>',
+          extra1: true,
+        })
+      )
+    })
+  })
+})

--- a/src/loggers/index.js
+++ b/src/loggers/index.js
@@ -1,3 +1,5 @@
+const { keys } = Object
+
 const LEVELS = {
   NOTHING: 0,
   ERROR: 1,
@@ -25,8 +27,12 @@ const createLevel = (label, level, currentLevel, namespace, loggerFunction) => (
   )
 }
 
-const createLogger = ({ level = LEVELS.INFO, logFunction = null } = {}) => {
-  const logLevel = parseInt(process.env.LOG_LEVEL, 10) || level
+const createLogger = ({ level = LEVELS.INFO, logCreator = null } = {}) => {
+  const envLogLevel = (process.env.KAFKAJS_LOG_LEVEL || '').toUpperCase()
+  const logLevel = LEVELS[envLogLevel] || level
+  const logLevelLabel = keys(LEVELS).find(k => LEVELS[k] === logLevel)
+  const logFunction = logCreator(logLevelLabel)
+
   const createLogFunctions = namespace => ({
     info: createLevel('INFO', LEVELS.INFO, logLevel, namespace, logFunction),
     error: createLevel('ERROR', LEVELS.ERROR, logLevel, namespace, logFunction),

--- a/src/loggers/index.spec.js
+++ b/src/loggers/index.spec.js
@@ -1,0 +1,69 @@
+const MockDate = require('mockdate')
+const { createLogger, LEVELS } = require('./index')
+
+describe('Loggers', () => {
+  let logger, timeNow, MyLogCreator, myLogger
+
+  beforeEach(() => {
+    timeNow = new Date('2017-12-29T14:15:38.572Z')
+    MockDate.set(timeNow.getTime())
+
+    myLogger = jest.fn()
+    MyLogCreator = jest.fn(logLevel => {
+      return jest.fn((namespace, log) => {
+        myLogger(logLevel, namespace, log)
+      })
+    })
+
+    const rootLogger = createLogger({ logCreator: MyLogCreator, level: LEVELS.DEBUG })
+    logger = rootLogger.namespace('MyNamespace')
+  })
+
+  it('calls the log creator with the log level', () => {
+    expect(MyLogCreator).toHaveBeenCalledWith('DEBUG')
+  })
+
+  it('calls log function info with namespace and log', () => {
+    logger.info('<message info>', { extra1: true })
+    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
+      level: 'INFO',
+      timestamp: timeNow.toISOString(),
+      logger: 'kafkajs',
+      message: '<message info>',
+      extra1: true,
+    })
+  })
+
+  it('calls log function error with namespace and log', () => {
+    logger.error('<message error>', { extra1: true })
+    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
+      level: 'ERROR',
+      timestamp: timeNow.toISOString(),
+      logger: 'kafkajs',
+      message: '<message error>',
+      extra1: true,
+    })
+  })
+
+  it('calls log function warn with namespace and log', () => {
+    logger.warn('<message warn>', { extra1: true })
+    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
+      level: 'WARN',
+      timestamp: timeNow.toISOString(),
+      logger: 'kafkajs',
+      message: '<message warn>',
+      extra1: true,
+    })
+  })
+
+  it('calls log function debug with namespace and log', () => {
+    logger.debug('<message debug>', { extra1: true })
+    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
+      level: 'DEBUG',
+      timestamp: timeNow.toISOString(),
+      logger: 'kafkajs',
+      message: '<message debug>',
+      extra1: true,
+    })
+  })
+})

--- a/src/loggers/index.spec.js
+++ b/src/loggers/index.spec.js
@@ -10,8 +10,8 @@ describe('Loggers', () => {
 
     myLogger = jest.fn()
     MyLogCreator = jest.fn(logLevel => {
-      return jest.fn((namespace, log) => {
-        myLogger(logLevel, namespace, log)
+      return jest.fn(({ namespace, level, label, log }) => {
+        myLogger(logLevel, { namespace, level, label, log })
       })
     })
 
@@ -20,50 +20,66 @@ describe('Loggers', () => {
   })
 
   it('calls the log creator with the log level', () => {
-    expect(MyLogCreator).toHaveBeenCalledWith('DEBUG')
+    expect(MyLogCreator).toHaveBeenCalledWith(LEVELS.DEBUG)
   })
 
-  it('calls log function info with namespace and log', () => {
+  it('calls log function info with namespace, level, label, and log', () => {
     logger.info('<message info>', { extra1: true })
-    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
-      level: 'INFO',
-      timestamp: timeNow.toISOString(),
-      logger: 'kafkajs',
-      message: '<message info>',
-      extra1: true,
+    expect(myLogger).toHaveBeenCalledWith(LEVELS.DEBUG, {
+      namespace: 'MyNamespace',
+      level: LEVELS.INFO,
+      label: 'INFO',
+      log: {
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<message info>',
+        extra1: true,
+      },
     })
   })
 
-  it('calls log function error with namespace and log', () => {
+  it('calls log function error with namespace, level, label, and log', () => {
     logger.error('<message error>', { extra1: true })
-    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
-      level: 'ERROR',
-      timestamp: timeNow.toISOString(),
-      logger: 'kafkajs',
-      message: '<message error>',
-      extra1: true,
+    expect(myLogger).toHaveBeenCalledWith(LEVELS.DEBUG, {
+      namespace: 'MyNamespace',
+      level: LEVELS.ERROR,
+      label: 'ERROR',
+      log: {
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<message error>',
+        extra1: true,
+      },
     })
   })
 
-  it('calls log function warn with namespace and log', () => {
+  it('calls log function warn with namespace, level, label, and log', () => {
     logger.warn('<message warn>', { extra1: true })
-    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
-      level: 'WARN',
-      timestamp: timeNow.toISOString(),
-      logger: 'kafkajs',
-      message: '<message warn>',
-      extra1: true,
+    expect(myLogger).toHaveBeenCalledWith(LEVELS.DEBUG, {
+      namespace: 'MyNamespace',
+      level: LEVELS.WARN,
+      label: 'WARN',
+      log: {
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<message warn>',
+        extra1: true,
+      },
     })
   })
 
-  it('calls log function debug with namespace and log', () => {
+  it('calls log function debug with namespace, level, label, and log', () => {
     logger.debug('<message debug>', { extra1: true })
-    expect(myLogger).toHaveBeenCalledWith('DEBUG', 'MyNamespace', {
-      level: 'DEBUG',
-      timestamp: timeNow.toISOString(),
-      logger: 'kafkajs',
-      message: '<message debug>',
-      extra1: true,
+    expect(myLogger).toHaveBeenCalledWith(LEVELS.DEBUG, {
+      namespace: 'MyNamespace',
+      level: LEVELS.DEBUG,
+      label: 'DEBUG',
+      log: {
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: '<message debug>',
+        extra1: true,
+      },
     })
   })
 })

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -7,9 +7,9 @@ const Cluster = require('../src/cluster')
 const connectionBuilder = require('../src/cluster/connectionBuilder')
 const Connection = require('../src/network/connection')
 const { createLogger, LEVELS: { NOTHING } } = require('../src/loggers')
-const logFunctionConsole = require('../src/loggers/console')
+const LoggerConsole = require('../src/loggers/console')
 
-const newLogger = () => createLogger({ level: NOTHING, logFunction: logFunctionConsole })
+const newLogger = () => createLogger({ level: NOTHING, logCreator: LoggerConsole })
 const getHost = () => process.env.HOST_IP || ip.address()
 const secureRandom = (length = 10) => crypto.randomBytes(length).toString('hex')
 const plainTextBrokers = (host = getHost()) => [`${host}:9092`, `${host}:9095`, `${host}:9098`]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2062,6 +2062,10 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
This PR does 3 things:

1) Changes the log function into a factory function. The change improves how KafkaJS can interoperate with different log libraries, it also add tests for the logger module
2) Uses the client retry configurations as the default values for producers and consumers
3) Adds extensive but still incomplete documentation

This is the beginning of a proper documentation.

@ticolucci @matthiasfeist can you also take a look at the readme?
