### PR TITLE
Add description to lock instances

### DIFF
--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -38,7 +38,12 @@ module.exports = class Broker {
     this.authenticated = false
 
     const lockTimeout = this.connection.connectionTimeout + this.authenticationTimeout
-    this.lock = new Lock({ timeout: lockTimeout })
+    const brokerAddress = `${this.connection.host}:${this.connection.port}`
+
+    this.lock = new Lock({
+      timeout: lockTimeout,
+      description: `connect to broker ${brokerAddress}`,
+    })
 
     this.lookupRequest = () => {
       throw new Error('Broker not connected')

--- a/src/utils/lock.spec.js
+++ b/src/utils/lock.spec.js
@@ -37,7 +37,7 @@ describe('Utils > Lock', () => {
 
     await expect(
       Promise.all([callResource(), callResource(), callResource()])
-    ).rejects.toHaveProperty('message', 'Timeout while acquiring lock')
+    ).rejects.toHaveProperty('message', 'Timeout while acquiring lock (2 waiting locks)')
   })
 
   describe('with a description', () => {
@@ -53,7 +53,10 @@ describe('Utils > Lock', () => {
 
       await expect(
         Promise.all([callResource(), callResource(), callResource()])
-      ).rejects.toHaveProperty('message', 'Timeout while acquiring lock: "My test mock"')
+      ).rejects.toHaveProperty(
+        'message',
+        'Timeout while acquiring lock (2 waiting locks): "My test mock"'
+      )
     })
   })
 })

--- a/src/utils/lock.spec.js
+++ b/src/utils/lock.spec.js
@@ -39,4 +39,21 @@ describe('Utils > Lock', () => {
       Promise.all([callResource(), callResource(), callResource()])
     ).rejects.toHaveProperty('message', 'Timeout while acquiring lock')
   })
+
+  describe('with a description', () => {
+    it('throws an error with the configured description if the lock cannot be acquired within a period', async () => {
+      const lock = new Lock({ timeout: 60, description: 'My test mock' })
+      const resource = jest.fn()
+      const callResource = async () => {
+        await lock.acquire()
+        resource(Date.now())
+        await sleep(50)
+        // it never releases the lock
+      }
+
+      await expect(
+        Promise.all([callResource(), callResource(), callResource()])
+      ).rejects.toHaveProperty('message', 'Timeout while acquiring lock: "My test mock"')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #177

Example of the new error message:

```
Timeout while acquiring lock (2 waiting locks): "connect to broker broker2.net:9094"
```

EDIT:
I've included the number of waiting locks to the error message