### PR TITLE
Expose a "getTopicMetadata" method on admin instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,8 +858,15 @@ delete.topic.enable=true
 ### <a name="admin-get-topic-metadata"></a> Get topic metadata
 
 ```javascript
-await admin.getTopicMetadata(<String>)
+await admin.getTopicMetadata({ topics: <Array<String> })
 ```
+
+`TopicsMetadata` structure:
+
+```javascript
+{
+  topics: <Array<TopicMetadata>>,
+}
 
 `TopicMetadata` structure:
 
@@ -882,7 +889,14 @@ await admin.getTopicMetadata(<String>)
 }
 ```
 
-By default the admin client will throw an exception if the topic does not already exist.
+The admin client will throw an exception if any of the provided topics do not already exist.
+
+If you omit the `topics` argument the admin client will fetch metadata for all topics
+of which it is already aware (all the cluster's target topics):
+
+```
+await admin.getTopicMetadata();
+```
 
 ### <a name="admin-fetch-offsets"></a> Fetch consumer group offsets
 

--- a/README.md
+++ b/README.md
@@ -855,6 +855,35 @@ Topic deletion is disabled by default in Apache Kafka versions prior to `1.0.0`.
 delete.topic.enable=true
 ```
 
+### <a name="admin-get-topic-metadata"></a> Get topic metadata
+
+```javascript
+await admin.getTopicMetadata(<String>)
+```
+
+`TopicMetadata` structure:
+
+```javascript
+{
+  topic: <String>,
+  partitions: <Array<PartitionMetadata>>     // default: 1
+}
+```
+
+`PartitionMetadata` structure:
+
+```javascript
+{
+  partitionErrorCode: <Number>,              // default: 0
+  partitionId: <Number>,
+  leader: <Number>,
+  replicas: <Array<Number>>,
+  isr: <Array<Number>>,
+}
+```
+
+By default the admin client will throw an exception if the topic does not already exist.
+
 ### <a name="admin-fetch-offsets"></a> Fetch consumer group offsets
 
 `fetchOffsets` returns the consumer group offset for a topic.

--- a/src/admin/__tests__/getTopicMetadata.spec.js
+++ b/src/admin/__tests__/getTopicMetadata.spec.js
@@ -1,0 +1,76 @@
+const createAdmin = require('../index')
+
+const { secureRandom, createCluster, newLogger, createTopic } = require('testHelpers')
+
+describe('Admin', () => {
+  let existingTopicName, numPartitions, admin, consumer
+
+  beforeEach(async () => {
+    existingTopicName = `test-topic-${secureRandom()}`
+    numPartitions = 4
+
+    await createTopic({ topic: existingTopicName, partitions: numPartitions })
+  })
+
+  afterEach(async () => {
+    await admin.disconnect()
+    consumer && (await consumer.disconnect())
+  })
+
+  describe('getTopicMetadata', () => {
+    test('throws an error if the topic name is not a valid string', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.getTopicMetadata(null)).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+
+    test('retrieves metadata for each partition in the topic', async () => {
+      const cluster = createCluster()
+      admin = createAdmin({ cluster, logger: newLogger() })
+
+      await admin.connect()
+      const topicMetadata = await admin.getTopicMetadata(existingTopicName)
+
+      expect(topicMetadata).toHaveProperty('name', existingTopicName)
+      expect(topicMetadata.partitions).toHaveLength(numPartitions)
+
+      topicMetadata.partitions.forEach(partition => {
+        expect(partition).toHaveProperty('partitionId')
+        expect(partition).toHaveProperty('leader')
+        expect(partition).toHaveProperty('replicas')
+        expect(partition).toHaveProperty('partitionErrorCode')
+        expect(partition).toHaveProperty('isr')
+      })
+    })
+
+    test('creates a new topic if the topic does not exist and "allowAutoTopicCreation" is true', async () => {
+      admin = createAdmin({
+        cluster: createCluster({ allowAutoTopicCreation: true }),
+        logger: newLogger(),
+      })
+      const newTopicName = `test-topic-${secureRandom()}`
+
+      await admin.connect()
+      const topicMetadata = await admin.getTopicMetadata(newTopicName)
+
+      expect(topicMetadata).toHaveProperty('name', newTopicName)
+      expect(topicMetadata.partitions).toHaveLength(1)
+    })
+
+    test('throws an error if the topic does not exist and "allowAutoTopicCreation" is false', async () => {
+      admin = createAdmin({
+        cluster: createCluster({ allowAutoTopicCreation: false }),
+        logger: newLogger(),
+      })
+      const newTopicName = `test-topic-${secureRandom()}`
+
+      await admin.connect()
+      await expect(admin.getTopicMetadata(newTopicName)).rejects.toHaveProperty(
+        'message',
+        'This server does not host this topic-partition'
+      )
+    })
+  })
+})


### PR DESCRIPTION
Hiya! 

## Description

We had a need to lookup the partition metadata for a topic but found this method was not exposed in the public API, though the functionality exists on cluster instances. Accordingly I've added a method `getTopicMetadata` on the admin instance to permit users to lookup topic metadata. Since [admin instances are created with the `allowAutoTopicCreation ` option set to `false`](https://github.com/tulios/kafkajs/blob/master/src/index.js#L104) we should expect this method to throw an error when run against a topic that does not exist. Please let me know if there are changes we should make to bring this up to snuff, or if you have concerns about whether this method should be exposed.

## Example

```javascript
const admin = kafka.admin();
await admin.connect();
const { partitions } = await admin.getTopicMetadata('my-topic');
const numPartitions = partitions.length;
```

## Addendum 

As something of an aside, this work came up because we have a need to assign our messages to a partition according to a property other than _key_, because we are [compacting](http://cloudurable.com/blog/kafka-architecture-log-compaction/index.html) on the key. Currently we plan to accomplish this by adding a custom partitioner, identical to the [default](https://github.com/tulios/kafkajs/blob/master/src/producer/partitioners/default/index.js), except with the following as the first condition:

```javascript
if (typeof message.partition === 'string') {
      return toPositive(murmur2(message.partition)) % numPartitions
}
```

Basically if the `partition` property is a string we hash on that property instead of the key. Do you think this is a common enough use case that it would be worth porting into the library? Or is it best left outside the library as a custom partitioner for the client to implement?

Thanks!
