### PR TITLE
Add `sendBatch` method to producer

### DIFF
--- a/src/producer/createTopicData.js
+++ b/src/producer/createTopicData.js
@@ -1,9 +1,9 @@
-module.exports = ({ topic, partitions, messagesPerPartition }) => [
-  {
+module.exports = topicDataForBroker => {
+  return topicDataForBroker.map(({ topic, partitions, messagesPerPartition }) => ({
     topic,
     partitions: partitions.map(partition => ({
       partition,
       messages: messagesPerPartition[partition],
     })),
-  },
-]
+  }))
+}

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -14,6 +14,66 @@ module.exports = ({
   const sendMessages = createSendMessages({ cluster, partitioner })
   const logger = rootLogger.namespace('Producer')
 
+  const sendBatch = async ({ acks, timeout, compression, topicMessages }) => {
+    if (topicMessages.some(({ topic }) => !topic)) {
+      throw new KafkaJSNonRetriableError(`Invalid topic`)
+    }
+
+    for (let { topic, messages } of topicMessages) {
+      if (!messages) {
+        throw new KafkaJSNonRetriableError(
+          `Invalid messages array [${messages}] for topic "${topic}"`
+        )
+      }
+    }
+
+    return retrier(async (bail, retryCount, retryTime) => {
+      try {
+        return await sendMessages({
+          acks,
+          timeout,
+          compression,
+          topicMessages,
+        })
+      } catch (error) {
+        if (!cluster.isConnected()) {
+          logger.debug(`Cluster has disconnected, reconnecting: ${error.message}`, {
+            retryCount,
+            retryTime,
+          })
+          await cluster.connect()
+          await cluster.refreshMetadata()
+          throw error
+        }
+
+        // This is necessary in case the metadata is stale and the number of partitions
+        // for this topic has increased in the meantime
+        if (
+          error.name === 'KafkaJSConnectionError' ||
+          (error.name === 'KafkaJSProtocolError' && error.retriable)
+        ) {
+          logger.error(`Failed to send messages: ${error.message}`, { retryCount, retryTime })
+          await cluster.refreshMetadata()
+          throw error
+        }
+
+        // Skip retries for errors not related to the Kafka protocol
+        logger.error(`${error.message}`, { retryCount, retryTime })
+        bail(error)
+      }
+    })
+  }
+
+  const send = async ({ acks, timeout, compression, topic, messages }) => {
+    const topicMessage = { topic, messages }
+    return sendBatch({
+      acks,
+      timeout,
+      compression,
+      topicMessages: [topicMessage],
+    })
+  }
+
   return {
     /**
      * @returns {Promise}
@@ -26,61 +86,40 @@ module.exports = ({
     disconnect: async () => await cluster.disconnect(),
 
     /**
-     * @param {string} topic
-     * @param {Array} messages An array of objects with "key" and "value", example:
+     * @param {ProduceRequest} ProduceRequest
+     * @returns {Promise}
+     *
+     * @typedef {Object} ProduceRequest
+     * @property {string} topic
+     * @property {Array} messages An array of objects with "key" and "value", example:
      *                         [{ key: 'my-key', value: 'my-value'}]
-     * @param {number} [acks=-1] Control the number of required acks.
+     * @property {number} [acks=-1] Control the number of required acks.
      *                           -1 = all replicas must acknowledge
      *                            0 = no acknowledgments
      *                            1 = only waits for the leader to acknowledge
-     * @param {number} [timeout=30000] The time to await a response in ms
-     * @param {Compression.Types} [compression=Compression.Types.None] Compression codec
+     * @property {number} [timeout=30000] The time to await a response in ms
+     * @property {Compression.Types} [compression=Compression.Types.None] Compression codec
+     */
+    send,
+
+    /**
+     * @typedef {Object} TopicMessages
+     * @property {string} topic
+     * @property {Array} messages An array of objects with "key" and "value", example:
+     *                         [{ key: 'my-key', value: 'my-value'}]
+     *
+     * @typedef {Object} SendBatchRequest
+     * @property {Array<TopicMessages>} topicMessages
+     * @property {number} [acks=-1] Control the number of required acks.
+     *                           -1 = all replicas must acknowledge
+     *                            0 = no acknowledgments
+     *                            1 = only waits for the leader to acknowledge
+     * @property {number} [timeout=30000] The time to await a response in ms
+     * @property {Compression.Types} [compression=Compression.Types.None] Compression codec
+     *
+     * @param {SendBatchRequest}
      * @returns {Promise}
      */
-    send: async ({ topic, messages, acks, timeout, compression }) => {
-      if (!topic) {
-        throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
-      }
-      if (!messages) {
-        throw new KafkaJSNonRetriableError(`Invalid messages array ${messages}`)
-      }
-
-      return retrier(async (bail, retryCount, retryTime) => {
-        try {
-          return await sendMessages({
-            topic,
-            messages,
-            acks,
-            timeout,
-            compression,
-          })
-        } catch (error) {
-          if (!cluster.isConnected()) {
-            logger.debug(`Cluster has disconnected, reconnecting: ${error.message}`, {
-              retryCount,
-              retryTime,
-            })
-            await cluster.connect()
-            await cluster.refreshMetadata()
-            throw error
-          }
-
-          // This is necessary in case the metadata is stale and the number of partitions
-          // for this topic has increased in the meantime
-          if (
-            error.name === 'KafkaJSConnectionError' ||
-            (error.name === 'KafkaJSProtocolError' && error.retriable)
-          ) {
-            logger.error(`Failed to send messages: ${error.message}`, { retryCount, retryTime })
-            await cluster.refreshMetadata()
-            throw error
-          }
-
-          // Skip retries for errors not related to the Kafka protocol
-          logger.error(`${error.message}`, { retryCount, retryTime })
-          bail(error)
-        }
-      })
-    },
+    sendBatch,
   }
 }

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -32,8 +32,8 @@ module.exports = ({
    * @param {SendBatchRequest}
    * @returns {Promise}
    */
-  const sendBatch = async ({ acks, timeout, compression, topicMessages }) => {
-    if (topicMessages && topicMessages.length > 0 && topicMessages.some(({ topic }) => !topic)) {
+  const sendBatch = async ({ acks, timeout, compression, topicMessages = [] }) => {
+    if (topicMessages.length === 0 || topicMessages.some(({ topic }) => !topic)) {
       throw new KafkaJSNonRetriableError(`Invalid topic`)
     }
 

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -29,7 +29,7 @@ describe('Producer', () => {
     producer = createProducer({ cluster: createCluster(), logger: newLogger() })
     await expect(producer.send({ acks: 1, topic: null })).rejects.toHaveProperty(
       'message',
-      'Invalid topic null'
+      'Invalid topic'
     )
   })
 
@@ -37,7 +37,7 @@ describe('Producer', () => {
     producer = createProducer({ cluster: createCluster(), logger: newLogger() })
     await expect(
       producer.send({ acks: 1, topic: topicName, messages: null })
-    ).rejects.toHaveProperty('message', 'Invalid messages array null')
+    ).rejects.toHaveProperty('message', `Invalid messages array [null] for topic "${topicName}"`)
   })
 
   test('support SSL connections', async () => {
@@ -200,5 +200,73 @@ describe('Producer', () => {
         timestamp: '-1',
       },
     ])
+  })
+
+  test('produce messages to multiple topics', async () => {
+    const topics = [`test-topic-${secureRandom()}`, `test-topic-${secureRandom()}`]
+    const cluster = createCluster({
+      ...connectionOpts(),
+      createPartitioner: createModPartitioner,
+    })
+    const byTopicName = (a, b) => a.topicName.localeCompare(b.topicName)
+
+    producer = createProducer({ cluster, logger: newLogger() })
+    await producer.connect()
+
+    const sendBatch = async topics => {
+      const topicMessages = topics.map(topic => ({
+        acks: 1,
+        topic,
+        messages: new Array(10).fill().map((_, i) => ({
+          key: `key-${i}`,
+          value: `value-${i}`,
+        })),
+      }))
+
+      return producer.sendBatch({
+        acks: 1,
+        topicMessages,
+      })
+    }
+
+    let result = await sendBatch(topics)
+    expect(result.sort(byTopicName)).toEqual(
+      [
+        {
+          topicName: topics[0],
+          errorCode: 0,
+          offset: '0',
+          partition: 0,
+          timestamp: '-1',
+        },
+        {
+          topicName: topics[1],
+          errorCode: 0,
+          offset: '0',
+          partition: 0,
+          timestamp: '-1',
+        },
+      ].sort(byTopicName)
+    )
+
+    result = await sendBatch(topics)
+    expect(result.sort(byTopicName)).toEqual(
+      [
+        {
+          topicName: topics[0],
+          errorCode: 0,
+          offset: '10',
+          partition: 0,
+          timestamp: '-1',
+        },
+        {
+          topicName: topics[1],
+          errorCode: 0,
+          offset: '10',
+          partition: 0,
+          timestamp: '-1',
+        },
+      ].sort(byTopicName)
+    )
   })
 })

--- a/src/producer/sendMessages.spec.js
+++ b/src/producer/sendMessages.spec.js
@@ -71,7 +71,7 @@ describe('Producer > sendMessages', () => {
       })
       .mockImplementationOnce(() => createProducerResponse(topic, 2))
 
-    const response = await sendMessages({ topic, messages })
+    const response = await sendMessages({ topicMessages: [{ topic, messages }] })
     expect(brokers[1].produce).toHaveBeenCalledTimes(2)
     expect(brokers[2].produce).toHaveBeenCalledTimes(1)
     expect(brokers[3].produce).toHaveBeenCalledTimes(3)
@@ -104,7 +104,7 @@ describe('Producer > sendMessages', () => {
         })
         .mockImplementationOnce(() => createProducerResponse(topic, 0))
 
-      await sendMessages({ topic, messages })
+      await sendMessages({ topicMessages: [{ topic, messages }] })
       expect(brokers[1].produce).toHaveBeenCalledTimes(2)
       expect(cluster.refreshMetadata).toHaveBeenCalled()
     })
@@ -128,7 +128,7 @@ describe('Producer > sendMessages', () => {
         3: [2],
       }))
 
-    const response = await sendMessages({ topic, messages })
+    const response = await sendMessages({ topicMessages: [{ topic, messages }] })
 
     expect(response).toEqual([
       { errorCode: 0, offset: '0', partition: 0, timestamp: '-1', topicName: 'topic-name' },


### PR DESCRIPTION
Allows the producer to produce messages to multiple topics at the same time.

Example:

```javascript
await producer.sendBatch([
  {
    topic: 'topic-name',
    messages: [
      { key: 'key1', value: 'hello world' },
      { key: 'key2', value: 'hey hey!' }
    ],
  },
  {
    topic: 'topic-name-2',
    messages: [
      { key: 'key1', value: 'foo bar' },
    ],
  }
])
```

Co-authored-by: Túlio Ornelas <ornelas.tulio@gmail.com>

@carlrygart