### PR TITLE
Handle API version not supported

### DIFF
--- a/src/broker/__tests__/apiVersions.spec.js
+++ b/src/broker/__tests__/apiVersions.spec.js
@@ -1,5 +1,10 @@
 const { createConnection, connectionOpts, newLogger } = require('testHelpers')
+const { KafkaJSProtocolError, KafkaJSNonRetriableError } = require('../../errors')
+const { createErrorFromCode } = require('../../protocol/error')
+const { requests } = require('../../protocol/requests')
 const Broker = require('../index')
+
+const UNSUPPORTED_VERSION_CODE = 35
 
 describe('Broker > ApiVersions', () => {
   let broker
@@ -18,5 +23,26 @@ describe('Broker > ApiVersions', () => {
 
   test('request', async () => {
     await expect(broker.apiVersions()).resolves.toBeTruthy()
+  })
+
+  test('try to use the latest version', async () => {
+    jest.spyOn(requests.ApiVersions, 'protocol').mockImplementationOnce(() => () => {
+      throw new KafkaJSProtocolError(createErrorFromCode(UNSUPPORTED_VERSION_CODE))
+    })
+
+    await expect(broker.apiVersions()).resolves.toBeTruthy()
+    expect(requests.ApiVersions.protocol).toHaveBeenCalledWith({ version: 2 })
+    expect(requests.ApiVersions.protocol).toHaveBeenCalledWith({ version: 1 })
+  })
+
+  test('throws if API versions cannot be used', async () => {
+    jest.spyOn(requests.ApiVersions, 'protocol').mockImplementation(() => () => {
+      throw new KafkaJSProtocolError(createErrorFromCode(UNSUPPORTED_VERSION_CODE))
+    })
+
+    await expect(broker.apiVersions()).rejects.toThrow(
+      KafkaJSNonRetriableError,
+      'API Versions not supported'
+    )
   })
 })

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -1,6 +1,7 @@
 const Lock = require('../utils/lock')
 const { Types: Compression } = require('../protocol/message/compression')
 const { requests, lookup } = require('../protocol/requests')
+const { KafkaJSNonRetriableError } = require('../errors')
 const apiKeys = require('../protocol/requests/apiKeys')
 const SASLAuthenticator = require('./saslAuthenticator')
 
@@ -94,8 +95,25 @@ module.exports = class Broker {
    * @returns {Promise}
    */
   async apiVersions() {
-    const apiVersions = requests.ApiVersions.protocol({ version: 0 })
-    const response = await this.connection.send(apiVersions())
+    const availableVersions = requests.ApiVersions.versions.map(Number).reverse()
+    let response
+
+    // Find the best version implemented by the server
+    for (let candidateVersion of availableVersions) {
+      try {
+        const apiVersions = requests.ApiVersions.protocol({ version: candidateVersion })
+        response = await this.connection.send(apiVersions())
+      } catch (e) {
+        if (e.type !== 'UNSUPPORTED_VERSION') {
+          throw e
+        }
+      }
+    }
+
+    if (!response) {
+      throw new KafkaJSNonRetriableError('API Versions not supported')
+    }
+
     return response.apiVersions.reduce(
       (obj, version) =>
         Object.assign(obj, {

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -95,8 +95,11 @@ module.exports = class Broker {
    * @returns {Promise}
    */
   async apiVersions() {
-    const availableVersions = requests.ApiVersions.versions.map(Number).reverse()
     let response
+    const availableVersions = requests.ApiVersions.versions
+      .map(Number)
+      .sort()
+      .reverse()
 
     // Find the best version implemented by the server
     for (let candidateVersion of availableVersions) {

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -256,11 +256,13 @@ module.exports = class Connection {
 
       return data
     } catch (e) {
-      this.logError(`Response ${requestInfo(entry)}`, {
-        error: e.message,
-        correlationId,
-        size,
-      })
+      if (entry.apiName !== 'ApiVersions') {
+        this.logError(`Response ${requestInfo(entry)}`, {
+          error: e.message,
+          correlationId,
+          size,
+        })
+      }
 
       this.logDebug(`Response ${requestInfo(entry)}`, {
         error: e.message,

--- a/src/protocol/error.js
+++ b/src/protocol/error.js
@@ -473,7 +473,7 @@ const createErrorFromCode = code => {
 }
 const failIfVersionNotSupported = code => {
   if (code === UNSUPPORTED_VERSION_CODE) {
-    throw new KafkaJSProtocolError(errorCodes.find(e => e.code === code))
+    throw createErrorFromCode(UNSUPPORTED_VERSION_CODE)
   }
 }
 

--- a/src/protocol/error.js
+++ b/src/protocol/error.js
@@ -465,13 +465,21 @@ const unknownErrorCode = errorCode => ({
 })
 
 const SUCCESS_CODE = 0
+const UNSUPPORTED_VERSION_CODE = 35
+
 const failure = code => code !== SUCCESS_CODE
 const createErrorFromCode = code => {
   return new KafkaJSProtocolError(errorCodes.find(e => e.code === code) || unknownErrorCode(code))
+}
+const failIfVersionNotSupported = code => {
+  if (code === UNSUPPORTED_VERSION_CODE) {
+    throw new KafkaJSProtocolError(errorCodes.find(e => e.code === code))
+  }
 }
 
 module.exports = {
   failure,
   errorCodes,
   createErrorFromCode,
+  failIfVersionNotSupported,
 }

--- a/src/protocol/requests/apiKeys.js
+++ b/src/protocol/requests/apiKeys.js
@@ -17,7 +17,7 @@ module.exports = {
   DescribeGroups: 15,
   ListGroups: 16,
   SaslHandshake: 17,
-  ApiVersions: 18,
+  ApiVersions: 18, // ApiVersions v0 on Kafka 0.10
   CreateTopics: 19,
   DeleteTopics: 20,
   DeleteRecords: 21,
@@ -32,7 +32,7 @@ module.exports = {
   CreateAcls: 30,
   DeleteAcls: 31,
   DescribeConfigs: 32,
-  AlterConfigs: 33,
+  AlterConfigs: 33, // ApiVersions v0 and v1 on Kafka 0.11
   AlterReplicaLogDirs: 34,
   DescribeLogDirs: 35,
   SaslAuthenticate: 36,
@@ -41,5 +41,5 @@ module.exports = {
   RenewDelegationToken: 39,
   ExpireDelegationToken: 40,
   DescribeDelegationToken: 41,
-  DeleteGroups: 42,
+  DeleteGroups: 42, // ApiVersions v2 on Kafka 1.0
 }

--- a/src/protocol/requests/apiVersions/index.js
+++ b/src/protocol/requests/apiVersions/index.js
@@ -9,6 +9,11 @@ const versions = {
     const response = require('./v1/response')
     return { request: request(), response }
   },
+  2: () => {
+    const request = require('./v2/request')
+    const response = require('./v2/response')
+    return { request: request(), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/apiVersions/v0/response.js
+++ b/src/protocol/requests/apiVersions/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * ApiVersionResponse => ApiVersions
@@ -19,8 +19,12 @@ const apiVersion = decoder => ({
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
   return {
-    errorCode: decoder.readInt16(),
+    errorCode,
     apiVersions: decoder.readArray(apiVersion),
   }
 }

--- a/src/protocol/requests/apiVersions/v0/response.spec.js
+++ b/src/protocol/requests/apiVersions/v0/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > ApiVersions > v0', () => {
@@ -31,5 +32,11 @@ describe('Protocol > Requests > ApiVersions > v0', () => {
     })
 
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/src/protocol/requests/apiVersions/v1/response.js
+++ b/src/protocol/requests/apiVersions/v1/response.js
@@ -1,4 +1,5 @@
 const Decoder = require('../../../decoder')
+const { failIfVersionNotSupported } = require('../../../error')
 const { parse: parseV0 } = require('../v0/response')
 
 /**
@@ -18,10 +19,13 @@ const apiVersion = decoder => ({
 })
 
 const decode = async rawData => {
-  console.log(JSON.stringify(rawData))
   const decoder = new Decoder(rawData)
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
   return {
-    errorCode: decoder.readInt16(),
+    errorCode,
     apiVersions: decoder.readArray(apiVersion),
     throttleTime: decoder.readInt32(),
   }

--- a/src/protocol/requests/apiVersions/v1/response.spec.js
+++ b/src/protocol/requests/apiVersions/v1/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > ApiVersions > v1', () => {
@@ -45,5 +46,11 @@ describe('Protocol > Requests > ApiVersions > v1', () => {
     })
 
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/src/protocol/requests/apiVersions/v2/request.js
+++ b/src/protocol/requests/apiVersions/v2/request.js
@@ -1,0 +1,5 @@
+const requestV0 = require('../v0/request')
+
+// ApiVersions Request after v1 indicates the client can parse throttle_time_ms
+
+module.exports = () => ({ ...requestV0(), apiVersion: 2 })

--- a/src/protocol/requests/apiVersions/v2/request.spec.js
+++ b/src/protocol/requests/apiVersions/v2/request.spec.js
@@ -1,0 +1,18 @@
+const apiKeys = require('../../apiKeys')
+const RequestV0Protocol = require('./request')
+
+describe('Protocol > Requests > ApiVersions > v2', () => {
+  describe('request', () => {
+    test('metadata about the API', () => {
+      const request = RequestV0Protocol()
+      expect(request.apiKey).toEqual(apiKeys.ApiVersions)
+      expect(request.apiVersion).toEqual(2)
+      expect(request.apiName).toEqual('ApiVersions')
+    })
+
+    test('encode', async () => {
+      const { buffer } = await RequestV0Protocol().encode()
+      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+    })
+  })
+})

--- a/src/protocol/requests/apiVersions/v2/response.js
+++ b/src/protocol/requests/apiVersions/v2/response.js
@@ -1,0 +1,16 @@
+const { parse: parseV1, decode: decodeV1 } = require('../v1/response')
+
+/**
+ * ApiVersions Response (Version: 2) => error_code [api_versions] throttle_time_ms
+ *   error_code => INT16
+ *   api_versions => api_key min_version max_version
+ *     api_key => INT16
+ *     min_version => INT16
+ *     max_version => INT16
+ *   throttle_time_ms => INT32
+ */
+
+module.exports = {
+  parse: parseV1,
+  decode: decodeV1,
+}

--- a/src/protocol/requests/findCoordinator/v0/response.js
+++ b/src/protocol/requests/findCoordinator/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * FindCoordinator Response (Version: 0) => error_code coordinator
@@ -13,6 +13,9 @@ const { failure, createErrorFromCode } = require('../../../error')
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
   const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
   const coordinator = {
     nodeId: decoder.readInt32(),
     host: decoder.readString(),

--- a/src/protocol/requests/findCoordinator/v0/response.spec.js
+++ b/src/protocol/requests/findCoordinator/v0/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > FindCoordinator > v0', () => {
@@ -9,5 +10,11 @@ describe('Protocol > Requests > FindCoordinator > v0', () => {
     })
 
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/src/protocol/requests/heartbeat/v0/response.js
+++ b/src/protocol/requests/heartbeat/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * Heartbeat Response (Version: 0) => error_code
@@ -8,9 +8,11 @@ const { failure, createErrorFromCode } = require('../../../error')
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
-  return {
-    errorCode: decoder.readInt16(),
-  }
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
+  return { errorCode }
 }
 
 const parse = async data => {

--- a/src/protocol/requests/heartbeat/v0/response.spec.js
+++ b/src/protocol/requests/heartbeat/v0/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > Heartbeat > v0', () => {
@@ -6,5 +7,11 @@ describe('Protocol > Requests > Heartbeat > v0', () => {
     expect(data).toEqual({ errorCode: 0 })
 
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/src/protocol/requests/index.js
+++ b/src/protocol/requests/index.js
@@ -53,9 +53,10 @@ const BEGIN_EXPERIMENTAL_V011_REQUEST_VERSION = {
 
 const lookup = (versions, allowExperimentalV011) => (apiKey, definition) => {
   const version = versions[apiKey]
+  const availableVersions = definition.versions.map(Number)
   const allowedVersions = allowExperimentalV011
-    ? definition.versions
-    : definition.versions.filter(
+    ? availableVersions
+    : availableVersions.filter(
         version =>
           !BEGIN_EXPERIMENTAL_V011_REQUEST_VERSION[apiKey] ||
           version < BEGIN_EXPERIMENTAL_V011_REQUEST_VERSION[apiKey]

--- a/src/protocol/requests/joinGroup/v0/response.js
+++ b/src/protocol/requests/joinGroup/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * JoinGroup Response (Version: 0) => error_code generation_id group_protocol leader_id member_id [members]
@@ -15,8 +15,12 @@ const { failure, createErrorFromCode } = require('../../../error')
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
   return {
-    errorCode: decoder.readInt16(),
+    errorCode,
     generationId: decoder.readInt32(),
     groupProtocol: decoder.readString(),
     leaderId: decoder.readString(),

--- a/src/protocol/requests/joinGroup/v0/response.spec.js
+++ b/src/protocol/requests/joinGroup/v0/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > JoinGroup > v0', () => {
@@ -18,5 +19,11 @@ describe('Protocol > Requests > JoinGroup > v0', () => {
     })
 
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/src/protocol/requests/leaveGroup/v0/response.js
+++ b/src/protocol/requests/leaveGroup/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * LeaveGroup Response (Version: 0) => error_code
@@ -8,9 +8,11 @@ const { failure, createErrorFromCode } = require('../../../error')
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
-  return {
-    errorCode: decoder.readInt16(),
-  }
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
+  return { errorCode }
 }
 
 const parse = async data => {

--- a/src/protocol/requests/leaveGroup/v0/response.spec.js
+++ b/src/protocol/requests/leaveGroup/v0/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > LeaveGroup > v0', () => {
@@ -5,5 +6,11 @@ describe('Protocol > Requests > LeaveGroup > v0', () => {
     const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
     expect(data).toEqual({ errorCode: 0 })
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/src/protocol/requests/saslHandshake/v0/response.js
+++ b/src/protocol/requests/saslHandshake/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * SaslHandshake Response (Version: 0) => error_code [enabled_mechanisms]
@@ -9,8 +9,12 @@ const { failure, createErrorFromCode } = require('../../../error')
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
   return {
-    errorCode: decoder.readInt16(),
+    errorCode,
     enabledMechanisms: decoder.readArray(decoder => decoder.readString()),
   }
 }

--- a/src/protocol/requests/saslHandshake/v0/response.spec.js
+++ b/src/protocol/requests/saslHandshake/v0/response.spec.js
@@ -1,0 +1,10 @@
+const { unsupportedVersionResponse } = require('testHelpers')
+const { decode } = require('./response')
+
+describe('Protocol > Requests > SASLHandshake > v0', () => {
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
+  })
+})

--- a/src/protocol/requests/syncGroup/v0/response.js
+++ b/src/protocol/requests/syncGroup/v0/response.js
@@ -1,5 +1,5 @@
 const Decoder = require('../../../decoder')
-const { failure, createErrorFromCode } = require('../../../error')
+const { failure, createErrorFromCode, failIfVersionNotSupported } = require('../../../error')
 
 /**
  * SyncGroup Response (Version: 0) => error_code member_assignment
@@ -9,8 +9,12 @@ const { failure, createErrorFromCode } = require('../../../error')
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
+  const errorCode = decoder.readInt16()
+
+  failIfVersionNotSupported(errorCode)
+
   return {
-    errorCode: decoder.readInt16(),
+    errorCode,
     memberAssignment: decoder.readBytes(),
   }
 }
@@ -20,10 +24,7 @@ const parse = async data => {
     throw createErrorFromCode(data.errorCode)
   }
 
-  return {
-    errorCode: data.errorCode,
-    memberAssignment: data.memberAssignment,
-  }
+  return data
 }
 
 module.exports = {

--- a/src/protocol/requests/syncGroup/v0/response.spec.js
+++ b/src/protocol/requests/syncGroup/v0/response.spec.js
@@ -1,3 +1,4 @@
+const { unsupportedVersionResponse } = require('testHelpers')
 const { decode, parse } = require('./response')
 
 describe('Protocol > Requests > SyncGroup > v0', () => {
@@ -13,5 +14,11 @@ describe('Protocol > Requests > SyncGroup > v0', () => {
     })
 
     await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
   })
 })

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -143,6 +143,8 @@ const testIfKafka011 = (description, callback) => {
     : test.skip(description, callback)
 }
 
+const unsupportedVersionResponse = () => Buffer.from({ type: 'Buffer', data: [0, 35, 0, 0, 0, 0] })
+
 module.exports = {
   secureRandom,
   connectionOpts,
@@ -163,4 +165,5 @@ module.exports = {
   waitFor: testWaitFor,
   waitForMessages,
   testIfKafka011,
+  unsupportedVersionResponse,
 }


### PR DESCRIPTION
This PR does two things:

1) All single response protocols now validate error code 35 (`UNSUPPORTED_VERSION`) and throw the appropriate error

```javascript
{
  "level": "ERROR",
  "timestamp": "2018-09-23T10:39:18.904Z",
  "logger": "kafkajs",
  "message": "[Connection] Response ApiVersions(key: 18, version: 2)",
  "broker": "192.168.43.30:9093",
  "clientId": "test-9e51c3d1c7f66590661b",
  "error": "The version of API is not supported",
  "correlationId": 0,
  "size": 10
}
```

\* this particular error is suppressed

2) `Broker#apiVersions` will try to use the latest supported version of the APIVersions protocol. Currently, KafkaJS is always using version 0. This change will allow us to use newer versions of some protocols.

The error log for `APIVersion` was suppressed to avoid unnecessary error logs for an operation that will always happen.