### PR TITLE
Fix a bug when updating fetched offsets

### DIFF
--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -293,7 +293,10 @@ module.exports = class OffsetManager {
     }
 
     offsets.forEach(({ topic, partitions }) => {
-      this.committedOffsets[topic] = partitions.reduce(indexPartitions, {})
+      this.committedOffsets[topic] = partitions.reduce(
+        indexPartitions,
+        { ...this.committedOffsets[topic] },
+      )
     })
   }
 

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -293,10 +293,9 @@ module.exports = class OffsetManager {
     }
 
     offsets.forEach(({ topic, partitions }) => {
-      this.committedOffsets[topic] = partitions.reduce(
-        indexPartitions,
-        { ...this.committedOffsets[topic] },
-      )
+      this.committedOffsets[topic] = partitions.reduce(indexPartitions, {
+        ...this.committedOffsets[topic],
+      })
     })
   }
 


### PR DESCRIPTION
When updating committed offsets with the fetched offsets, the initial value of the `reduce` call was set as an empty object. This could cause offsets loss for resolved partitions, and it would further cause a `commitOffsetsIfNecessary` failure.

**PoC**
```typescript
import { Kafka, PartitionAssigners } from "kafkajs";

async function main() {
    const kafka = new Kafka({ brokers: ["kafka:9092"], clientId: "test-client" });
    const consumer = kafka.consumer({
        groupId: "test-group",
        partitionAssigners: [PartitionAssigners.roundRobin],
    });
    await consumer.connect();
    await consumer.subscribe({ topic: "test-topic", fromBeginning: true });
    await consumer.run({
        autoCommitThreshold: 1,
        eachBatchAutoResolve: false,
        eachBatch: async ({ batch, resolveOffset, heartbeat, commitOffsetsIfNecessary }) => {
            for (const { offset } of batch.messages) {
                resolveOffset(offset);
                await commitOffsetsIfNecessary();
                await heartbeat();
            }
        },
    });
}

main();
```

**Log**
```
{"level":"INFO","timestamp":"2018-08-29T23:50:53.600Z","logger":"kafkajs","message":"[Consumer] Starting","groupId":"test-group"}
{"level":"INFO","timestamp":"2018-08-29T23:50:56.913Z","logger":"kafkajs","message":"[Runner] Consumer has joined the group","groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65","leaderId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65","isLeader":true,"duration":3312}
{"level":"ERROR","timestamp":"2018-08-29T23:50:56.965Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.4:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":5,"size":78}
{"level":"ERROR","timestamp":"2018-08-29T23:50:56.965Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":2,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:50:56.968Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.5:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":1,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:50:56.982Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":0,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.051Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.4:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":9,"size":78}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.051Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":5,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.052Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.5:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":2,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.053Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":1,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.129Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.5:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":3,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.130Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":3,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:50:57.130Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":2,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:51:02.493Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.5:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":5,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:51:02.493Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":0,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:51:02.493Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":3,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:51:07.707Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":4,"size":96}
{"level":"ERROR","timestamp":"2018-08-29T23:51:07.707Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":4,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:51:12.979Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":6,"size":265940}
{"level":"ERROR","timestamp":"2018-08-29T23:51:12.979Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":7,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:51:18.171Z","logger":"kafkajs","message":"[Connection] Response Fetch(key: 1, version: 3)","broker":"xxx.xxx.xxx.6:9092","clientId":"test-client","error":"The requested offset is not within the range of offsets maintained by the server","correlationId":8,"size":376754}
{"level":"ERROR","timestamp":"2018-08-29T23:51:18.171Z","logger":"kafkajs","message":"[ConsumerGroup] Offset out of range, resetting to default offset","topic":"test-topic","partition":1,"groupId":"test-group","memberId":"test-client-f6898a47-ed3b-41c6-8e2d-1197ac77ca65"}
{"level":"ERROR","timestamp":"2018-08-29T23:51:28.309Z","logger":"kafkajs","message":"[Runner] Error when calling eachBatch","topic":"test-topic","partition":0,"offset":"2395","stack":"TypeError: Cannot read property 'low' of undefined\n    at Function.fromValue (.../node_modules/long/src/long.js:286:25)\n    at subtractOffsets (.../node_modules/kafkajs/src/consumer/offsetManager/index.js:105:44)\n    at subtractPartitionOffsets (.../node_modules/kafkajs/src/consumer/offsetManager/index.js:109:7)\n    at toPartitions.map.partition (.../node_modules/kafkajs/src/consumer/offsetManager/index.js:115:44)\n    at Array.map (<anonymous>)\n    at subtractTopicOffsets (.../node_modules/kafkajs/src/consumer/offsetManager/index.js:115:27)\n    at Array.map (<anonymous>)\n    at OffsetManager.countResolvedOffsets (.../node_modules/kafkajs/src/consumer/offsetManager/index.js:117:37)\n    at OffsetManager.commitOffsetsIfNecessary (.../node_modules/kafkajs/src/consumer/offsetManager/index.js:184:12)\n    at ConsumerGroup.commitOffsetsIfNecessary (.../node_modules/kafkajs/src/consumer/consumerGroup.js:216:30)"}
{"level":"ERROR","timestamp":"2018-08-29T23:51:28.332Z","logger":"kafkajs","message":"[Consumer] Crash: KafkaJSNumberOfRetriesExceeded: Cannot read property 'low' of undefined","retryCount":0,"groupId":"test-group"}
{"level":"INFO","timestamp":"2018-08-29T23:51:28.354Z","logger":"kafkajs","message":"[Consumer] Stopped","groupId":"test-group"}
{"level":"ERROR","timestamp":"2018-08-29T23:51:28.354Z","logger":"kafkajs","message":"[Consumer] Restarting the consumer in 355ms","retryCount":0,"groupId":"test-group"}
{"level":"INFO","timestamp":"2018-08-29T23:51:28.713Z","logger":"kafkajs","message":"[Consumer] Starting","groupId":"test-group"}
{"level":"INFO","timestamp":"2018-08-29T23:51:32.130Z","logger":"kafkajs","message":"[Runner] Consumer has joined the group","groupId":"test-group","memberId":"test-client-c6f840e2-a2e7-45ef-a5e3-3d23078e3969","leaderId":"test-client-c6f840e2-a2e7-45ef-a5e3-3d23078e3969","isLeader":true,"duration":3417}
```