### PR TITLE
Add consumer pause & resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ __In active development - alpha__
     - [eachMessage](#consuming-messages-each-message)
     - [eachBatch](#consuming-messages-each-batch)
     - [Options](#consuming-messages-options)
+    - [Pause & Resume](#consuming-messages-pause-resume)
     - [Custom assigner](#consuming-messages-custom-assigner)
     - [Seek](#consuming-messages-seek)
     - [Describe group](#consuming-messages-describe-group)
@@ -424,6 +425,36 @@ await consumer.disconnect()
 - __maxBytes__ - Maximum amount of bytes to accumulate in the response. Supported by Kafka >= `0.10.1.0`. default: `10485760` (10MB)
 - __maxWaitTimeInMs__ - The maximum amount of time in milliseconds the server will block before answering the fetch request if there isn’t sufficient data to immediately satisfy the requirement given by `minBytes`. default: `5000`,
 - __retry__ - default: `{ retries: 10 }`
+
+#### <a name="consuming-messages-pause-resume"></a> Pause & Resume
+
+In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`.
+
+```javascript
+await consumer.connect()
+
+await consumer.subscribe({ topic: 'jobs' })
+await consumer.subscribe({ topic: 'pause' })
+await consumer.subscribe({ topic: 'resume' })
+
+await consumer.run({ eachMessage: async ({ topic, message }) => {
+  switch(topic) {
+    case 'jobs':
+      doSomeWork(message)
+      break
+    case 'pause':
+      // Stop consuming from the 'jobs' topic
+      consumer.pause([{ topic: 'jobs' }])
+      break
+    case 'resume':
+      // Resume consming from the 'jobs' topic
+      consumer.resume([{ topic: 'jobs' }])
+      break
+  }
+}})
+```
+
+Calling `pause` with a topic that the consumer is not subscribed to is a no-op, as is calling `resume` with a topic that is not paused.
 
 #### <a name="consuming-messages-custom-assigner"></a> Custom assigner
 

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ await consumer.disconnect()
 
 #### <a name="consuming-messages-pause-resume"></a> Pause & Resume
 
-In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`.
+In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`. Note that pausing a topic means that it won't be fetched in the next cycle. You may still receive messages for the topic within the current batch.
 
 ```javascript
 await consumer.connect()
@@ -443,12 +443,24 @@ await consumer.run({ eachMessage: async ({ topic, message }) => {
       doSomeWork(message)
       break
     case 'pause':
-      // Stop consuming from the 'jobs' topic
-      consumer.pause([{ topic: 'jobs' }])
+      // Stop consuming from the 'jobs' topic.
+      consumer.pause([{ topic: 'jobs'}])
+
+      // `pause` accepts an optional `partitions` property for each topic
+      // to pause consuming only specific partitions. However, this
+      // functionality is not currently supported by the library.
+      //
+      // consumer.pause([{ topic: 'jobs', partitions: [0, 1] }])
       break
     case 'resume':
       // Resume consming from the 'jobs' topic
       consumer.resume([{ topic: 'jobs' }])
+
+      // `resume` accepts an optional `partitions` property for each topic
+      // to resume consuming only specific partitions. However, this
+      // functionality is not currently supported by the library.
+      //
+      // consumer.resume([{ topic: 'jobs', partitions: [0, 1] }])
       break
   }
 }})

--- a/src/consumer/__tests__/pause.spec.js
+++ b/src/consumer/__tests__/pause.spec.js
@@ -1,0 +1,167 @@
+const createProducer = require('../../producer')
+const createConsumer = require('../index')
+const { KafkaJSNonRetriableError } = require('../../errors')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  newLogger,
+  waitForMessages,
+} = require('testHelpers')
+
+describe('Consumer', () => {
+  let groupId, cluster, producer, consumer, topics
+
+  beforeEach(async () => {
+    topics = [`test-topic-${secureRandom()}`, `test-topic-${secureRandom()}`]
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    for (let topic of topics) {
+      await createTopic({ topic, partitions: 2 })
+    }
+
+    cluster = createCluster()
+    producer = createProducer({
+      cluster,
+      logger: newLogger(),
+    })
+
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      maxWaitTimeInMs: 1,
+      maxBytesPerPartition: 180,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    await consumer.disconnect()
+    await producer.disconnect()
+  })
+
+  describe('when pausing', () => {
+    it('throws an error if the topic is invalid', () => {
+      expect(() => consumer.pause([{ topic: null, partitions: [0] }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid topic null'
+      )
+    })
+
+    it('throws an error if Consumer#run has not been called', () => {
+      expect(() => consumer.pause([{ topic: 'foo', partitions: [0] }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    })
+
+    it('does not fetch messages for the paused topic', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key1 = secureRandom()
+      const message1 = { key: `key-${key1}`, value: `value-${key1}`, partition: 0 }
+      const key2 = secureRandom()
+      const message2 = { key: `key-${key2}`, value: `value-${key2}`, partition: 1 }
+
+      for (let topic of topics) {
+        await producer.send({ topic, messages: [message1] })
+        await consumer.subscribe({ topic, fromBeginning: true })
+      }
+
+      const messagesConsumed = []
+      consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+
+      await waitForMessages(messagesConsumed, { number: 2 })
+
+      const [pausedTopic, activeTopic] = topics
+      consumer.pause([{ topic: pausedTopic }])
+
+      for (let topic of topics) {
+        await producer.send({ topic, messages: [message2] })
+      }
+
+      const consumedMessages = await waitForMessages(messagesConsumed, { number: 3 })
+
+      expect(consumedMessages.filter(({ topic }) => topic === pausedTopic)).toEqual([
+        {
+          topic: pausedTopic,
+          partition: 0,
+          message: expect.objectContaining({ offset: '0' }),
+        },
+      ])
+
+      const byPartition = (a, b) => a.partition - b.partition
+      expect(
+        consumedMessages.filter(({ topic }) => topic === activeTopic).sort(byPartition)
+      ).toEqual([
+        {
+          topic: activeTopic,
+          partition: 0,
+          message: expect.objectContaining({ offset: '0' }),
+        },
+        {
+          topic: activeTopic,
+          partition: 1,
+          message: expect.objectContaining({ offset: '0' }),
+        },
+      ])
+    })
+  })
+
+  describe('when resuming', () => {
+    it('throws an error if the topic is invalid', () => {
+      expect(() => consumer.pause([{ topic: null, partitions: [0] }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid topic null'
+      )
+    })
+
+    it('throws an error if Consumer#run has not been called', () => {
+      expect(() => consumer.pause([{ topic: 'foo', partitions: [0] }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    })
+
+    it('resumes fetching from the specified topic', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key = secureRandom()
+      const message = { key: `key-${key}`, value: `value-${key}`, partition: 0 }
+
+      for (let topic of topics) {
+        await consumer.subscribe({ topic, fromBeginning: true })
+      }
+
+      const messagesConsumed = []
+      consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+
+      const [pausedTopic, activeTopic] = topics
+      consumer.pause([{ topic: pausedTopic }])
+
+      for (let topic of topics) {
+        await producer.send({ topic, messages: [message] })
+      }
+
+      await waitForMessages(messagesConsumed, { number: 1 })
+
+      consumer.resume([{ topic: pausedTopic }])
+
+      await expect(waitForMessages(messagesConsumed, { number: 2 })).resolves.toEqual([
+        {
+          topic: activeTopic,
+          partition: 0,
+          message: expect.objectContaining({ offset: '0' }),
+        },
+        {
+          topic: pausedTopic,
+          partition: 0,
+          message: expect.objectContaining({ offset: '0' }),
+        },
+      ])
+    })
+  })
+})

--- a/src/consumer/__tests__/subscribe.spec.js
+++ b/src/consumer/__tests__/subscribe.spec.js
@@ -1,0 +1,29 @@
+const createConsumer = require('../index')
+
+const { secureRandom, createCluster, newLogger } = require('testHelpers')
+
+describe('Consumer', () => {
+  let groupId, cluster, consumer
+
+  beforeEach(async () => {
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    cluster = createCluster()
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      maxWaitTimeInMs: 1,
+      maxBytesPerPartition: 180,
+      logger: newLogger(),
+    })
+  })
+
+  describe('when subscribe', () => {
+    it('throws an error if the topic is invalid', async () => {
+      await expect(consumer.subscribe({ topic: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+  })
+})

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -1,4 +1,5 @@
 const flatten = require('../utils/flatten')
+const sleep = require('../utils/sleep')
 const OffsetManager = require('./offsetManager')
 const Batch = require('./batch')
 const SeekOffsets = require('./seekOffsets')
@@ -219,6 +220,17 @@ module.exports = class ConsumerGroup {
 
       const pausedTopics = this.subscriptionState.paused()
       const activeTopics = topics.filter(topic => !pausedTopics.includes(topic))
+
+      if (activeTopics.length === 0) {
+        this.logger.debug(`No active topics, sleeping for ${this.maxWaitTime}ms`, {
+          topics,
+          activeTopics,
+          pausedTopics,
+        })
+
+        await sleep(this.maxWaitTime)
+        return []
+      }
 
       this.logger.debug(`Fetching from ${activeTopics.length} out of ${topics.length} topics`, {
         topics,

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -208,6 +208,58 @@ module.exports = ({
     })
   }
 
+  /**
+   * @param {Array<TopicPartitions>} topicPartitions Example: [{ topic: 'topic-name', partitions: [1, 2] }]
+   *
+   * @typedef {Object} TopicPartitions
+   * @property {string} topic
+   * @property {Array<{number}>} [partitions] Not used at the moment. The entire topic will be paused,
+   *                                          regardless of the partitions passed in
+   */
+  const pause = (topicPartitions = []) => {
+    for (let topicPartition of topicPartitions) {
+      if (!topicPartition || !topicPartition.topic) {
+        throw new KafkaJSNonRetriableError(
+          `Invalid topic ${(topicPartition && topicPartition.topic) || topicPartition}`
+        )
+      }
+    }
+
+    if (!consumerGroup) {
+      throw new KafkaJSNonRetriableError(
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    }
+
+    consumerGroup.pause(topicPartitions.map(({ topic }) => topic))
+  }
+
+  /**
+   * @param {Array<TopicPartitions>} topicPartitions Example: [{ topic: 'topic-name', partitions: [1, 2] }]
+   *
+   * @typedef {Object} TopicPartitions
+   * @property {string} topic
+   * @property {Array<{number}>} [partitions] Not used at the moment. All partitions will be consumed regardless
+   *                                          of the partitions passed in.
+   */
+  const resume = (topicPartitions = []) => {
+    for (let topicPartition of topicPartitions) {
+      if (!topicPartition || !topicPartition.topic) {
+        throw new KafkaJSNonRetriableError(
+          `Invalid topic ${(topicPartition && topicPartition.topic) || topicPartition}`
+        )
+      }
+    }
+
+    if (!consumerGroup) {
+      throw new KafkaJSNonRetriableError(
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    }
+
+    consumerGroup.resume(topicPartitions.map(({ topic }) => topic))
+  }
+
   return {
     connect,
     disconnect,
@@ -215,6 +267,8 @@ module.exports = ({
     run,
     seek,
     describeGroup,
+    pause,
+    resume,
     on,
     events,
   }

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -93,6 +93,10 @@ module.exports = ({
    * @return {Promise}
    */
   const subscribe = async ({ topic, fromBeginning = false }) => {
+    if (!topic) {
+      throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
+    }
+
     topics[topic] = { fromBeginning }
     await cluster.addTargetTopic(topic)
   }

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -203,7 +203,7 @@ module.exports = class Runner {
         this.consuming = true
         await this.fetch()
         this.consuming = false
-        this.scheduleFetch()
+        setImmediate(() => this.scheduleFetch())
       } catch (e) {
         if (isRebalancing(e)) {
           this.logger.error('The group is rebalancing, re-joining', {

--- a/src/consumer/subscriptionState.js
+++ b/src/consumer/subscriptionState.js
@@ -1,0 +1,26 @@
+module.exports = class SubscriptionState {
+  constructor() {
+    this.pausedTopics = new Set()
+  }
+
+  /**
+   * @param {Array<string>} topics 
+   */
+  pause(topics = []) {
+    topics.forEach(topic => this.pausedTopics.add(topic))
+  }
+
+  /**
+   * @param {Array<string>} topics 
+   */
+  resume(topics = []) {
+    topics.forEach(topic => this.pausedTopics.delete(topic))
+  }
+
+  /**
+   * @returns {Array<string>} paused topics
+   */
+  paused() {
+    return Array.from(this.pausedTopics.values())
+  }
+}

--- a/src/consumer/subscriptionState.spec.js
+++ b/src/consumer/subscriptionState.spec.js
@@ -1,0 +1,20 @@
+const SubscriptionState = require('./subscriptionState')
+
+describe('Consumer > OffsetMananger > pause / resume', () => {
+  let subscriptionState
+
+  beforeEach(() => {
+    subscriptionState = new SubscriptionState()
+  })
+
+  it('pauses the selected topics', () => {
+    subscriptionState.pause(['topic1', 'topic2'])
+    expect(subscriptionState.paused()).toEqual(['topic1', 'topic2'])
+  })
+
+  it('resumes the selected topics', () => {
+    subscriptionState.pause(['topic1', 'topic2'])
+    subscriptionState.resume(['topic2'])
+    expect(subscriptionState.paused()).toEqual(['topic1'])
+  })
+})

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -1,6 +1,7 @@
 const createRetry = require('../retry')
 const createDefaultPartitioner = require('./partitioners/default')
 const createSendMessages = require('./sendMessages')
+const { KafkaJSNonRetriableError } = require('../errors')
 
 module.exports = ({
   cluster,
@@ -37,6 +38,13 @@ module.exports = ({
      * @returns {Promise}
      */
     send: async ({ topic, messages, acks, timeout, compression }) => {
+      if (!topic) {
+        throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
+      }
+      if (!messages) {
+        throw new KafkaJSNonRetriableError(`Invalid messages array ${messages}`)
+      }
+
       return retrier(async (bail, retryCount, retryTime) => {
         try {
           return await sendMessages({

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -23,6 +23,22 @@ describe('Producer', () => {
     await producer.disconnect()
   })
 
+  test('throws an error if the topic is invalid', async () => {
+    producer = createProducer({ cluster: createCluster(), logger: newLogger() })
+    await expect(producer.send({ topic: null })).rejects.toHaveProperty(
+      'message',
+      'Invalid topic null'
+    )
+  })
+
+  test('throws an error if messages is invalid', async () => {
+    producer = createProducer({ cluster: createCluster(), logger: newLogger() })
+    await expect(producer.send({ topic: topicName, messages: null })).rejects.toHaveProperty(
+      'message',
+      'Invalid messages array null'
+    )
+  })
+
   test('support SSL connections', async () => {
     const cluster = createCluster(sslConnectionOpts(), sslBrokers())
     producer = createProducer({ cluster, logger: newLogger() })

--- a/src/producer/partitioners/default/index.js
+++ b/src/producer/partitioners/default/index.js
@@ -26,7 +26,7 @@ module.exports = () => {
     const availablePartitions = partitionMetadata.filter(p => p.leader >= 0)
     const numAvailablePartitions = availablePartitions.length
 
-    if (message.partition) {
+    if (message.partition !== null && message.partition !== undefined) {
       return message.partition
     }
 

--- a/src/producer/partitioners/default/index.spec.js
+++ b/src/producer/partitioners/default/index.spec.js
@@ -60,4 +60,14 @@ describe('Producer > Partitioner > Default', () => {
 
     expect(partition).toEqual(99)
   })
+
+  test('returns the configured partition even if the partition is falsy', () => {
+    const partition = partitioner({
+      topic,
+      partitionMetadata,
+      message: { key: '1', partition: 0 },
+    })
+
+    expect(partition).toEqual(0)
+  })
 })

--- a/src/utils/sleep.js
+++ b/src/utils/sleep.js
@@ -1,0 +1,4 @@
+module.exports = timeInMs =>
+  new Promise(resolve => {
+    setTimeout(resolve, timeInMs)
+  })


### PR DESCRIPTION
This also fixes a bug where if you specify `0` as the partition for a message, the partitioner would fall back to using the hash of the key, as it would consider `message.partition` falsy.