### PR TITLE
Allow auto-resolve to be disabled for eachBatch

### DIFF
--- a/src/consumer/__tests__/runner.spec.js
+++ b/src/consumer/__tests__/runner.spec.js
@@ -69,7 +69,7 @@ describe('Consumer > Runner', () => {
       consumerGroup.fetch.mockImplementationOnce(() => [batch])
       await runner.start()
       expect(onCrash).not.toHaveBeenCalled()
-      expect(consumerGroup.resolveOffset).not.toHaveBeenCalledWith({ topic, partition, offset: 4 })
+      expect(consumerGroup.resolveOffset).not.toHaveBeenCalled()
     })
   })
 

--- a/src/consumer/__tests__/runner.spec.js
+++ b/src/consumer/__tests__/runner.spec.js
@@ -1,4 +1,5 @@
 const Runner = require('../runner')
+const Batch = require('../batch')
 const { KafkaJSProtocolError } = require('../../errors')
 const { createErrorFromCode } = require('../../protocol/error')
 const { newLogger } = require('testHelpers')
@@ -12,7 +13,14 @@ describe('Consumer > Runner', () => {
 
   beforeEach(() => {
     onCrash = jest.fn()
-    consumerGroup = { join: jest.fn(), sync: jest.fn() }
+    consumerGroup = {
+      join: jest.fn(),
+      sync: jest.fn(),
+      fetch: jest.fn(),
+      resolveOffset: jest.fn(),
+      commitOffsets: jest.fn(),
+      heartbeat: jest.fn(),
+    }
     runner = new Runner({ consumerGroup, onCrash, logger: newLogger() })
   })
 
@@ -31,6 +39,37 @@ describe('Consumer > Runner', () => {
       await runner.start()
       expect(runner.scheduleFetch).toHaveBeenCalled()
       expect(onCrash).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when eachBatchAutoResolve is set to false', () => {
+    let eachBatch
+
+    beforeEach(() => {
+      eachBatch = jest.fn()
+      runner = new Runner({
+        consumerGroup,
+        eachBatchAutoResolve: false,
+        eachBatch,
+        onCrash,
+        logger: newLogger(),
+      })
+      runner.scheduleFetch = jest.fn(() => runner.fetch())
+    })
+
+    it('does not call resolveOffset with the last offset', async () => {
+      const topic = 'topic-name'
+      const partition = 0
+      const batch = new Batch(topic, {
+        partition,
+        highWatermark: 5,
+        messages: [{ offset: 4, key: '1', value: '2' }],
+      })
+
+      consumerGroup.fetch.mockImplementationOnce(() => [batch])
+      await runner.start()
+      expect(onCrash).not.toHaveBeenCalled()
+      expect(consumerGroup.resolveOffset).not.toHaveBeenCalledWith({ topic, partition, offset: 4 })
     })
   })
 

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -56,10 +56,11 @@ module.exports = ({
     })
   }
 
-  const createRunner = ({ eachBatch, eachMessage, onCrash }) => {
+  const createRunner = ({ eachBatchAutoResolve, eachBatch, eachMessage, onCrash }) => {
     return new Runner({
       logger: rootLogger,
       consumerGroup,
+      eachBatchAutoResolve,
       eachBatch,
       eachMessage,
       heartbeatInterval,
@@ -102,16 +103,20 @@ module.exports = ({
   }
 
   /**
+   * @param {boolean} [eachBatchAutoResolve=true] Automatically resolves the last offset of the batch when the
+   *                                              the callback succeeds
    * @param {Function} [eachBatch=null]
    * @param {Function} [eachMessage=null]
    * @return {Promise}
    */
-  const run = async ({ eachBatch = null, eachMessage = null } = {}) => {
+  const run = async (
+    { eachBatchAutoResolve = true, eachBatch = null, eachMessage = null } = {}
+  ) => {
     consumerGroup = createConsumerGroup()
 
     const start = async onCrash => {
       logger.info('Starting', { groupId })
-      runner = createRunner({ eachBatch, eachMessage, onCrash })
+      runner = createRunner({ eachBatchAutoResolve, eachBatch, eachMessage, onCrash })
       await runner.start()
     }
 

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -12,6 +12,7 @@ module.exports = class Runner {
   constructor({
     consumerGroup,
     logger,
+    eachBatchAutoResolve = true,
     eachBatch,
     eachMessage,
     heartbeatInterval,
@@ -20,6 +21,7 @@ module.exports = class Runner {
   }) {
     this.consumerGroup = consumerGroup
     this.logger = logger.namespace('Runner')
+    this.eachBatchAutoResolve = eachBatchAutoResolve
     this.eachBatch = eachBatch
     this.eachMessage = eachMessage
     this.heartbeatInterval = heartbeatInterval
@@ -163,7 +165,11 @@ module.exports = class Runner {
       throw e
     }
 
-    this.consumerGroup.resolveOffset({ topic, partition, offset: batch.lastOffset() })
+    // resolveOffset for the last offset can be disabled to allow the users of eachBatch to
+    // stop their consumers without resolving unprocessed offsets (issues/18)
+    if (this.eachBatchAutoResolve) {
+      this.consumerGroup.resolveOffset({ topic, partition, offset: batch.lastOffset() })
+    }
   }
 
   async fetch() {


### PR DESCRIPTION
This is the last piece missing to allow `eachBatch` to have full control over the message processing.

```javascript
consumer.run({
  eachBatchAutoResolve: false,
  eachBatch: ({ batch, resolveOffset, isRunning }) => {
    try {
      for (let message of batch.messages) {
        if (!isRunning()) break
        await processMessage(message)
        await resolveOffset(message.offset)
      }
    } catch (e) {
      // messages won't be automatically resolved and committed
    }
  }
})
```

This PR resolves #18 