### PR TITLE
Fix a bug when parsing multiple responses

### DIFF
--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -304,43 +304,43 @@ module.exports = class Connection {
 
     this.buffer = Buffer.concat([this.buffer, rawData])
 
-    // Not enough bytes to read the expected response size, keep buffering
-    if (Buffer.byteLength(this.buffer) <= Decoder.int32Size()) {
-      return
+    // Process data if there are enough bytes to read the expected response size,
+    // otherwise keep buffering
+    while (Buffer.byteLength(this.buffer) > Decoder.int32Size()) {
+      const data = Buffer.from(this.buffer)
+      const decoder = new Decoder(data)
+      const expectedResponseSize = decoder.readInt32()
+
+      if (!decoder.canReadBytes(expectedResponseSize)) {
+        return
+      }
+
+      const response = new Decoder(decoder.readBytes(expectedResponseSize))
+      // Reset the buffer as the rest of the bytes
+      this.buffer = decoder.readAll()
+
+      if (this.authHandlers) {
+        return this.authHandlers.onSuccess(data.slice(0, this.offset + byteLength))
+      }
+
+      const correlationId = response.readInt32()
+      const payload = response.readAll()
+
+      const entry = this.pendingQueue[correlationId]
+      delete this.pendingQueue[correlationId]
+
+      if (!entry) {
+        this.logDebug(`Response without match`, { correlationId })
+        return
+      }
+
+      entry.resolve({
+        size: expectedResponseSize,
+        correlationId,
+        entry,
+        payload,
+      })
     }
-
-    const data = Buffer.from(this.buffer)
-    const decoder = new Decoder(data)
-    const expectedResponseSize = decoder.readInt32()
-
-    if (!decoder.canReadBytes(expectedResponseSize)) {
-      return
-    }
-
-    // The full payload is loaded, erase the temporary buffer
-    this.buffer = Buffer.alloc(0)
-
-    if (this.authHandlers) {
-      return this.authHandlers.onSuccess(data)
-    }
-
-    const correlationId = decoder.readInt32()
-    const payload = decoder.readAll()
-
-    const entry = this.pendingQueue[correlationId]
-    delete this.pendingQueue[correlationId]
-
-    if (!entry) {
-      this.logDebug(`Response without match`, { correlationId })
-      return
-    }
-
-    entry.resolve({
-      size: expectedResponseSize,
-      correlationId,
-      entry,
-      payload,
-    })
   }
 
   /**

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -320,7 +320,7 @@ module.exports = class Connection {
       this.buffer = decoder.readAll()
 
       if (this.authHandlers) {
-        return this.authHandlers.onSuccess(data.slice(0, this.offset + byteLength))
+        return this.authHandlers.onSuccess(data.slice(0, Decoder.int32Size() + expectedResponseSize))
       }
 
       const correlationId = response.readInt32()

--- a/src/protocol/decoder.js
+++ b/src/protocol/decoder.js
@@ -90,9 +90,7 @@ module.exports = class Decoder {
     return Buffer.byteLength(this.buffer) - this.offset >= length
   }
 
-  readBytes() {
-    const byteLength = this.readInt32()
-
+  readBytes(byteLength = this.readInt32()) {
     if (byteLength === -1) {
       return null
     }


### PR DESCRIPTION
The previous implementation was assuming that the `rawData` only contains the bytes of a single response. This could cause response loss when mutiple reponses are concatenated into one `rawData`.