### PR TITLE
Handle receiving assignments for unsubscribed topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,6 +1165,9 @@ List of available events:
 
 * consumer.events.STOP
 
+* consumer.events.CRASH
+  payload: {`error`, `groupId`}
+
 ### <a name="instrumentation-producer"></a> Producer
 
 * producer.events.CONNECT

--- a/src/consumer/__tests__/assignmentForUnsubscribedTopic.spec.js
+++ b/src/consumer/__tests__/assignmentForUnsubscribedTopic.spec.js
@@ -1,0 +1,56 @@
+const createConsumer = require('../index')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  newLogger,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+
+describe('Consumer', () => {
+  let topicNames, groupId, consumer1, consumer2
+
+  beforeEach(async () => {
+    topicNames = [`test-topic-${secureRandom()}`, `test-topic-${secureRandom()}`]
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await Promise.all(topicNames.map(topicName => createTopic({ topic: topicName })))
+
+    consumer1 = createConsumer({
+      cluster: createCluster({ metadataMaxAge: 50 }),
+      groupId,
+      heartbeatInterval: 100,
+      maxWaitTimeInMs: 100,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    consumer1 && (await consumer1.disconnect())
+    consumer2 && (await consumer2.disconnect())
+  })
+
+  it('handles receiving assignments for unsubscribed topics', async () => {
+    await consumer1.connect()
+    await Promise.all(
+      topicNames.map(topicName => consumer1.subscribe({ topic: topicName, fromBeginning: true }))
+    )
+
+    consumer1.run({ eachMessage: () => {} })
+    await waitForConsumerToJoinGroup(consumer1)
+
+    // Second consumer re-uses group id but only subscribes to one of the topics
+    consumer2 = createConsumer({
+      cluster: createCluster({ metadataMaxAge: 50 }),
+      groupId,
+      heartbeatInterval: 100,
+      maxWaitTimeInMs: 100,
+      logger: newLogger(),
+    })
+    await consumer2.subscribe({ topic: topicNames[0], fromBeginning: true })
+
+    consumer2.run({ eachMessage: () => {} })
+    await waitForConsumerToJoinGroup(consumer2)
+  })
+})

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -166,7 +166,7 @@ module.exports = class ConsumerGroup {
     }
 
     // Check if the consumer is aware of all assigned partitions
-    for (let topic of assignedTopics) {
+    for (let topic of keys(currentMemberAssignment)) {
       const assignedPartitions = currentMemberAssignment[topic]
       const knownPartitions = this.partitionsPerSubscribedTopic.get(topic)
       const isAwareOfAllAssignedPartitions = assignedPartitions.every(partition =>

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -4,7 +4,7 @@ const ConsumerGroup = require('./consumerGroup')
 const Runner = require('./runner')
 const events = require('./instrumentationEvents')
 const InstrumentationEventEmitter = require('../instrumentation/emitter')
-const { CONNECT, DISCONNECT, STOP } = require('./instrumentationEvents')
+const { CONNECT, DISCONNECT, STOP, CRASH } = require('./instrumentationEvents')
 const { KafkaJSNonRetriableError } = require('../errors')
 const { roundRobin } = require('./assigners')
 const { EARLIEST_OFFSET, LATEST_OFFSET } = require('../constants')
@@ -185,6 +185,11 @@ module.exports = ({
       })
 
       await disconnect()
+
+      instrumentationEmitter.emit(CRASH, {
+        error: e,
+        groupId,
+      })
 
       if (e.name === 'KafkaJSNumberOfRetriesExceeded') {
         logger.error(`Restarting the consumer in ${e.retryTime}ms`, {

--- a/src/consumer/instrumentationEvents.js
+++ b/src/consumer/instrumentationEvents.js
@@ -11,4 +11,5 @@ module.exports = {
   CONNECT: consumerType('connect'),
   DISCONNECT: consumerType('disconnect'),
   STOP: consumerType('stop'),
+  CRASH: consumerType('crash'),
 }

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -132,6 +132,10 @@ const waitForConsumerToJoinGroup = (consumer, { maxWait = 10000 } = {}) =>
       clearTimeout(timeoutId)
       resolve()
     })
+    consumer.on(consumer.events.CRASH, event => {
+      clearTimeout(timeoutId)
+      reject(event.payload.error)
+    })
   })
 
 const createTopic = async ({ topic, partitions = 1, config = [] }) => {


### PR DESCRIPTION
If a consumer re-uses a group id from a consumer group with a different topic configuration we may receive member assignments for a topic that we're not subscribed to. We already attempted to handle this, but I don't think it was tested properly.

This also adds a new instrumentation event for the consumer, `consumer.crash`.