### PR TITLE
Fix retry on error for message handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ __In active development - alpha__
     - [Logger](#setup-client-logger)
   - [Producing Messages to Kafka](#producing-messages)
     - [Custom partitioner](#producing-messages-custom-partitioner)
+    - [GZIP compression](#producing-messages-gzip-compression)
     - [Retry](#producing-messages-retry)
-  - [Consuming messages from Kafka](consuming-messages)
-    - [eachMessage](consuming-messages-each-message)
-    - [eachBatch](consuming-messages-each-batch)
-    - [Options](consuming-messages-options)
+  - [Consuming messages from Kafka](#consuming-messages)
+    - [eachMessage](#consuming-messages-each-message)
+    - [eachBatch](#consuming-messages-each-batch)
+    - [Options](#consuming-messages-options)
     - [Custom assigner](#consuming-messages-custom-assigner)
   - [Instrumentation](#instrumentation)
   - [Development](#development)
@@ -158,7 +159,7 @@ The environment variable `KAFKAJS_LOG_LEVEL` can also be used and it has precede
 KAFKAJS_LOG_LEVEL=info node code.js
 ```
 
-__How to create a log creator?___
+__How to create a log creator?__
 
 A log creator is a function which receives a log level and returns a log function. The log function receives: namespace, level, label, and log.
 
@@ -276,6 +277,10 @@ await producer.send({
   ],
 })
 ```
+
+#### <a name="producing-messages-gzip-compression"></a> GZIP compression
+
+TODO: write
 
 #### <a name="producing-messages-custom-partitioner"></a> Custom partitioner
 

--- a/src/consumer/index.spec.js
+++ b/src/consumer/index.spec.js
@@ -414,7 +414,7 @@ describe('Consumer', () => {
       await consumer.subscribe({ topic: topicName, fromBeginning: true })
     })
 
-    it.only('retries the same batch', async () => {
+    it('retries the same batch', async () => {
       let succeeded = false
       const batches = []
       const eachBatch = jest

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -52,12 +52,7 @@ module.exports = class OffsetManager {
       offset = '0'
     }
 
-    const nextOffset = Long.fromValue(offset)
-      .add(1)
-      .toString()
-
-    this.resolvedOffsets[topic][partition] = nextOffset
-    return offset
+    return Long.fromValue(offset)
   }
 
   /**

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -111,7 +111,12 @@ module.exports = class Runner {
         await this.eachMessage({ topic, partition, message })
       } catch (e) {
         if (!isKafkaJSError(e)) {
-          this.logger.error(`Error when calling eachMessage`, { stack: e.stack })
+          this.logger.error(`Error when calling eachMessage`, {
+            topic,
+            partition,
+            offset: message.offset,
+            stack: e.stack,
+          })
         }
 
         // In case of errors, commit the previously consumed offsets
@@ -140,7 +145,12 @@ module.exports = class Runner {
       })
     } catch (e) {
       if (!isKafkaJSError(e)) {
-        this.logger.error(`Error when calling eachBatch`, { stack: e.stack })
+        this.logger.error(`Error when calling eachBatch`, {
+          topic,
+          partition,
+          offset: batch.firstOffset(),
+          stack: e.stack,
+        })
       }
 
       // eachBatch has a special resolveOffset which can be used

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -99,7 +99,7 @@ const retryProtocol = (errorType, fn) =>
   })
 
 const waitForMessages = (buffer, { number = 1, delay = 50 } = {}) =>
-  waitFor(() => (buffer.length >= number ? buffer.splice(0) : false), { delay })
+  waitFor(() => (buffer.length >= number ? buffer : false), { delay })
 
 const createTopic = ({ topic, partitions = 1 }) => {
   const cmd = path.join(__dirname, '../scripts/createTopic.sh')


### PR DESCRIPTION
The expected behavior for `eachMessage` and `eachBatch` is to retry if an exception is thrown by the user. This wasn't happening, instead, KafkaJS would skip the offset and "retry" with the next one.

The bug was on the offset manager which was also increasing the offset. This logic was in flux for a while and ended up in two places. This is now set and should only happen in `resolveOffset`:

https://github.com/tulios/kafkajs/blob/6a928f8396ad2db46f85971d1c50e1dbf2522ca5/src/consumer/offsetManager/index.js#L82-L91

New tests were added to catch similar issues in the next time and some tests were improved to make sure all offsets are being consumed.