### PR TITLE
Don't log buffer on network send errors by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ KafkaJS is battle-tested and ready for production.
 - [Custom logging](#custom-logging)
 - [Retry (detailed)](#configuration-default-retry-detailed)
 - [Development](#development)
+  - [Environment variables](#environment-variables)
 
 ## <a name="installation"></a> Installation
 
@@ -1267,6 +1268,12 @@ yarn test:local
 
 Password for test keystore and certificates: `testtest`
 Password for SASL `test:testtest`
+
+### <a name="environment-variables"></a> Environment variables
+
+| variable                       | description                              | default |
+| ------------------------------ | ---------------------------------------- | ------- |
+| KAFKAJS_DEBUG_PROTOCOL_BUFFERS | Output raw protocol buffers in debug log | 0       |
 
 ## Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/tulios/kafkajs",
   "scripts": {
-    "test:local": "export KAFKA_VERSION=${KAFKA_VERSION:='0.11'} && NODE_ENV=test echo \"KAFKA_VERSION: ${KAFKA_VERSION}\" && ./node_modules/.bin/jest --forceExit --detectOpenHandles",
-    "test:debug": "NODE_ENV=test node --inspect-brk node_modules/.bin/jest --detectOpenHandles --runInBand --watch",
+    "test:local": "export KAFKA_VERSION=${KAFKA_VERSION:='0.11'} && NODE_ENV=test echo \"KAFKA_VERSION: ${KAFKA_VERSION}\" && DEBUG_LOG_BUFFERS=1 ./node_modules/.bin/jest --forceExit --detectOpenHandles",
+    "test:debug": "NODE_ENV=test node DEBUG_LOG_BUFFERS=1 --inspect-brk node_modules/.bin/jest --detectOpenHandles --runInBand --watch",
     "test:local:watch": "yarn test:local --watch",
     "test": "yarn lint && JEST_JUNIT_OUTPUT=test-report.xml ./scripts/testWithKafka.sh 'yarn test:local --ci --maxWorkers=4 --no-watchman'",
     "lint": "find . -path ./node_modules -prune -o -path ./coverage -prune -o -name '*.js' -print0 | xargs -0 ./node_modules/.bin/eslint",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/tulios/kafkajs",
   "scripts": {
     "test:local": "export KAFKA_VERSION=${KAFKA_VERSION:='0.11'} && NODE_ENV=test echo \"KAFKA_VERSION: ${KAFKA_VERSION}\" && DEBUG_LOG_BUFFERS=1 ./node_modules/.bin/jest --forceExit --detectOpenHandles",
-    "test:debug": "NODE_ENV=test node DEBUG_LOG_BUFFERS=1 --inspect-brk node_modules/.bin/jest --detectOpenHandles --runInBand --watch",
+    "test:debug": "NODE_ENV=test DEBUG_LOG_BUFFERS=1 node --inspect-brk node_modules/.bin/jest --detectOpenHandles --runInBand --watch",
     "test:local:watch": "yarn test:local --watch",
     "test": "yarn lint && JEST_JUNIT_OUTPUT=test-report.xml ./scripts/testWithKafka.sh 'yarn test:local --ci --maxWorkers=4 --no-watchman'",
     "lint": "find . -path ./node_modules -prune -o -path ./coverage -prune -o -name '*.js' -print0 | xargs -0 ./node_modules/.bin/eslint",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/tulios/kafkajs",
   "scripts": {
-    "test:local": "export KAFKA_VERSION=${KAFKA_VERSION:='0.11'} && NODE_ENV=test echo \"KAFKA_VERSION: ${KAFKA_VERSION}\" && DEBUG_LOG_BUFFERS=1 ./node_modules/.bin/jest --forceExit --detectOpenHandles",
-    "test:debug": "NODE_ENV=test DEBUG_LOG_BUFFERS=1 node --inspect-brk node_modules/.bin/jest --detectOpenHandles --runInBand --watch",
+    "test:local": "export KAFKA_VERSION=${KAFKA_VERSION:='0.11'} && NODE_ENV=test echo \"KAFKA_VERSION: ${KAFKA_VERSION}\" && KAFKAJS_DEBUG_PROTOCOL_BUFFERS=1 ./node_modules/.bin/jest --forceExit --detectOpenHandles",
+    "test:debug": "NODE_ENV=test KAFKAJS_DEBUG_PROTOCOL_BUFFERS=1 node --inspect-brk node_modules/.bin/jest --detectOpenHandles --runInBand --watch",
     "test:local:watch": "yarn test:local --watch",
     "test": "yarn lint && JEST_JUNIT_OUTPUT=test-report.xml ./scripts/testWithKafka.sh 'yarn test:local --ci --maxWorkers=4 --no-watchman'",
     "lint": "find . -path ./node_modules -prune -o -path ./coverage -prune -o -name '*.js' -print0 | xargs -0 ./node_modules/.bin/eslint",

--- a/scripts/testWithKafka.sh
+++ b/scripts/testWithKafka.sh
@@ -5,7 +5,7 @@ extraArgs="$2"
 
 export HOST_IP=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
 export COMPOSE_FILE=${COMPOSE_FILE:="docker-compose.0_11.yml"}
-export DEBUG_LOG_BUFFERS=${DEBUG_LOG_BUFFERS:=1}
+export KAFKAJS_DEBUG_PROTOCOL_BUFFERS=${KAFKAJS_DEBUG_PROTOCOL_BUFFERS:=1}
 
 find_container_id() {
   echo $(docker ps \

--- a/scripts/testWithKafka.sh
+++ b/scripts/testWithKafka.sh
@@ -5,6 +5,7 @@ extraArgs="$2"
 
 export HOST_IP=$(ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1)
 export COMPOSE_FILE=${COMPOSE_FILE:="docker-compose.0_11.yml"}
+export DEBUG_LOG_BUFFERS=${DEBUG_LOG_BUFFERS:=1}
 
 find_container_id() {
   echo $(docker ps \

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  KAFKAJS_DEBUG_PROTOCOL_BUFFERS: process.env.KAFKAJS_DEBUG_PROTOCOL_BUFFERS,
+})

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -59,6 +59,7 @@ module.exports = class Connection {
 
     this.logDebug = log('debug')
     this.logError = log('error')
+    this.shouldLogBuffers = process.env['DEBUG_LOG_BUFFERS'] === '1'
   }
 
   /**
@@ -265,10 +266,12 @@ module.exports = class Connection {
         })
       }
 
+      const isBuffer = Buffer.isBuffer(payload)
       this.logDebug(`Response ${requestInfo(entry)}`, {
         error: e.message,
         correlationId,
-        payload,
+        payload:
+          isBuffer && !this.shouldLogBuffers ? { type: 'Buffer', data: '[filtered]' } : payload,
       })
 
       throw e

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -3,6 +3,7 @@ const createSocket = require('./socket')
 const createRequest = require('../protocol/request')
 const Decoder = require('../protocol/decoder')
 const { KafkaJSConnectionError } = require('../errors')
+const getEnv = require('../env')
 
 /**
  * @param {string} host
@@ -59,7 +60,7 @@ module.exports = class Connection {
 
     this.logDebug = log('debug')
     this.logError = log('error')
-    this.shouldLogBuffers = process.env['DEBUG_LOG_BUFFERS'] === '1'
+    this.shouldLogBuffers = getEnv().KAFKAJS_DEBUG_PROTOCOL_BUFFERS === '1'
   }
 
   /**

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -95,23 +95,15 @@ describe('Network > Connection', () => {
     })
 
     test('rejects the Promise in case of a non-retriable error', async () => {
-      const debugStub = jest.fn()
-      connection.logger.debug = debugStub
       const protocol = apiVersions()
       protocol.response.parse = () => {
         throw new Error('non-retriable')
       }
       await connection.connect()
       await expect(connection.send(protocol)).rejects.toEqual(new Error('non-retriable'))
-
-      const lastCall = debugStub.mock.calls[debugStub.mock.calls.length - 1]
-      expect(lastCall[1].payload).toEqual({
-        data: '[filtered]',
-        type: 'Buffer',
-      })
     })
 
-    describe.only('Debug logging', () => {
+    describe('Debug logging', () => {
       let initialValue
 
       beforeAll(() => {

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -107,15 +107,15 @@ describe('Network > Connection', () => {
       let initialValue
 
       beforeAll(() => {
-        initialValue = process.env.DEBUG_LOG_BUFFERS
+        initialValue = process.env.KAFKAJS_DEBUG_PROTOCOL_BUFFERS
       })
 
       afterAll(() => {
-        process.env['DEBUG_LOG_BUFFERS'] = initialValue
+        process.env['KAFKAJS_DEBUG_PROTOCOL_BUFFERS'] = initialValue
       })
 
-      test('logs the full payload in case of non-retriable error when "DEBUG_LOG_BUFFERS" runtime flag is set', async () => {
-        process.env['DEBUG_LOG_BUFFERS'] = '1'
+      test('logs the full payload in case of non-retriable error when "KAFKAJS_DEBUG_PROTOCOL_BUFFERS" runtime flag is set', async () => {
+        process.env['KAFKAJS_DEBUG_PROTOCOL_BUFFERS'] = '1'
         const connection = new Connection(connectionOpts())
         const debugStub = jest.fn()
         connection.logger.debug = debugStub
@@ -130,8 +130,8 @@ describe('Network > Connection', () => {
         expect(lastCall[1].payload).toEqual(expect.any(Buffer))
       })
 
-      test('filters payload in case of non-retriable error when "DEBUG_LOG_BUFFERS" runtime flag is not set', async () => {
-        delete process.env['DEBUG_LOG_BUFFERS']
+      test('filters payload in case of non-retriable error when "KAFKAJS_DEBUG_PROTOCOL_BUFFERS" runtime flag is not set', async () => {
+        delete process.env['KAFKAJS_DEBUG_PROTOCOL_BUFFERS']
         const connection = new Connection(connectionOpts())
         const debugStub = jest.fn()
         connection.logger.debug = debugStub


### PR DESCRIPTION
Exposes a new environment flag `DEBUG_LOG_BUFFERS`, which when set to `1` will log the full payload.
If not set, the payload will be logged as:

```
{ "type": "Buffer", "data": "[filtered]"}
```

Fixes #172 

@paambaati 