### PR TITLE
Add default assigner to JoinGroup request

### DIFF
--- a/src/broker/heartbeat.spec.js
+++ b/src/broker/heartbeat.spec.js
@@ -21,7 +21,11 @@ describe('Broker > Heartbeat', () => {
     await seedBroker.connect()
     createTopic({ topic: topicName })
 
-    const metadata = await seedBroker.metadata([topicName])
+    const metadata = await retryProtocol(
+      'LEADER_NOT_AVAILABLE',
+      async () => await seedBroker.metadata([topicName])
+    )
+
     // Find leader of partition
     const partitionBroker = metadata.topicMetadata[0].partitionMetadata[0].leader
     const newBrokerData = metadata.brokers.find(b => b.nodeId === partitionBroker)

--- a/src/broker/listOffsets.spec.js
+++ b/src/broker/listOffsets.spec.js
@@ -1,5 +1,11 @@
 const Broker = require('./index')
-const { secureRandom, createConnection, newLogger, createTopic } = require('testHelpers')
+const {
+  secureRandom,
+  createConnection,
+  newLogger,
+  createTopic,
+  retryProtocol,
+} = require('testHelpers')
 
 const EARLIEST = -2
 const LATEST = -1
@@ -16,7 +22,11 @@ describe('Broker > ListOffsets', () => {
     await seedBroker.connect()
     createTopic({ topic: topicName })
 
-    const metadata = await seedBroker.metadata([topicName])
+    const metadata = await retryProtocol(
+      'LEADER_NOT_AVAILABLE',
+      async () => await seedBroker.metadata([topicName])
+    )
+
     // Find leader of partition
     const partitionBroker = metadata.topicMetadata[0].partitionMetadata[0].leader
     const newBrokerData = metadata.brokers.find(b => b.nodeId === partitionBroker)

--- a/src/broker/metadata.spec.js
+++ b/src/broker/metadata.spec.js
@@ -1,5 +1,11 @@
 const Broker = require('./index')
-const { secureRandom, createConnection, newLogger, createTopic } = require('testHelpers')
+const {
+  secureRandom,
+  createConnection,
+  newLogger,
+  createTopic,
+  retryProtocol,
+} = require('testHelpers')
 
 describe('Broker > Metadata', () => {
   let topicName, broker
@@ -24,7 +30,10 @@ describe('Broker > Metadata', () => {
     await broker.connect()
     createTopic({ topic: topicName })
 
-    const response = await broker.metadata([topicName])
+    const response = await retryProtocol(
+      'LEADER_NOT_AVAILABLE',
+      async () => await broker.metadata([topicName])
+    )
 
     expect(response).toMatchObject({
       brokers: expect.arrayContaining([

--- a/src/broker/offsetCommit.spec.js
+++ b/src/broker/offsetCommit.spec.js
@@ -22,7 +22,11 @@ describe('Broker > OffsetCommit', () => {
 
     createTopic({ topic: topicName })
 
-    const metadata = await seedBroker.metadata([topicName])
+    const metadata = await retryProtocol(
+      'LEADER_NOT_AVAILABLE',
+      async () => await seedBroker.metadata([topicName])
+    )
+
     // Find leader of partition
     const partitionBroker = metadata.topicMetadata[0].partitionMetadata[0].leader
     const newBrokerData = metadata.brokers.find(b => b.nodeId === partitionBroker)

--- a/src/broker/offsetFetch.spec.js
+++ b/src/broker/offsetFetch.spec.js
@@ -21,7 +21,11 @@ describe('Broker > OffsetFetch', () => {
     await seedBroker.connect()
     createTopic({ topic: topicName })
 
-    const metadata = await seedBroker.metadata([topicName])
+    const metadata = await retryProtocol(
+      'LEADER_NOT_AVAILABLE',
+      async () => await seedBroker.metadata([topicName])
+    )
+
     // Find leader of partition
     const partitionBroker = metadata.topicMetadata[0].partitionMetadata[0].leader
     const newBrokerData = metadata.brokers.find(b => b.nodeId === partitionBroker)

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -67,7 +67,14 @@ module.exports = class ConsumerGroup {
       groupId,
       sessionTimeout,
       memberId: this.memberId || '',
-      groupProtocols: [this.assigner.protocol({ topics: this.topics })],
+
+      // Keep the default procotol in the list to enable consumers running an old
+      // version of Kafkajs to smoothly transition to the new protocol. The changes
+      // in the protocol format and name happened on PR #27
+      groupProtocols: [
+        this.assigner.protocol({ topics: this.topics }),
+        { name: 'default', metadata: Buffer.from([0, 0]) },
+      ],
     })
 
     this.generationId = groupData.generationId


### PR DESCRIPTION
Keep the default protocol in the list to enable consumers running an old version of KafkaJS to smoothly transition to the new protocol.

Default and RoundRobin are the same so no extra changes are needed now, we are still to using the protocol given by JoinGroup