### PR TITLE
Add consumer group offset commands to the admin client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ KafkaJS is battle-tested and ready for production.
   - [Compression](#consuming-messages-compression)
 - [Admin](#admin)
   - [Create Topics](#admin-create-topics)
+  - [Fetch consumer group offsets](#admin-fetch-offsets)
+  - [Reset consumer group offsets](#admin-reset-offsets)
+  - [Set consumer group offsets](#admin-set-offsets)
 - [Instrumentation](#instrumentation)
 - [Custom logging](#custom-logging)
 - [Retry (detailed)](#configuration-default-retry-detailed)
@@ -760,6 +763,64 @@ await admin.createTopics({
 | validateOnly   | If this is `true`, the request will be validated, but the topic won't be created.                     | false   |
 | timeout        | The time in ms to wait for a topic to be completely created on the controller node                    | 5000    |
 | waitForLeaders | If this is `true` it will wait until metadata for the new topics doesn't throw `LEADER_NOT_AVAILABLE` | true    |
+
+### <a name="admin-fetch-offsets"></a> Fetch consumer group offsets
+
+`fetchOffsets` returns the consumer group offset for a topic.
+
+```javascript
+await admin.fetchOffsets({ groupId, topic })
+// [
+//   { partition: 0, offset: '31004' },
+//   { partition: 1, offset: '54312' },
+//   { partition: 2, offset: '32103' },
+//   { partition: 3, offset: '28' },
+// ]
+```
+
+### <a name="admin-reset-offsets"></a> Reset consumer group offsets
+
+`resetOffsets` resets the consumer group offset to the earliest or latest offset (latest by default).
+The consumer group must have no running instances when performing the reset. Otherwise, the command will be rejected.
+
+```javascript
+await admin.resetOffsets({ groupId, topic }) // latest by default
+// await admin.resetOffsets({ groupId, topic, earliest: true })
+```
+
+### <a name="admin-set-offsets"></a> Set consumer group offsets
+
+`setOffsets` allows you to set the consumer group offset to any value offset.
+
+```javascript
+await admin.setOffsets({
+  groupId: <String>,
+  topic: <String>,
+  partitions: <SeekEntry[]>,
+})
+```
+
+`SeekEntry` structure:
+
+```javascript
+{
+  partition: <Number>,
+  offset: <String>,
+}
+```
+
+Example:
+
+```javascript
+await admin.setOffsets({
+  groupId: 'my-consumer-group',
+  topic: 'custom-topic',
+  partitions: [
+    { partition: 0, offset: '35' },
+    { partition: 3, offset: '19' },
+  ]
+})
+```
 
 ## <a name="instrumentation"></a> Instrumentation
 

--- a/src/admin/__snapshots__/index.spec.js.snap
+++ b/src/admin/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ Object {
   "debug": [Function],
   "error": [Function],
   "info": [Function],
+  "namespace": [Function],
   "warn": [Function],
 }
 `;

--- a/src/admin/__tests__/connection.spec.js
+++ b/src/admin/__tests__/connection.spec.js
@@ -1,0 +1,45 @@
+const createAdmin = require('../index')
+
+const {
+  sslConnectionOpts,
+  saslConnectionOpts,
+  saslSCRAM256ConnectionOpts,
+  saslSCRAM512ConnectionOpts,
+  createCluster,
+  sslBrokers,
+  saslBrokers,
+  newLogger,
+} = require('testHelpers')
+
+describe('Admin', () => {
+  let admin
+
+  afterEach(async () => {
+    await admin.disconnect()
+  })
+
+  test('support SSL connections', async () => {
+    const cluster = createCluster(sslConnectionOpts(), sslBrokers())
+    admin = createAdmin({ cluster, logger: newLogger() })
+
+    await admin.connect()
+  })
+
+  test('support SASL PLAIN connections', async () => {
+    const cluster = createCluster(saslConnectionOpts(), saslBrokers())
+    admin = createAdmin({ cluster, logger: newLogger() })
+    await admin.connect()
+  })
+
+  test('support SASL SCRAM 256 connections', async () => {
+    const cluster = createCluster(saslSCRAM256ConnectionOpts(), saslBrokers())
+    admin = createAdmin({ cluster, logger: newLogger() })
+    await admin.connect()
+  })
+
+  test('support SASL SCRAM 512 connections', async () => {
+    const cluster = createCluster(saslSCRAM512ConnectionOpts(), saslBrokers())
+    admin = createAdmin({ cluster, logger: newLogger() })
+    await admin.connect()
+  })
+})

--- a/src/admin/__tests__/createTopics.spec.js
+++ b/src/admin/__tests__/createTopics.spec.js
@@ -1,18 +1,8 @@
-const createAdmin = require('./index')
-const { KafkaJSProtocolError } = require('../errors')
-const { createErrorFromCode } = require('../protocol/error')
+const createAdmin = require('../index')
+const { KafkaJSProtocolError } = require('../../errors')
+const { createErrorFromCode } = require('../../protocol/error')
 
-const {
-  secureRandom,
-  sslConnectionOpts,
-  saslConnectionOpts,
-  saslSCRAM256ConnectionOpts,
-  saslSCRAM512ConnectionOpts,
-  createCluster,
-  sslBrokers,
-  saslBrokers,
-  newLogger,
-} = require('testHelpers')
+const { secureRandom, createCluster, newLogger } = require('testHelpers')
 
 const NOT_CONTROLLER = 41
 const TOPIC_ALREADY_EXISTS = 36
@@ -26,31 +16,6 @@ describe('Admin', () => {
 
   afterEach(async () => {
     await admin.disconnect()
-  })
-
-  test('support SSL connections', async () => {
-    const cluster = createCluster(sslConnectionOpts(), sslBrokers())
-    admin = createAdmin({ cluster, logger: newLogger() })
-
-    await admin.connect()
-  })
-
-  test('support SASL PLAIN connections', async () => {
-    const cluster = createCluster(saslConnectionOpts(), saslBrokers())
-    admin = createAdmin({ cluster, logger: newLogger() })
-    await admin.connect()
-  })
-
-  test('support SASL SCRAM 256 connections', async () => {
-    const cluster = createCluster(saslSCRAM256ConnectionOpts(), saslBrokers())
-    admin = createAdmin({ cluster, logger: newLogger() })
-    await admin.connect()
-  })
-
-  test('support SASL SCRAM 512 connections', async () => {
-    const cluster = createCluster(saslSCRAM512ConnectionOpts(), saslBrokers())
-    admin = createAdmin({ cluster, logger: newLogger() })
-    await admin.connect()
   })
 
   describe('createTopics', () => {

--- a/src/admin/__tests__/createTopics.spec.js
+++ b/src/admin/__tests__/createTopics.spec.js
@@ -133,13 +133,4 @@ describe('Admin', () => {
       expect(broker.metadata).toHaveBeenCalledWith([topicName, topic2, topic3])
     })
   })
-
-  it('gives access to its logger', () => {
-    expect(
-      createAdmin({
-        cluster: createCluster(),
-        logger: newLogger(),
-      }).logger()
-    ).toMatchSnapshot()
-  })
 })

--- a/src/admin/__tests__/fetchOffsets.spec.js
+++ b/src/admin/__tests__/fetchOffsets.spec.js
@@ -1,0 +1,68 @@
+const createAdmin = require('../index')
+const { secureRandom, createCluster, newLogger, createTopic } = require('testHelpers')
+
+describe('Admin', () => {
+  let topicName, groupId, admin, consumer
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+  })
+
+  afterEach(async () => {
+    await admin.disconnect()
+    consumer && (await consumer.disconnect())
+  })
+
+  describe('fetchOffsets', () => {
+    test('throws an error if the groupId is invalid', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.fetchOffsets({ groupId: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid groupId null'
+      )
+    })
+
+    test('throws an error if the topic name is not a valid string', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.fetchOffsets({ groupId: 'groupId', topic: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+
+    test('returns unresolved consumer group offsets', async () => {
+      const cluster = createCluster()
+      admin = createAdmin({ cluster, logger: newLogger() })
+
+      await admin.connect()
+      const offsets = await admin.fetchOffsets({
+        groupId,
+        topic: topicName,
+      })
+
+      expect(offsets).toEqual([{ partition: 0, offset: '-1' }])
+    })
+
+    test('returns the current consumer group offset', async () => {
+      const cluster = createCluster()
+      admin = createAdmin({ cluster, logger: newLogger() })
+
+      await admin.connect()
+      await admin.setOffsets({
+        groupId,
+        topic: topicName,
+        partitions: [{ partition: 0, offset: 13 }],
+      })
+
+      const offsets = await admin.fetchOffsets({
+        groupId,
+        topic: topicName,
+      })
+
+      expect(offsets).toEqual([{ partition: 0, offset: '13' }])
+    })
+  })
+})

--- a/src/admin/__tests__/resetOffsets.spec.js
+++ b/src/admin/__tests__/resetOffsets.spec.js
@@ -1,0 +1,107 @@
+const createAdmin = require('../index')
+const createConsumer = require('../../consumer')
+
+const { secureRandom, createCluster, newLogger, createTopic } = require('testHelpers')
+
+describe('Admin', () => {
+  let topicName, groupId, admin, consumer
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+  })
+
+  afterEach(async () => {
+    await admin.disconnect()
+    consumer && (await consumer.disconnect())
+  })
+
+  describe('resetOffsets', () => {
+    test('throws an error if the groupId is invalid', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.setOffsets({ groupId: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid groupId null'
+      )
+    })
+
+    test('throws an error if the topic name is not a valid string', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.setOffsets({ groupId: 'groupId', topic: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+
+    test('set the consumer group offsets to the latest offsets', async () => {
+      const cluster = createCluster()
+      admin = createAdmin({ cluster, logger: newLogger() })
+
+      await admin.connect()
+      await admin.setOffsets({
+        groupId,
+        topic: topicName,
+        partitions: [{ partition: 0, offset: 13 }],
+      })
+
+      await admin.resetOffsets({
+        groupId,
+        topic: topicName,
+      })
+
+      const offsets = await admin.fetchOffsets({
+        groupId,
+        topic: topicName,
+      })
+
+      expect(offsets).toEqual([{ partition: 0, offset: '-1' }])
+    })
+
+    test('set the consumer group offsets to the earliest offsets', async () => {
+      const cluster = createCluster()
+      admin = createAdmin({ cluster, logger: newLogger() })
+
+      await admin.connect()
+      await admin.setOffsets({
+        groupId,
+        topic: topicName,
+        partitions: [{ partition: 0, offset: 13 }],
+      })
+
+      await admin.resetOffsets({
+        groupId,
+        topic: topicName,
+        earliest: true,
+      })
+
+      const offsets = await admin.fetchOffsets({
+        groupId,
+        topic: topicName,
+      })
+
+      expect(offsets).toEqual([{ partition: 0, offset: '-2' }])
+    })
+
+    test('throws an error if the consumer group is runnig', async () => {
+      consumer = createConsumer({ groupId, cluster: createCluster(), logger: newLogger() })
+      await consumer.connect()
+      await consumer.subscribe({ topic: topicName })
+      await consumer.run({ eachMessage: () => true })
+
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+
+      await admin.connect()
+      await expect(
+        admin.resetOffsets({
+          groupId,
+          topic: topicName,
+        })
+      ).rejects.toHaveProperty(
+        'message',
+        'The consumer group must have no running instances, current state: Stable'
+      )
+    })
+  })
+})

--- a/src/admin/__tests__/setOffsets.spec.js
+++ b/src/admin/__tests__/setOffsets.spec.js
@@ -1,0 +1,100 @@
+const createAdmin = require('../index')
+const createConsumer = require('../../consumer')
+
+const { secureRandom, createCluster, newLogger } = require('testHelpers')
+
+describe('Admin', () => {
+  let topicName, groupId, admin, consumer
+
+  const offsetFetch = async ({ cluster }) => {
+    const coordinator = await cluster.findGroupCoordinator({ groupId })
+    return coordinator.offsetFetch({
+      groupId,
+      topics: [
+        {
+          topic: topicName,
+          partitions: [{ partition: 0 }],
+        },
+      ],
+    })
+  }
+
+  beforeEach(() => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+  })
+
+  afterEach(async () => {
+    await admin.disconnect()
+    consumer && (await consumer.disconnect())
+  })
+
+  describe('createTopics', () => {
+    test('throws an error if the groupId is invalid', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.setOffsets({ groupId: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid groupId null'
+      )
+    })
+
+    test('throws an error if the topic name is not a valid string', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.setOffsets({ groupId: 'groupId', topic: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+
+    test('throws an error if partitions is invalid', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(
+        admin.setOffsets({ groupId: 'groupId', topic: 'topic', partitions: null })
+      ).rejects.toHaveProperty('message', 'Invalid partitions')
+
+      await expect(
+        admin.setOffsets({ groupId: 'groupId', topic: 'topic', partitions: [] })
+      ).rejects.toHaveProperty('message', 'Invalid partitions')
+    })
+
+    test('set the consumer group to any offsets', async () => {
+      const cluster = createCluster()
+      admin = createAdmin({ cluster, logger: newLogger() })
+      await admin.setOffsets({
+        groupId,
+        topic: topicName,
+        partitions: [{ partition: 0, offset: 13 }],
+      })
+
+      const offsets = await offsetFetch({ cluster })
+      expect(offsets).toEqual({
+        errorCode: 0,
+        responses: [
+          {
+            partitions: [{ errorCode: 0, metadata: '', offset: '13', partition: 0 }],
+            topic: topicName,
+          },
+        ],
+      })
+    })
+
+    test('throws an error if the consumer group is runnig', async () => {
+      consumer = createConsumer({ groupId, cluster: createCluster(), logger: newLogger() })
+      await consumer.connect()
+      await consumer.subscribe({ topic: topicName })
+      await consumer.run({ eachMessage: () => true })
+
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(
+        admin.setOffsets({
+          groupId,
+          topic: topicName,
+          partitions: [{ partition: 0, offset: 13 }],
+        })
+      ).rejects.toHaveProperty(
+        'message',
+        'The consumer group must have no running instances, current state: Stable'
+      )
+    })
+  })
+})

--- a/src/admin/__tests__/setOffsets.spec.js
+++ b/src/admin/__tests__/setOffsets.spec.js
@@ -61,7 +61,7 @@ describe('Admin', () => {
       expect(offsets).toEqual([{ partition: 0, offset: '13' }])
     })
 
-    test('throws an error if the consumer group is runnig', async () => {
+    test('throws an error if the consumer group is running', async () => {
       consumer = createConsumer({ groupId, cluster: createCluster(), logger: newLogger() })
       await consumer.connect()
       await consumer.subscribe({ topic: topicName })

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,6 +1,7 @@
 const createRetry = require('../retry')
 const waitFor = require('../utils/waitFor')
 const createConsumer = require('../consumer')
+const { LEVELS } = require('../loggers')
 const { KafkaJSNonRetriableError } = require('../errors')
 
 const retryOnLeaderNotAvailable = (fn, opts = {}) => {
@@ -175,7 +176,11 @@ module.exports = ({ retry = { retries: 5 }, logger: rootLogger, cluster }) => {
       throw new KafkaJSNonRetriableError(`Invalid partitions`)
     }
 
-    const consumer = createConsumer({ logger: rootLogger, cluster, groupId })
+    const consumer = createConsumer({
+      logger: rootLogger.namespace('Admin', LEVELS.NOTHING),
+      cluster,
+      groupId,
+    })
 
     await consumer.subscribe({ topic, fromBeginning: true })
     const description = await consumer.describeGroup()

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -105,7 +105,6 @@ module.exports = ({ retry = { retries: 5 }, logger: rootLogger, cluster }) => {
 
     const consumer = createConsumer({ logger: rootLogger, cluster, groupId })
 
-    await consumer.connect()
     await consumer.subscribe({ topic, fromBeginning: true })
     const description = await consumer.describeGroup()
 
@@ -118,7 +117,7 @@ module.exports = ({ retry = { retries: 5 }, logger: rootLogger, cluster }) => {
     return new Promise((resolve, reject) => {
       consumer.on(consumer.events.FETCH, async () =>
         consumer
-          .disconnect()
+          .stop()
           .then(resolve)
           .catch(reject)
       )

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -152,6 +152,16 @@ module.exports = ({ retry = { retries: 5 }, logger: rootLogger, cluster }) => {
     return setOffsets({ groupId, topic, partitions: partitionsToSeek })
   }
 
+  /**
+   * @param {string} groupId
+   * @param {string} topic
+   * @param {Array<SeekEntry>} partitions
+   * @return {Promise}
+   *
+   * @typedef {Object} SeekEntry
+   * @property {number} partition
+   * @property {string} offset
+   */
   const setOffsets = async ({ groupId, topic, partitions }) => {
     if (!groupId) {
       throw new KafkaJSNonRetriableError(`Invalid groupId ${groupId}`)

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -2,6 +2,7 @@ const BrokerPool = require('./brokerPool')
 const createRetry = require('../retry')
 const connectionBuilder = require('./connectionBuilder')
 const flatten = require('../utils/flatten')
+const { EARLIEST_OFFSET, LATEST_OFFSET } = require('../constants')
 const {
   KafkaJSError,
   KafkaJSBrokerNotFound,
@@ -11,9 +12,6 @@ const {
 } = require('../errors')
 
 const { keys } = Object
-
-const EARLIEST_OFFSET = -2
-const LATEST_OFFSET = -1
 
 const mergeTopics = (obj, { topic, partitions }) => ({
   ...obj,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,7 @@
+const EARLIEST_OFFSET = -2
+const LATEST_OFFSET = -1
+
+module.exports = {
+  EARLIEST_OFFSET,
+  LATEST_OFFSET,
+}

--- a/src/consumer/__tests__/__snapshots__/logger.spec.js.snap
+++ b/src/consumer/__tests__/__snapshots__/logger.spec.js.snap
@@ -5,6 +5,7 @@ Object {
   "debug": [Function],
   "error": [Function],
   "info": [Function],
+  "namespace": [Function],
   "warn": [Function],
 }
 `;

--- a/src/consumer/__tests__/seek.spec.js
+++ b/src/consumer/__tests__/seek.spec.js
@@ -61,8 +61,8 @@ describe('Consumer', () => {
       )
     })
 
-    it('throws an error if the offset is negative', () => {
-      expect(() => consumer.seek({ topic: topicName, partition: 0, offset: '-1' })).toThrow(
+    it('throws an error if the offset is negative and not a special offset', () => {
+      expect(() => consumer.seek({ topic: topicName, partition: 0, offset: '-32' })).toThrow(
         KafkaJSNonRetriableError,
         'Offset must not be a negative number'
       )

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -6,6 +6,7 @@ const events = require('./instrumentationEvents')
 const InstrumentationEventEmitter = require('../instrumentation/emitter')
 const { KafkaJSNonRetriableError } = require('../errors')
 const { roundRobin } = require('./assigners')
+const { EARLIEST_OFFSET, LATEST_OFFSET } = require('../constants')
 
 const { keys, values } = Object
 
@@ -13,6 +14,11 @@ const eventNames = values(events)
 const eventKeys = keys(events)
   .map(key => `consumer.events.${key}`)
   .join(', ')
+
+const specialOffsets = [
+  Long.fromValue(EARLIEST_OFFSET).toString(),
+  Long.fromValue(LATEST_OFFSET).toString(),
+]
 
 module.exports = ({
   cluster,
@@ -200,25 +206,31 @@ module.exports = ({
     if (!topic) {
       throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
     }
+
     if (isNaN(partition)) {
       throw new KafkaJSNonRetriableError(
         `Invalid partition, expected a number received ${partition}`
       )
     }
+
+    let seekOffset
     try {
-      if (Long.fromValue(offset).lessThan(0)) {
-        throw new KafkaJSNonRetriableError('Offset must not be a negative number')
-      }
+      seekOffset = Long.fromValue(offset)
     } catch (_) {
       throw new KafkaJSNonRetriableError(`Invalid offset, expected a long received ${offset}`)
     }
+
+    if (seekOffset.lessThan(0) && !specialOffsets.includes(seekOffset.toString())) {
+      throw new KafkaJSNonRetriableError('Offset must not be a negative number')
+    }
+
     if (!consumerGroup) {
       throw new KafkaJSNonRetriableError(
         'Consumer group was not initialized, consumer#run must be called first'
       )
     }
 
-    consumerGroup.seek({ topic, partition, offset })
+    consumerGroup.seek({ topic, partition, offset: seekOffset.toString() })
   }
 
   /**

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -94,13 +94,25 @@ module.exports = ({
    */
   const disconnect = async () => {
     try {
-      if (runner) {
-        await runner.stop()
-        logger.debug('consumer has stopped, disconnecting', { groupId })
-      }
+      await stop()
+      logger.debug('consumer has stopped, disconnecting', { groupId })
       await cluster.disconnect()
     } catch (e) {}
-    logger.info('Stopped', { groupId })
+  }
+
+  /**
+   * @return {Promise}
+   */
+  const stop = async () => {
+    try {
+      if (runner) {
+        await runner.stop()
+        runner = null
+        consumerGroup = null
+      }
+
+      logger.info('Stopped', { groupId })
+    } catch (e) {}
   }
 
   /**
@@ -320,6 +332,7 @@ module.exports = ({
     connect,
     disconnect,
     subscribe,
+    stop,
     run,
     seek,
     describeGroup,

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -88,10 +88,15 @@ module.exports = class Runner {
   }
 
   async stop() {
+    if (!this.running) {
+      return
+    }
+
     this.logger.debug('stop consumer group', {
       groupId: this.consumerGroup.groupId,
       memberId: this.consumerGroup.memberId,
     })
+
     this.running = false
 
     try {

--- a/src/loggers/index.spec.js
+++ b/src/loggers/index.spec.js
@@ -82,4 +82,10 @@ describe('Loggers', () => {
       },
     })
   })
+
+  it('accepts a custom logLevel for the namespaced logger', () => {
+    const newLogger = logger.namespace('Custom', LEVELS.NOTHING)
+    newLogger.debug('<test custom logLevel for namespaced logger>')
+    expect(myLogger).not.toHaveBeenCalled()
+  })
 })

--- a/src/producer/__snapshots__/index.spec.js.snap
+++ b/src/producer/__snapshots__/index.spec.js.snap
@@ -5,6 +5,7 @@ Object {
   "debug": [Function],
   "error": [Function],
   "info": [Function],
+  "namespace": [Function],
   "warn": [Function],
 }
 `;


### PR DESCRIPTION
This PR mainly adds 3 new methods to the admin client:

```javascript
await admin.fetchOffsets({ groupId, topic })

await admin.resetOffsets({ groupId, topic }) // latest by default
// await admin.resetOffsets({ groupId, topic, earliest: true })

await admin.setOffsets({
  groupId: 'my-consumer-group',
  topic: 'custom-topic',
  partitions: [
    { partition: 0, offset: '35' },
    { partition: 3, offset: '19' },
  ]
})
```