### PR TITLE
Improve stack trace for KafkaJSNumberOfRetriesExceeded

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -178,7 +178,12 @@ module.exports = ({
     }
 
     const onCrash = async e => {
-      logger.error(`Crash: ${e.name}: ${e.message}`, { retryCount: e.retryCount, groupId })
+      logger.error(`Crash: ${e.name}: ${e.message}`, {
+        groupId,
+        retryCount: e.retryCount,
+        stack: e.stack,
+      })
+
       await disconnect()
 
       if (e.name === 'KafkaJSNumberOfRetriesExceeded') {

--- a/src/errors.js
+++ b/src/errors.js
@@ -33,6 +33,7 @@ class KafkaJSOffsetOutOfRange extends KafkaJSProtocolError {
 class KafkaJSNumberOfRetriesExceeded extends KafkaJSNonRetriableError {
   constructor(e, { retryCount, retryTime }) {
     super(e)
+    this.stack = `${this.name}\n  Caused by: ${e.stack}`
     this.originalError = e
     this.retryCount = retryCount
     this.retryTime = retryTime


### PR DESCRIPTION
Before:

```javascript
KafkaJSNumberOfRetriesExceeded: fail on purpose
    at fn.then.catch.e (./kafkajs/src/retry/index.js:49:18)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

After:

```javascript
KafkaJSNumberOfRetriesExceeded
  Caused by: Error: fail on purpose
    at Runner.eachMessage (./kafkajs/examples/consumer.js:38:13)
    at Runner.processEachMessage (./kafkajs/src/consumer/runner.js:138:20)
    at Runner.fetch (./kafkajs/src/consumer/runner.js:233:20)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```