### PR TITLE
Add ZSTD to codecs and types

### DIFF
--- a/src/protocol/message/compression/index.js
+++ b/src/protocol/message/compression/index.js
@@ -8,6 +8,7 @@ const Types = {
   GZIP: 1,
   Snappy: 2,
   LZ4: 3,
+  ZSTD: 4,
 }
 
 const Codecs = {
@@ -17,6 +18,9 @@ const Codecs = {
   },
   [Types.LZ4]: () => {
     throw new KafkaJSNotImplemented('LZ4 compression not implemented')
+  },
+  [Types.ZSTD]: () => {
+    throw new KafkaJSNotImplemented('ZSTD compression not implemented')
   },
 }
 


### PR DESCRIPTION
Support for the [ZStandard](https://facebook.github.io/zstd/) compression codec is landing in Kafka 2.1.0, due for release 29th October, 2018.

Following [`kafkajs-lz4`](https://github.com/indix/kafkajs-lz4), I also plan to write a similar `kafkajs-zstd` codec soon.

References -

1. https://cwiki.apache.org/confluence/display/KAFKA/KIP-110%3A+Add+Codec+for+ZStandard+Compression
2. https://issues.apache.org/jira/browse/KAFKA-4514
3. https://github.com/apache/kafka/pull/2267
4. https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=91554044