### PR TITLE
Expose namespaced loggers from consumer and producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,17 @@ const kafka = new Kafka({
 })
 ```
 
+To get access to the namespaced logger of a consumer or producer after instantiation, you can use the `logger` method:
+
+```javascript
+const consumer = kafka.consumer( ... )
+consumer.logger().info('Hello from the consumer')
+
+const producer = kafka.producer( ... )
+producer.logger().info('Hello from the producer')
+
+```
+
 ## <a name="configuration-default-retry-detailed"></a> Retry (detailed)
 
 The retry mechanism uses a randomization function that grows exponentially. This formula and how the default values affect it is best described by the example below:

--- a/src/consumer/__tests__/__snapshots__/logger.spec.js.snap
+++ b/src/consumer/__tests__/__snapshots__/logger.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Consumer gives access to its logger 1`] = `
+Object {
+  "debug": [Function],
+  "error": [Function],
+  "info": [Function],
+  "warn": [Function],
+}
+`;

--- a/src/consumer/__tests__/logger.spec.js
+++ b/src/consumer/__tests__/logger.spec.js
@@ -1,0 +1,15 @@
+const createConsumer = require('../index')
+
+const { createCluster, newLogger } = require('testHelpers')
+
+describe('Consumer', () => {
+  it('gives access to its logger', () => {
+    expect(
+      createConsumer({
+        cluster: createCluster(),
+        groupId: '',
+        logger: newLogger(),
+      }).logger()
+    ).toMatchSnapshot()
+  })
+})

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -298,6 +298,11 @@ module.exports = ({
     consumerGroup.resume(topicPartitions.map(({ topic }) => topic))
   }
 
+  /**
+   * @return {Object} logger
+   */
+  const getLogger = () => logger
+
   return {
     connect,
     disconnect,
@@ -309,5 +314,6 @@ module.exports = ({
     resume,
     on,
     events,
+    logger: getLogger,
   }
 }

--- a/src/producer/__snapshots__/index.spec.js.snap
+++ b/src/producer/__snapshots__/index.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Producer gives access to its logger 1`] = `
+Object {
+  "debug": [Function],
+  "error": [Function],
+  "info": [Function],
+  "warn": [Function],
+}
+`;

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -107,6 +107,11 @@ module.exports = ({
     })
   }
 
+  /**
+   * @returns {Object} logger
+   */
+  const getLogger = () => logger
+
   return {
     /**
      * @returns {Promise}
@@ -121,5 +126,7 @@ module.exports = ({
     send,
 
     sendBatch,
+
+    logger: getLogger,
   }
 }

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -269,4 +269,10 @@ describe('Producer', () => {
       ].sort(byTopicName)
     )
   })
+
+  test('gives access to its logger', () => {
+    producer = createProducer({ cluster: createCluster(), logger: newLogger() })
+
+    expect(producer.logger()).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Here's my proposal for exposing the namespaced loggers. Rationale is in #96

Fixes #96 
