### PR TITLE
Fix message timestamp on produce v3

### DIFF
--- a/src/protocol/requests/produce/v3/request.js
+++ b/src/protocol/requests/produce/v3/request.js
@@ -63,11 +63,15 @@ const topicEncoder = compression => async ({ topic, partitions }) => {
 
 const partitionsEncoder = compression => async ({ partition, messages }) => {
   const dateNow = Date.now()
-  let timestamps = messages.map(m => m.timestamp)
-  timestamps = timestamps.length === 0 ? [dateNow] : timestamps
+  const messageTimestamps = messages
+    .map(m => m.timestamp)
+    .filter(timestamp => timestamp != null)
+    .sort()
 
-  const firstTimestamp = Math.min(...timestamps)
-  const maxTimestamp = Math.max(...timestamps)
+  const timestamps = messageTimestamps.length === 0 ? [dateNow] : messageTimestamps
+  const firstTimestamp = timestamps[0]
+  const maxTimestamp = timestamps[timestamps.length - 1]
+
   const records = messages.map((message, i) =>
     Record({
       ...message,

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -165,10 +165,14 @@ const addPartitions = async ({ topic, partitions }) => {
   })
 }
 
-const testIfKafka011 = (description, callback) => {
+const testIfKafka011 = (description, callback, testFn = test) => {
   return process.env.KAFKA_VERSION === '0.11'
-    ? test(description, callback)
+    ? testFn(description, callback)
     : test.skip(description, callback)
+}
+
+testIfKafka011.only = (description, callback) => {
+  return testIfKafka011(description, callback, test.only)
 }
 
 const unsupportedVersionResponse = () => Buffer.from({ type: 'Buffer', data: [0, 35, 0, 0, 0, 0] })


### PR DESCRIPTION
Produce v3 isn't filtering `undefined` timestamps and is sending timestamp `0` (NaN converted) for all messages. This error should affect features that rely on the message timestamps and topics with "log.message.timestamp.difference.max.ms", the producer will throw `INVALID_TIMESTAMP` error.

Example on how to create a topic with the timestamp difference configuration:

```javascript
await admin.createTopics({
    waitForLeaders: true,
    topics: [
      {
        topic: 'topic-with-max-timstamp-difference',
        numPartitions: 2,
        configEntries: [
          {
            name: 'message.timestamp.difference.max.ms',
            value: '604800000', // 7 days
          },
        ],
      },
    ],
  })
```