### PR TITLE
Allow messages with a value of null to support tombstones

### DIFF
--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -54,7 +54,7 @@ module.exports = ({
         )
       }
 
-      const messageWithoutValue = messages.find(message => !message.value)
+      const messageWithoutValue = messages.find(message => message.value === undefined)
       if (messageWithoutValue) {
         throw new KafkaJSNonRetriableError(
           `Invalid message without value for topic "${topic}": ${JSON.stringify(

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -42,14 +42,20 @@ describe('Producer', () => {
     ).rejects.toHaveProperty('message', `Invalid messages array [null] for topic "${topicName}"`)
   })
 
-  test('throws and error for messages without value', async () => {
+  test('throws an error for messages with a value of undefined', async () => {
     producer = createProducer({ cluster: createCluster(), logger: newLogger() })
+
     await expect(
       producer.send({ acks: 1, topic: topicName, messages: [{ foo: 'bar' }] })
     ).rejects.toHaveProperty(
       'message',
       `Invalid message without value for topic "${topicName}": {"foo":"bar"}`
     )
+  })
+
+  test('allows messages with a null value to support tombstones', async () => {
+    producer = createProducer({ cluster: createCluster(), logger: newLogger() })
+    await producer.send({ acks: 1, topic: topicName, messages: [{ foo: 'bar', value: null }] })
   })
 
   test('support SSL connections', async () => {


### PR DESCRIPTION
Validations was added in #142 to enforce truthy message values. It seems the intention was to blow up when the program forgot to set a value. However compacted topics use `null` values as _tombstones_* to mark delete. [From the docs](https://github.com/apache/kafka/blob/trunk/docs/design.html#L489):

> Compaction also allows for deletes. A message with a key and a **null payload** will be treated as a delete from the log. This delete marker will cause any prior message with that key to be removed

In order to support tombstones while preserving validation we've updated the check to only throw on `undefined` values. This should still help users who have forgotten to set the value while also allowing us to send tombstones (or messages with a value of an empty string!).

Thanks!

NB. The term _tombstone_ is used in the codebase & in discussion of this feature, but is missing from the docs. [There's an open PR to add the term](https://github.com/apache/kafka/pull/3480/commits/480327c53b6ad5278b5a7a50c043829e6a58be32#diff-5e58e6e65be8d6a09e8d96ed51cfa67f).