### PR TITLE
Skip incomplete record batches

### DIFF
--- a/src/protocol/requests/fetch/v4/response.js
+++ b/src/protocol/requests/fetch/v4/response.js
@@ -46,7 +46,7 @@ const decodeMessages = async decoder => {
         records = [...records, ...recordBatch.records]
       } catch (e) {
         // The tail of the record batches can have incomplete records
-        // due to how maxBytes works
+        // due to how maxBytes works. See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-FetchAPI
         if (e.name === 'KafkaJSPartialMessageError') {
           break
         }


### PR DESCRIPTION
Each record batch can contain incomplete records due to how maxBytes works. This should finally fix #152

@paambaati can you try this branch?

Here is a raw FetchV4 Response buffer with an incomplete RecordBatch:
https://drive.google.com/open?id=1gvaudaYIcZWI3GsZNj1ytkbF-QXhGwUo

The file is quite big; the messages are compressed with LZ4