### PR TITLE
Enable Kafka 0.11 API by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ module.exports = class Client {
     retry,
     logLevel = INFO,
     logCreator = LoggerConsole,
-    allowExperimentalV011 = false,
+    allowExperimentalV011 = true,
   }) {
     this[PRIVATE.LOGGER] = createLogger({ level: logLevel, logCreator })
     this[PRIVATE.CREATE_CLUSTER] = ({ metadataMaxAge = 300000, allowAutoTopicCreation = true }) =>


### PR DESCRIPTION
I'm making this change as a PR to document the reason we are keeping the experimental flag on version `1.4.0`, even though it is enabled by default. We will remove the experimental flag in the next versions. The flag will be in place in case we need to switch back to 0.10 API quickly.