### PR TITLE
Remove unused configuration for protocol leaveGroup v1

### DIFF
--- a/src/protocol/requests/leaveGroup/index.js
+++ b/src/protocol/requests/leaveGroup/index.js
@@ -7,14 +7,6 @@ const versions = {
       response,
     }
   },
-  1: ({ groupId, memberId }) => {
-    const request = require('./v1/request')
-    const response = require('./v1/response')
-    return {
-      request: request({ groupId, memberId }),
-      response,
-    }
-  },
 }
 
 module.exports = {


### PR DESCRIPTION
The protocol versions will be updated, but this is a leftover of some tests I've performed before. It shouldn't be in the code