### PR TITLE
Skip unsubscribed topic assignment

### DIFF
--- a/src/cluster/__tests__/findLeaderForPartitions.spec.js
+++ b/src/cluster/__tests__/findLeaderForPartitions.spec.js
@@ -64,4 +64,27 @@ describe('Cluster > findLeaderForPartitions', () => {
     const partitions = [0, 5]
     expect(cluster.findLeaderForPartitions(topic, partitions)).toEqual({ '0': [0], '2': [5] })
   })
+
+  it('does not include leaders for topics without metadata', () => {
+    cluster.brokerPool.metadata = {
+      topicMetadata: [
+        {
+          topic,
+          partitionMetadata: [
+            {
+              partitionErrorCode: 0,
+              partitionId: 2,
+              leader: 2,
+              replicas: [0, 1, 2],
+              isr: [2, 0, 1],
+            },
+          ],
+        },
+      ],
+    }
+
+    const anotherTopic = `test-topic-${secureRandom()}`
+    const partitions = [0]
+    expect(cluster.findLeaderForPartitions(anotherTopic, partitions)).toEqual({})
+  })
 })

--- a/src/cluster/__tests__/findTopicPartitionMetadata.spec.js
+++ b/src/cluster/__tests__/findTopicPartitionMetadata.spec.js
@@ -31,4 +31,17 @@ describe('Cluster > findTopicPartitionMetadata', () => {
       /Topic metadata not loaded/
     )
   })
