### PR TITLE
Make consumers detect that a topic was updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,7 +888,7 @@ List of available events:
   payload: {`groupId`, `memberId`, `groupGenerationId`, `topics`}
 
 * consumer.events.GROUP_JOIN  
-  payload: {`groupId`, `memberId`, `leaderId`, `isLeader`, `duration`}
+  payload: {`groupId`, `memberId`, `leaderId`, `isLeader`, `memberAssignment`, `duration`}
 
 * consumer.events.FETCH  
   payload: {`numberOfBatches`, `duration`}

--- a/scripts/addPartitions.sh
+++ b/scripts/addPartitions.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+find_container_id() {
+  echo $(docker ps \
+    --filter "status=running" \
+    --filter "label=com.docker.compose.project=kafkajs" \
+    --filter "label=com.docker.compose.service=kafka1" \
+    --no-trunc \
+    -q)
+}
+
+if [ -z "$TOPIC" ]; then
+  echo -d "TOPIC is mandatory"
+  exit 1
+fi
+
+if [ -z "$PARTITIONS" ]; then
+  echo -d "PARTITIONS is mandatory"
+  exit 1
+fi
+
+docker exec \
+  $(find_container_id) \
+  bash -c "/opt/kafka/bin/kafka-topics.sh --zookeeper zk:2181 --alter --topic ${TOPIC} --partitions ${PARTITIONS}"

--- a/src/consumer/__tests__/instrumentationEvents.spec.js
+++ b/src/consumer/__tests__/instrumentationEvents.spec.js
@@ -139,6 +139,7 @@ describe('Consumer > Instrumentation Events', () => {
         isLeader: true,
         leaderId: expect.any(String),
         memberId: expect.any(String),
+        memberAssignment: { [topicName]: [0] },
       },
     })
   })

--- a/src/consumer/__tests__/rebalanceOnPartitionChange.spec.js
+++ b/src/consumer/__tests__/rebalanceOnPartitionChange.spec.js
@@ -1,0 +1,92 @@
+const createProducer = require('../../producer')
+const createConsumer = require('../index')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  createModPartitioner,
+  newLogger,
+  waitForMessages,
+  waitForConsumerToJoinGroup,
+  addPartitions,
+} = require('testHelpers')
+
+describe('Consumer', () => {
+  let topicName, groupId, producer, consumer1, consumer2
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+
+    producer = createProducer({
+      cluster: createCluster({ metadataMaxAge: 20 }),
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+
+    consumer1 = createConsumer({
+      cluster: createCluster({ metadataMaxAge: 50 }),
+      groupId,
+      heartbeatInterval: 100,
+      maxWaitTimeInMs: 100,
+      logger: newLogger(),
+    })
+
+    consumer2 = createConsumer({
+      cluster: createCluster({ metadataMaxAge: 3000 }),
+      groupId,
+      heartbeatInterval: 100,
+      maxWaitTimeInMs: 100,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    consumer1 && (await consumer1.disconnect())
+    consumer2 && (await consumer2.disconnect())
+    producer && (await producer.disconnect())
+  })
+
+  test('trigger rebalance if partitions change after metadata update', async () => {
+    await consumer1.connect()
+    await consumer2.connect()
+    await producer.connect()
+
+    await consumer1.subscribe({ topic: topicName, fromBeginning: true })
+    await consumer2.subscribe({ topic: topicName, fromBeginning: true })
+
+    const messagesConsumed = []
+    consumer1.run({ eachMessage: async event => messagesConsumed.push(event) })
+    consumer2.run({ eachMessage: async event => messagesConsumed.push(event) })
+
+    await Promise.all([
+      waitForConsumerToJoinGroup(consumer1),
+      waitForConsumerToJoinGroup(consumer2),
+    ])
+
+    let messages = Array(2)
+      .fill()
+      .map(() => {
+        const value = secureRandom()
+        return { key: `key-${value}`, value: `value-${value}` }
+      })
+
+    await producer.send({ acks: 1, topic: topicName, messages })
+    await waitForMessages(messagesConsumed, { number: 2 })
+
+    await addPartitions({ topic: topicName, partitions: 4 })
+
+    messages = Array(6)
+      .fill()
+      .map(() => {
+        const value = secureRandom()
+        return { key: `key-${value}`, value: `value-${value}` }
+      })
+
+    await producer.send({ acks: 1, topic: topicName, messages })
+    await waitForMessages(messagesConsumed, { number: 8 })
+  })
+})

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -10,7 +10,7 @@ const { MemberAssignment } = require('./assignerProtocol')
 const {
   KafkaJSError,
   KafkaJSNonRetriableError,
-  KafkaJSStaleTopicMetadataAssigment,
+  KafkaJSStaleTopicMetadataAssignment,
 } = require('../errors')
 
 const { keys } = Object
@@ -383,7 +383,7 @@ module.exports = class ConsumerGroup {
         throw new KafkaJSError(e.message)
       }
 
-      if (e.name === 'KafkaJSStaleTopicMetadataAssigment') {
+      if (e.name === 'KafkaJSStaleTopicMetadataAssignment') {
         this.logger.warn(`${e.message}, resync group`, {
           groupId: this.groupId,
           memberId: this.memberId,
@@ -448,7 +448,7 @@ module.exports = class ConsumerGroup {
       const diff = arrayDiff(partitions, this.partitionsPerSubscribedTopic.get(topic))
 
       if (diff.length > 0) {
-        throw new KafkaJSStaleTopicMetadataAssigment('Topic has been updated', {
+        throw new KafkaJSStaleTopicMetadataAssignment('Topic has been updated', {
           topic,
           unknownPartitions: diff,
         })

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -114,7 +114,7 @@ module.exports = class ConsumerGroup {
         )
       }
 
-      await this.cluster.refreshMetadataIfNecessary()
+      await this.cluster.refreshMetadata()
 
       assignment = await assigner.assign({ members, topics })
       this.logger.debug('Group assignment', {

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -53,6 +53,7 @@ module.exports = class Runner {
           memberId: this.consumerGroup.memberId,
           leaderId: this.consumerGroup.leaderId,
           isLeader: this.consumerGroup.isLeader(),
+          memberAssignment: this.consumerGroup.memberAssignment,
           duration: Date.now() - startJoin,
         }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -54,6 +54,13 @@ class KafkaJSTopicMetadataNotLoaded extends KafkaJSMetadataNotLoaded {
     this.topic = topic
   }
 }
+class KafkaJSStaleTopicMetadataAssigment extends KafkaJSError {
+  constructor(e, { topic, unknownPartitions } = {}) {
+    super(e)
+    this.topic = topic
+    this.unknownPartitions = unknownPartitions
+  }
+}
 
 class KafkaJSBrokerNotFound extends KafkaJSError {}
 class KafkaJSPartialMessageError extends KafkaJSNonRetriableError {}
@@ -77,6 +84,7 @@ module.exports = {
   KafkaJSNotImplemented,
   KafkaJSMetadataNotLoaded,
   KafkaJSTopicMetadataNotLoaded,
+  KafkaJSStaleTopicMetadataAssigment,
   KafkaJSTimeout,
   KafkaJSLockTimeout,
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -55,7 +55,7 @@ class KafkaJSTopicMetadataNotLoaded extends KafkaJSMetadataNotLoaded {
     this.topic = topic
   }
 }
-class KafkaJSStaleTopicMetadataAssigment extends KafkaJSError {
+class KafkaJSStaleTopicMetadataAssignment extends KafkaJSError {
   constructor(e, { topic, unknownPartitions } = {}) {
     super(e)
     this.topic = topic
@@ -85,7 +85,7 @@ module.exports = {
   KafkaJSNotImplemented,
   KafkaJSMetadataNotLoaded,
   KafkaJSTopicMetadataNotLoaded,
-  KafkaJSStaleTopicMetadataAssigment,
+  KafkaJSStaleTopicMetadataAssignment,
   KafkaJSTimeout,
   KafkaJSLockTimeout,
 }

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const ip = require('ip')
+const execa = require('execa')
 const uuid = require('uuid/v4')
 const crypto = require('crypto')
 const Cluster = require('../src/cluster')
@@ -149,6 +150,22 @@ const createTopic = async ({ topic, partitions = 1 }) => {
   }
 }
 
+const addPartitions = async ({ topic, partitions }) => {
+  const cmd = `TOPIC=${topic} PARTITIONS=${partitions} ./scripts/addPartitions.sh`
+  const cluster = createCluster()
+
+  await cluster.connect()
+  await cluster.addTargetTopic(topic)
+
+  execa.shellSync(cmd)
+
+  waitFor(async () => {
+    await cluster.refreshMetadata()
+    const partitionMetadata = cluster.findTopicPartitionMetadata(topic)
+    return partitionMetadata.length === partitions
+  })
+}
+
 const testIfKafka011 = (description, callback) => {
   return process.env.KAFKA_VERSION === '0.11'
     ? test(description, callback)
@@ -176,4 +193,5 @@ module.exports = {
   waitForMessages,
   waitForConsumerToJoinGroup,
   testIfKafka011,
+  addPartitions,
 }


### PR DESCRIPTION
Consumers can now detect that their assignment is old and force the group to rebalance. The consumers will now verify that they are aware of the assigned partitions after the rebalance and perform a refresh if necessary.

Fixes #133 