+
+  it('returns an empty array if there is no metadata for a given topic', () => {
+    const partitionMetadata = {
+      isr: [2],
+      leader: 2,
+      partitionErrorCode: 0,
+      partitionId: 0,
+      replicas: [2],
+    }
+    cluster.brokerPool.metadata = { topicMetadata: [{ topic, partitionMetadata }] }
+    const anotherTopic = `test-topic-${secureRandom()}`
+    expect(cluster.findTopicPartitionMetadata(anotherTopic)).toEqual([])
+  })
 })

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -299,7 +299,7 @@ module.exports = class Cluster {
 
     const addDefaultOffset = topic => partition => {
       const { fromBeginning } = topicConfigurations[topic]
-      return { partition, timestamp: this.defaultOffset({ fromBeginning }) }
+      return { ...partition, timestamp: this.defaultOffset({ fromBeginning }) }
     }
 
     // Index all topics and partitions per leader (nodeId)

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -157,7 +157,8 @@ module.exports = class Cluster {
       throw new KafkaJSTopicMetadataNotLoaded('Topic metadata not loaded', { topic })
     }
 
-    return metadata.topicMetadata.find(t => t.topic === topic).partitionMetadata
+    const topicMetadata = metadata.topicMetadata.find(t => t.topic === topic)
+    return topicMetadata ? topicMetadata.partitionMetadata : []
   }
 
   /**
@@ -175,6 +176,11 @@ module.exports = class Cluster {
     return partitions.reduce((result, id) => {
       const partitionId = parseInt(id, 10)
       const metadata = partitionMetadata.find(p => p.partitionId === partitionId)
+
+      if (!metadata) {
+        return result
+      }
+
       if (metadata.leader === null || metadata.leader === undefined) {
         throw new KafkaJSError('Invalid partition metadata', { topic, partitionId, metadata })
       }

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -10,15 +10,15 @@ const {
   KafkaJSGroupCoordinatorNotFound,
 } = require('../errors')
 
-const { keys, assign } = Object
+const { keys } = Object
 
 const EARLIEST_OFFSET = -2
 const LATEST_OFFSET = -1
 
-const mergeTopics = (obj, { topic, partitions }) =>
-  assign(obj, {
-    [topic]: [...(obj[topic] || []), ...partitions],
-  })
+const mergeTopics = (obj, { topic, partitions }) => ({
+  ...obj,
+  [topic]: [...(obj[topic] || []), ...partitions],
+})
 
 /**
  * @param {Array<string>} brokers example: ['127.0.0.1:9092', '127.0.0.1:9094']
@@ -44,7 +44,7 @@ module.exports = class Cluster {
   }) {
     this.rootLogger = rootLogger
     this.logger = rootLogger.namespace('Cluster')
-    this.retrier = createRetry(assign({}, retry))
+    this.retrier = createRetry({ ...retry })
     this.connectionBuilder = connectionBuilder({
       logger: rootLogger,
       brokers,
@@ -187,7 +187,7 @@ module.exports = class Cluster {
 
       const { leader } = metadata
       const current = result[leader] || []
-      return assign(result, { [leader]: [...current, partitionId] })
+      return { ...result, [leader]: [...current, partitionId] }
     }, {})
   }
 
@@ -299,7 +299,7 @@ module.exports = class Cluster {
 
     const addDefaultOffset = topic => partition => {
       const { fromBeginning } = topicConfigurations[topic]
-      return Object.assign({}, partition, { timestamp: this.defaultOffset({ fromBeginning }) })
+      return { partition, timestamp: this.defaultOffset({ fromBeginning }) }
     }
 
     // Index all topics and partitions per leader (nodeId)

--- a/src/consumer/assignerProtocol.js
+++ b/src/consumer/assignerProtocol.js
@@ -60,7 +60,7 @@ const MemberAssignment = {
   decode(buffer) {
     const decoder = new Decoder(buffer)
     const decodePartitions = d => d.readInt32()
-    const decodeAssigment = d => ({
+    const decodeAssignment = d => ({
       topic: d.readString(),
       partitions: d.readArray(decodePartitions),
     })
@@ -69,7 +69,7 @@ const MemberAssignment = {
 
     return {
       version: decoder.readInt16(),
-      assignment: decoder.readArray(decodeAssigment).reduce(indexAssignment, {}),
+      assignment: decoder.readArray(decodeAssignment).reduce(indexAssignment, {}),
       userData: decoder.readBytes(),
     }
   },

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -122,15 +122,15 @@ module.exports = class ConsumerGroup {
       groupAssignment: assignment,
     })
 
-    const decodedAssigment = MemberAssignment.decode(memberAssignment).assignment
+    const decodedAssignment = MemberAssignment.decode(memberAssignment).assignment
     this.logger.debug('Received assignment', {
       groupId,
       generationId,
       memberId,
-      memberAssignment: decodedAssigment,
+      memberAssignment: decodedAssignment,
     })
 
-    let currentMemberAssignment = decodedAssigment
+    let currentMemberAssignment = decodedAssignment
     const assignedTopics = keys(currentMemberAssignment)
     const topicsNotSubscribed = arrayDiff(assignedTopics, this.topics)
 
@@ -147,7 +147,7 @@ module.exports = class ConsumerGroup {
       // Remove unsubscribed topics from the list
       const safeAssignment = arrayDiff(assignedTopics, topicsNotSubscribed)
       currentMemberAssignment = safeAssignment.reduce(
-        (assignment, topic) => ({ ...assignment, [topic]: decodedAssigment[topic] }),
+        (assignment, topic) => ({ ...assignment, [topic]: decodedAssignment[topic] }),
         {}
       )
     }

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -298,6 +298,14 @@ module.exports = class ConsumerGroup {
         return flatten(batchesPerPartition)
       })
 
+      // fetch can generate empty requests when the consumer group receives an assignment
+      // with more topics than the subscribed, so to prevent a busy loop we wait the
+      // configured max wait time
+      if (requests.length === 0) {
+        await sleep(this.maxWaitTime)
+        return []
+      }
+
       const results = await Promise.all(requests)
       return flatten(results)
     } catch (e) {

--- a/src/utils/arrayDiff.js
+++ b/src/utils/arrayDiff.js
@@ -1,0 +1,14 @@
+module.exports = (a, b) => {
+  const result = []
+  const length = a.length
+  let i = 0
+
+  while (i < length) {
+    if (b.indexOf(a[i]) === -1) {
+      result.push(a[i])
+    }
+    i += 1
+  }
+
+  return result
+}

--- a/src/utils/arrayDiff.spec.js
+++ b/src/utils/arrayDiff.spec.js
@@ -1,0 +1,26 @@
+const arrayDiff = require('./arrayDiff')
+
+describe('Utils > arrayDiff', () => {
+  it('returns the elements in A that are not in B', () => {
+    const a = [1, 2, 3, 4]
+    const b = [2, 3, 4]
+    expect(arrayDiff(a, b)).toEqual([1])
+  })
+
+  it('takes null and undefined in consideration', () => {
+    const a = [1, 2, 3, 4, null, undefined]
+    const b = [2, 3, 4, 5]
+    expect(arrayDiff(a, b)).toEqual([1, null, undefined])
+  })
+
+  it('returns empty if A is empty', () => {
+    const b = [2, 3, 4, 5]
+    expect(arrayDiff([], b)).toEqual([])
+  })
+
+  it('only takes A in consideration', () => {
+    const a = [1, 2, 3]
+    const b = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    expect(arrayDiff(a, b)).toEqual([])
+  })
+})


### PR DESCRIPTION
This PR makes the consumer skip any assignment for unsubscribed topics; it also prevents any high CPU busy loops due to the lack of requests. It partially fixes issue #83

This scenario in the consumer groups is super hard to simulate since you can't control which consumer will become the leader. I've manually setup the environment and confirmed that it works.