### PR TITLE
EoS #207 SendOffsets

### DIFF
--- a/src/cluster/__tests__/committedOffsets.spec.js
+++ b/src/cluster/__tests__/committedOffsets.spec.js
@@ -1,0 +1,46 @@
+const { createCluster } = require('testHelpers')
+
+describe('Cluster', () => {
+  let groupId
+
+  beforeEach(() => {
+    groupId = 'test-group-id'
+  })
+
+  const testWithOffsets = offsets => {
+    it(`should return all committed offsets by group ${
+      offsets ? '' : '(no offset map provided)'
+    }`, async () => {
+      const cluster = createCluster({ offsets })
+      const topic = 'test-topic'
+      const partition = 0
+
+      expect(cluster.committedOffsets({ groupId })).toEqual({})
+
+      cluster.markOffsetAsCommitted({ groupId, topic, partition, offset: '100' })
+      cluster.markOffsetAsCommitted({ groupId: 'foobar', topic, partition, offset: '999' })
+
+      expect(cluster.committedOffsets({ groupId })).toEqual({ [topic]: { [partition]: '100' } })
+      expect(cluster.committedOffsets({ groupId: 'foobar' })).toEqual({
+        [topic]: { [partition]: '999' },
+      })
+    })
+
+    if (offsets) {
+      it('should use the provided offsets map', async () => {
+        const cluster = createCluster({ offsets })
+        const topic = 'test-topic'
+        const partition = 0
+
+        cluster.markOffsetAsCommitted({ groupId, topic, partition, offset: '100' })
+        cluster.markOffsetAsCommitted({ groupId: 'foobar', topic, partition, offset: '999' })
+
+        expect(cluster.committedOffsets({ groupId })).toEqual({ [topic]: { [partition]: '100' } })
+        expect(offsets.get(groupId)).toEqual({ [topic]: { [partition]: '100' } })
+      })
+    }
+  }
+
+  testWithOffsets(undefined)
+  testWithOffsets(new Map())
+})

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -734,7 +734,7 @@ describe('Consumer', () => {
         const txnToCommit = await producer.transaction()
         await txnToCommit.sendOffsets({
           consumerGroupId: groupId,
-          offsets: uncommittedOffsetsPerMessage[97],
+          topics: uncommittedOffsetsPerMessage[97].topics,
         })
         await txnToCommit.commit()
 
@@ -768,7 +768,7 @@ describe('Consumer', () => {
         const txn2ToCommit = await producer.transaction()
         await txn2ToCommit.sendOffsets({
           consumerGroupId: groupId,
-          offsets: lastUncommittedOffsets,
+          topics: lastUncommittedOffsets.topics,
         })
         await txn2ToCommit.commit()
 
@@ -854,7 +854,7 @@ describe('Consumer', () => {
         const txnToAbort = await producer.transaction()
         await txnToAbort.sendOffsets({
           consumerGroupId: groupId,
-          offsets: uncommittedOffsetsPerMessage[98],
+          topics: uncommittedOffsetsPerMessage[98].topics,
         })
         await txnToAbort.abort()
 

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -758,8 +758,22 @@ describe('Consumer', () => {
         expect(getCurrentUncommittedOffsets()).toEqual(lastUncommittedOffsets)
         expect(getCurrentUncommittedOffsets()).toEqual({
           topics: [
-            { topic: topicName, partitions: [{ partition: partition.toString(), offset: '100' }] },
+            {
+              topic: topicName,
+              partitions: [{ partition: partition.toString(), offset: '100' }],
+            },
           ],
+        })
+
+        const txn2ToCommit = await producer.transaction()
+        await txn2ToCommit.sendOffsets({
+          consumerGroupId: groupId,
+          offsets: lastUncommittedOffsets,
+        })
+        await txn2ToCommit.commit()
+
+        expect(getCurrentUncommittedOffsets()).toEqual({
+          topics: [],
         })
       }
     )

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -805,9 +805,9 @@ describe('Consumer', () => {
           messages,
         })
 
-        const number = messages.length
-        await waitForMessages(messagesConsumed, {
-          number,
+        await waitFor(() => messagesConsumed.length >= messages.length, {
+          ignoreTimeout: false,
+          timeoutMessage: `Failed to consume all produced messages`,
         })
         await consumer.stop()
 
@@ -829,15 +829,16 @@ describe('Consumer', () => {
 
         consumer.run({ eachBatch })
 
-        // Assert we reprocess all the same messages
-        await waitForMessages(messagesConsumed, {
-          number: 1,
+        await waitFor(() => messagesConsumed.length >= 1, {
+          ignoreTimeout: false,
+          timeoutMessage: 'Failed to consume any messages after transaction was aborted',
         })
 
         expect(messagesConsumed[0].value.toString()).toMatch(/value-0/)
 
-        await waitForMessages(messagesConsumed, {
-          number,
+        await waitFor(() => messagesConsumed.length >= messages.length, {
+          ignoreTimeout: false,
+          timeoutMessage: 'Failed to consume all messages after transaction was aborted',
         })
 
         expect(messagesConsumed[messagesConsumed.length - 1].value.toString()).toMatch(/value-99/)

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -675,7 +675,6 @@ describe('Consumer', () => {
         })
 
         consumer = createConsumer({
-          autoCommit: false, // Have to manage offsets manually
           cluster,
           groupId,
           maxWaitTimeInMs: 100,
@@ -702,6 +701,7 @@ describe('Consumer', () => {
         }
 
         consumer.run({
+          autoCommit: false,
           eachBatch,
         })
         await waitForConsumerToJoinGroup(consumer)
@@ -764,7 +764,6 @@ describe('Consumer', () => {
         })
 
         consumer = createConsumer({
-          autoCommit: false, // Have to manage offsets manually
           cluster,
           groupId,
           maxWaitTimeInMs: 100,
@@ -792,6 +791,7 @@ describe('Consumer', () => {
         }
 
         consumer.run({
+          autoCommit: false,
           eachBatch,
         })
         await waitForConsumerToJoinGroup(consumer)
@@ -827,7 +827,10 @@ describe('Consumer', () => {
         messagesConsumed = []
         uncommittedOffsetsPerMessage = []
 
-        consumer.run({ eachBatch })
+        consumer.run({
+          autoCommit: false,
+          eachBatch,
+        })
 
         await waitFor(() => messagesConsumed.length >= 1, {
           ignoreTimeout: false,

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -143,9 +143,9 @@ describe('Consumer', () => {
     const batchesConsumed = []
     const functionsExposed = []
     consumer.run({
-      eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning }) => {
+      eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning, uncommittedOffsets }) => {
         batchesConsumed.push(batch)
-        functionsExposed.push(resolveOffset, heartbeat, isRunning)
+        functionsExposed.push(resolveOffset, heartbeat, isRunning, uncommittedOffsets)
       },
     })
 
@@ -179,6 +179,7 @@ describe('Consumer', () => {
     ])
 
     expect(functionsExposed).toEqual([
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
       expect.any(Function),

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -663,11 +663,10 @@ describe('Consumer', () => {
       }
     )
 
-    test.only('supports the "consume-transform-produce" workflow', async () => {
+    testIfKafka_0_11('supports the "consume-transform-produce" commit', async () => {
       cluster = createCluster({ allowExperimentalV011: true })
       producer = createProducer({
         cluster,
-        createPartitioner: createModPartitioner,
         logger: newLogger(),
         transactionalId: `transactional-id-${secureRandom()}`,
         maxInFlightRequests: 1,
@@ -683,20 +682,15 @@ describe('Consumer', () => {
 
       await consumer.connect()
       await producer.connect()
-      await consumer.subscribe({ topic: topicName })
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
 
       // 1. Run consumer with "autoCommit=false"
 
       let messagesConsumed = []
       let uncommittedOffsetsPerMessage = []
 
-      const eachBatch = async ({
-        batch: { messages },
-        uncommittedOffsets,
-        heartbeat,
-        resolveOffset,
-      }) => {
-        for (const message in messages) {
+      const eachBatch = async ({ batch, uncommittedOffsets, heartbeat, resolveOffset }) => {
+        for (const message of batch.messages) {
           messagesConsumed.push(message)
           resolveOffset(message.offset)
           uncommittedOffsetsPerMessage.push(uncommittedOffsets())
@@ -705,76 +699,51 @@ describe('Consumer', () => {
         await heartbeat()
       }
 
-      consumer.run({ eachBatch })
+      consumer.run({
+        eachBatch,
+      })
       await waitForConsumerToJoinGroup(consumer)
 
-      // 2. Produce messages
+      // 2. Produce messages and consume
 
       const messages = generateMessages()
       await producer.send({
+        acks: 1,
         topic: topicName,
         messages,
       })
 
-      // 3. Call sendOffset for all offsets prior to the last message
       const number = messages.length
       await waitForMessages(messagesConsumed, {
         number,
       })
 
-      expect(messagesConsumed[0].message.value.toString()).toMatch(/value-generated-0/)
-      expect(messagesConsumed[99].message.value.toString()).toMatch(/value-generated-99/)
+      expect(messagesConsumed[0].value.toString()).toMatch(/value-0/)
+      expect(messagesConsumed[99].value.toString()).toMatch(/value-99/)
+      expect(uncommittedOffsetsPerMessage).toHaveLength(messagesConsumed.length)
 
-      // * Assert we received offsets
-
-      const txnToAbort = await producer.transaction()
-      await txnToAbort.sendOffsets(
-        uncommittedOffsetsPerMessage[uncommittedOffsetsPerMessage.length - 2]
-      )
-
-      // 4. Stop consumer
-
-      await consumer.stop()
-
-      // 5. Abort txn
-
-      await txnToAbort.abort()
-
-      // 6. Start consumer
-
-      messagesConsumed = []
-      uncommittedOffsetsPerMessage = []
-      consumer.run({ eachBatch })
-
-      // 7. Assert we process previously produced messages
-      await waitForMessages(messagesConsumed, {
-        number,
-      })
-
-      expect(messagesConsumed[0].message.value.toString()).toMatch(/value-generated-0/)
-      expect(messagesConsumed[99].message.value.toString()).toMatch(/value-generated-99/)
-
-      // 8. Stop the consumer again
-
-      await consumer.stop()
-
-      // 9. Send offsets & commit txn
-
+      // 3. Send offsets in a transaction and commit
       const txnToCommit = await producer.transaction()
-      await txnToCommit.sendOffsets(
-        uncommittedOffsetsPerMessage[uncommittedOffsetsPerMessage.length - 2]
-      )
+      await txnToCommit.sendOffsets({
+        consumerGroupId: groupId,
+        offsets: uncommittedOffsetsPerMessage[98],
+      })
       await txnToCommit.commit()
 
-      // 10. Start consumer
+      // Restart consumer
+      await consumer.stop()
+      messagesConsumed = []
+      uncommittedOffsetsPerMessage = []
 
       consumer.run({ eachBatch })
 
-      // 11. Assert we consume from the last message (whose offset is after that which we sent)
+      // Assert we only consume the messages that were after the sent offset
       await waitForMessages(messagesConsumed, {
         number: 1,
       })
-      expect(messagesConsumed[0].message.value.toString()).toMatch(/value-generated-99/)
+
+      expect(messagesConsumed).toHaveLength(1)
+      expect(messagesConsumed[0].value.toString()).toMatch(/value-99/)
     })
   })
 })

--- a/src/consumer/__tests__/consumerGroup.spec.js
+++ b/src/consumer/__tests__/consumerGroup.spec.js
@@ -1,0 +1,24 @@
+const ConsumerGroup = require('../consumerGroup')
+const { newLogger } = require('testHelpers')
+
+describe('ConsumerGroup', () => {
+  let consumerGroup
+
+  beforeEach(() => {
+    consumerGroup = new ConsumerGroup({
+      logger: newLogger(),
+      topics: ['topic1'],
+      cluster: {},
+    })
+  })
+
+  describe('uncommittedOffsets', () => {
+    it("calls the offset manager's uncommittedOffsets", async () => {
+      const mockOffsets = { topics: [] }
+      consumerGroup.offsetManager = { uncommittedOffsets: jest.fn(() => mockOffsets) }
+
+      expect(consumerGroup.uncommittedOffsets()).toStrictEqual(mockOffsets)
+      expect(consumerGroup.offsetManager.uncommittedOffsets).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -268,6 +268,10 @@ module.exports = class ConsumerGroup {
     await this.offsetManager.commitOffsets()
   }
 
+  uncommittedOffsets() {
+    return this.offsetManager.uncommittedOffsets()
+  }
+
   async heartbeat({ interval }) {
     const { groupId, generationId, memberId } = this
     const now = Date.now()

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -139,6 +139,7 @@ module.exports = ({
   }
 
   /**
+   * @param {boolean} [autoCommit=true]
    * @param {number} [autoCommitInterval=null]
    * @param {number} [autoCommitThreshold=null]
    * @param {boolean} [eachBatchAutoResolve=true] Automatically resolves the last offset of the batch when the
@@ -148,6 +149,7 @@ module.exports = ({
    * @return {Promise}
    */
   const run = async ({
+    autoCommit = true,
     autoCommitInterval = null,
     autoCommitThreshold = null,
     eachBatchAutoResolve = true,
@@ -162,6 +164,7 @@ module.exports = ({
     const start = async onCrash => {
       logger.info('Starting', { groupId })
       runner = createRunner({
+        autoCommit,
         eachBatchAutoResolve,
         eachBatch,
         eachMessage,
@@ -173,6 +176,7 @@ module.exports = ({
 
     const restart = onCrash => {
       consumerGroup = createConsumerGroup({
+        autoCommit,
         autoCommitInterval,
         autoCommitThreshold,
       })

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -74,8 +74,9 @@ module.exports = ({
     })
   }
 
-  const createRunner = ({ eachBatchAutoResolve, eachBatch, eachMessage, onCrash }) => {
+  const createRunner = ({ eachBatchAutoResolve, eachBatch, eachMessage, onCrash, autoCommit }) => {
     return new Runner({
+      autoCommit,
       logger: rootLogger,
       consumerGroup,
       instrumentationEmitter,

--- a/src/consumer/offsetManager/__tests__/commitOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/commitOffsets.spec.js
@@ -1,0 +1,93 @@
+const OffsetManager = require('../index')
+const InstrumentationEventEmitter = require('../../../instrumentation/emitter')
+
+describe('Consumer > OffsetMananger > commitOffsets', () => {
+  let offsetManager,
+    topic1,
+    topic2,
+    memberAssignment,
+    mockCoordinator,
+    groupId,
+    generationId,
+    memberId
+
+  beforeEach(() => {
+    topic1 = 'topic-1'
+    topic2 = 'topic-2'
+    groupId = 'groupId'
+    generationId = 'generationId'
+    memberId = 'memberId'
+
+    memberAssignment = {
+      [topic1]: [0, 1],
+      [topic2]: [0, 1, 2, 3],
+    }
+
+    mockCoordinator = {
+      offsetCommit: jest.fn(),
+    }
+
+    offsetManager = new OffsetManager({
+      memberAssignment,
+      groupId,
+      generationId,
+      memberId,
+      instrumentationEmitter: new InstrumentationEventEmitter(),
+    })
+    offsetManager.getCoordinator = jest.fn(() => mockCoordinator)
+  })
+
+  it('commits all the resolved offsets that have not already been committed', async () => {
+    const defaultOffsetInt = 2
+
+    Object.keys(memberAssignment).forEach(topic => {
+      memberAssignment[topic].forEach(partition => {
+        offsetManager.resolveOffset({ topic, partition, offset: defaultOffsetInt.toString() })
+      })
+    })
+
+    const defaultResolvedOffsetInt = defaultOffsetInt + 1
+    const defaultResolvedOffsetStr = defaultResolvedOffsetInt.toString()
+
+    // If committed offset equal to resolved offset, then partition is marked as committed
+    offsetManager.committedOffsets[topic2][0] = defaultResolvedOffsetInt.toString() // "committed"
+
+    await offsetManager.commitOffsets()
+
+    expect(mockCoordinator.offsetCommit).toHaveBeenCalledWith({
+      groupId,
+      memberId,
+      groupGenerationId: generationId,
+      topics: [
+        {
+          topic: topic1,
+          partitions: [
+            { partition: '0', offset: defaultResolvedOffsetStr },
+            { partition: '1', offset: defaultResolvedOffsetStr },
+          ],
+        },
+        {
+          topic: topic2,
+          partitions: [
+            { partition: '1', offset: defaultResolvedOffsetStr },
+            { partition: '2', offset: defaultResolvedOffsetStr },
+            { partition: '3', offset: defaultResolvedOffsetStr },
+          ],
+        },
+      ],
+    })
+
+    expect(offsetManager.committedOffsets).toEqual({
+      'topic-1': {
+        '0': defaultResolvedOffsetStr,
+        '1': defaultResolvedOffsetStr,
+      },
+      'topic-2': {
+        '0': defaultResolvedOffsetStr,
+        '1': defaultResolvedOffsetStr,
+        '2': defaultResolvedOffsetStr,
+        '3': defaultResolvedOffsetStr,
+      },
+    })
+  })
+})

--- a/src/consumer/offsetManager/__tests__/commitOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/commitOffsets.spec.js
@@ -28,6 +28,9 @@ describe('Consumer > OffsetMananger > commitOffsets', () => {
     }
 
     offsetManager = new OffsetManager({
+      cluster: {
+        committedOffsets: jest.fn(() => ({})),
+      },
       memberAssignment,
       groupId,
       generationId,
@@ -50,7 +53,7 @@ describe('Consumer > OffsetMananger > commitOffsets', () => {
     const defaultResolvedOffsetStr = defaultResolvedOffsetInt.toString()
 
     // If committed offset equal to resolved offset, then partition is marked as committed
-    offsetManager.committedOffsets[topic2][0] = defaultResolvedOffsetInt.toString() // "committed"
+    offsetManager.committedOffsets()[topic2][0] = defaultResolvedOffsetInt.toString() // "committed"
 
     await offsetManager.commitOffsets()
 
@@ -77,7 +80,7 @@ describe('Consumer > OffsetMananger > commitOffsets', () => {
       ],
     })
 
-    expect(offsetManager.committedOffsets).toEqual({
+    expect(offsetManager.committedOffsets()).toEqual({
       'topic-1': {
         '0': defaultResolvedOffsetStr,
         '1': defaultResolvedOffsetStr,

--- a/src/consumer/offsetManager/__tests__/countResolvedOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/countResolvedOffsets.spec.js
@@ -20,14 +20,19 @@ describe('Consumer > OffsetMananger > countResolvedOffsets', () => {
       topic2: [0, 1, 2, 3, 4, 5],
     }
 
-    offsetManager = new OffsetManager({ memberAssignment })
+    offsetManager = new OffsetManager({
+      memberAssignment,
+      cluster: {
+        committedOffsets: jest.fn(() => new Map()),
+      },
+    })
   })
 
   it('counts the number of resolved offsets for all topics', () => {
-    offsetManager.committedOffsets['topic1'][0] = '-1'
-    offsetManager.committedOffsets['topic1'][1] = '-1'
-    offsetManager.committedOffsets['topic1'][2] = '-1'
-    offsetManager.committedOffsets['topic2'][5] = '-1'
+    offsetManager.committedOffsets()['topic1'][0] = '-1'
+    offsetManager.committedOffsets()['topic1'][1] = '-1'
+    offsetManager.committedOffsets()['topic1'][2] = '-1'
+    offsetManager.committedOffsets()['topic2'][5] = '-1'
 
     resolveOffsets('topic1', 0, { count: 10 })
     resolveOffsets('topic1', 1, { count: 1 })
@@ -39,10 +44,10 @@ describe('Consumer > OffsetMananger > countResolvedOffsets', () => {
 
   it('takes the committed offsets in consideration', () => {
     // committedOffsets will always have the next offset or -1
-    offsetManager.committedOffsets['topic1'][0] = '10'
-    offsetManager.committedOffsets['topic1'][1] = '1'
-    offsetManager.committedOffsets['topic1'][2] = '3'
-    offsetManager.committedOffsets['topic2'][5] = '5' // missing 1
+    offsetManager.committedOffsets()['topic1'][0] = '10'
+    offsetManager.committedOffsets()['topic1'][1] = '1'
+    offsetManager.committedOffsets()['topic1'][2] = '3'
+    offsetManager.committedOffsets()['topic2'][5] = '5' // missing 1
 
     resolveOffsets('topic1', 0, { count: 10 })
     resolveOffsets('topic1', 1, { count: 1 })

--- a/src/consumer/offsetManager/__tests__/uncommittedOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/uncommittedOffsets.spec.js
@@ -1,5 +1,3 @@
-const Long = require('long')
-const sleep = require('../../../utils/sleep')
 const OffsetManager = require('../index')
 
 describe('Consumer > OffsetMananger > uncommittedOffsets', () => {

--- a/src/consumer/offsetManager/__tests__/uncommittedOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/uncommittedOffsets.spec.js
@@ -27,9 +27,9 @@ describe('Consumer > OffsetMananger > uncommittedOffsets', () => {
     const defaultResolvedOffsetInt = defaultOffsetInt + 1
 
     // If committed offset equal to resolved offset, then partition is marked as committed
-    offsetManager.committedOffsets[topic2][0] = defaultResolvedOffsetInt.toString() // "committed"
-    offsetManager.committedOffsets[topic2][1] = (defaultResolvedOffsetInt - 1).toString() // not "committed"
-    offsetManager.committedOffsets[topic2][2] = (defaultResolvedOffsetInt + 1).toString() // not "committed"
+    offsetManager.committedOffsets()[topic2][0] = defaultResolvedOffsetInt.toString() // "committed"
+    offsetManager.committedOffsets()[topic2][1] = (defaultResolvedOffsetInt - 1).toString() // not "committed"
+    offsetManager.committedOffsets()[topic2][2] = (defaultResolvedOffsetInt + 1).toString() // not "committed"
 
     expect(offsetManager.uncommittedOffsets()).toEqual({
       topics: [

--- a/src/consumer/offsetManager/__tests__/uncommittedOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/uncommittedOffsets.spec.js
@@ -1,0 +1,56 @@
+const Long = require('long')
+const sleep = require('../../../utils/sleep')
+const OffsetManager = require('../index')
+
+describe('Consumer > OffsetMananger > uncommittedOffsets', () => {
+  let offsetManager, topic1, topic2, memberAssignment
+
+  beforeEach(() => {
+    topic1 = 'topic-1'
+    topic2 = 'topic-2'
+
+    memberAssignment = {
+      [topic1]: [0, 1],
+      [topic2]: [0, 1, 2, 3],
+    }
+
+    offsetManager = new OffsetManager({ memberAssignment })
+  })
+
+  it('returns all resolved offsets which have not been committed', () => {
+    const defaultOffsetInt = 2
+
+    Object.keys(memberAssignment).forEach(topic => {
+      memberAssignment[topic].forEach(partition => {
+        offsetManager.resolveOffset({ topic, partition, offset: defaultOffsetInt.toString() })
+      })
+    })
+
+    const defaultResolvedOffsetInt = defaultOffsetInt + 1
+
+    // If committed offset equal to resolved offset, then partition is marked as committed
+    offsetManager.committedOffsets[topic2][0] = defaultResolvedOffsetInt.toString() // "committed"
+    offsetManager.committedOffsets[topic2][1] = (defaultResolvedOffsetInt - 1).toString() // not "committed"
+    offsetManager.committedOffsets[topic2][2] = (defaultResolvedOffsetInt + 1).toString() // not "committed"
+
+    expect(offsetManager.uncommittedOffsets()).toEqual({
+      topics: [
+        {
+          topic: topic1,
+          partitions: [
+            { partition: '0', offset: defaultResolvedOffsetInt.toString() },
+            { partition: '1', offset: defaultResolvedOffsetInt.toString() },
+          ],
+        },
+        {
+          topic: topic2,
+          partitions: [
+            { partition: '1', offset: defaultResolvedOffsetInt.toString() },
+            { partition: '2', offset: defaultResolvedOffsetInt.toString() },
+            { partition: '3', offset: defaultResolvedOffsetInt.toString() },
+          ],
+        },
+      ],
+    })
+  })
+})

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -199,7 +199,7 @@ module.exports = class OffsetManager {
    * @property {PartitionOffset[]} partitions
    *
    * @typedef {Object} PartitionOffset
-   * @property {number} partition
+   * @property {string} partition
    * @property {string} offset
    */
   uncommittedOffsets() {
@@ -250,7 +250,7 @@ module.exports = class OffsetManager {
     this.instrumentationEmitter.emit(COMMIT_OFFSETS, payload)
 
     // Update local reference of committed offsets
-    topicsWithPartitionsToCommit.forEach(({ topic, partitions }) => {
+    topics.forEach(({ topic, partitions }) => {
       const updatedOffsets = partitions.reduce(
         (obj, { partition, offset }) => assign(obj, { [partition]: offset }),
         {}

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -174,8 +174,15 @@ module.exports = class Runner {
         heartbeat: async () => {
           await this.consumerGroup.heartbeat({ interval: this.heartbeatInterval })
         },
+        /**
+         * Note that this method _does not_ heed the "autoCommit" option,
+         * since it will only ever be called manually by the user.
+         */
         commitOffsetsIfNecessary: async () => {
           await this.consumerGroup.commitOffsetsIfNecessary()
+        },
+        uncommittedOffsets: () => {
+          this.consumerGroup.uncommittedOffsets()
         },
         isRunning: () => this.running,
       })

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -181,9 +181,7 @@ module.exports = class Runner {
         commitOffsetsIfNecessary: async () => {
           await this.consumerGroup.commitOffsetsIfNecessary()
         },
-        uncommittedOffsets: () => {
-          this.consumerGroup.uncommittedOffsets()
-        },
+        uncommittedOffsets: () => this.consumerGroup.uncommittedOffsets(),
         isRunning: () => this.running,
       })
     } catch (e) {

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -215,7 +215,6 @@ module.exports = class Runner {
       }
 
       if (batch.isEmpty()) {
-        this.consumerGroup.resetOffset(batch)
         continue
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const ISOLATION_LEVEL = require('./protocol/isolationLevel')
 const PRIVATE = {
   CREATE_CLUSTER: Symbol('private:Kafka:createCluster'),
   LOGGER: Symbol('private:Kafka:logger'),
+  OFFSETS: Symbol('private:Kafka:offsets'),
 }
 
 module.exports = class Client {
@@ -28,6 +29,7 @@ module.exports = class Client {
     logCreator = LoggerConsole,
     allowExperimentalV011 = true,
   }) {
+    this[PRIVATE.OFFSETS] = new Map()
     this[PRIVATE.LOGGER] = createLogger({ level: logLevel, logCreator })
     this[PRIVATE.CREATE_CLUSTER] = ({
       metadataMaxAge = 300000,
@@ -49,6 +51,7 @@ module.exports = class Client {
         allowExperimentalV011,
         maxInFlightRequests,
         isolationLevel,
+        offsets: this[PRIVATE.OFFSETS],
       })
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -13,6 +13,22 @@ describe('Client', () => {
     expect(new Client({ brokers: [] }).logger()).toMatchSnapshot()
   })
 
+  it('shares a commit mapping between the consumer and the producer', () => {
+    const client = new Client({ brokers: [] })
+
+    expect(Cluster).toHaveBeenCalledTimes(0)
+
+    client.producer({})
+    client.consumer({})
+
+    expect(Cluster).toHaveBeenCalledTimes(2)
+    expect(Cluster.mock.calls[0][0].offsets).toBeInstanceOf(Map)
+    expect(Cluster.mock.calls[0][0].offsets).toBe(Cluster.mock.calls[1][0].offsets)
+
+    expect(createProducer.mock.calls[0][0].cluster).toBe(Cluster.mock.instances[0])
+    expect(createConsumer.mock.calls[0][0].cluster).toBe(Cluster.mock.instances[1])
+  })
+
   it('passes options to the producer', () => {
     const client = new Client({ brokers: [] })
     const options = {

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -149,7 +149,7 @@ module.exports = ({
       /**
        * Abort the ongoing transaction.
        *
-       * @throws {KafkaJSNonRetriableError} If non-transactional
+       * @throws {KafkaJSNonRetriableError} If transaction has ended
        */
       abort: transactionGuard(async () => {
         await transactionalEosManager.abort()
@@ -158,12 +158,20 @@ module.exports = ({
       /**
        * Commit the ongoing transaction.
        *
-       * @throws {KafkaJSNonRetriableError} If non-transactional
+       * @throws {KafkaJSNonRetriableError} If transaction has ended
        */
       commit: transactionGuard(async () => {
         await transactionalEosManager.commit()
         transactionDidEnd = true
       }),
+      /**
+       * Sends a list of specified offsets to the consumer group coordinator, and also marks those offsets as part of the current transaction.
+       *
+       * @throws {KafkaJSNonRetriableError} If transaction has ended
+       */
+      sendOffsets: transactionGuard(({ consumerGroupId, offsets }) =>
+        transactionalEosManager.sendOffsets({ consumerGroupId, topics: offsets.topics })
+      ),
       isActive,
     }
   }

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -169,9 +169,10 @@ module.exports = ({
        *
        * @throws {KafkaJSNonRetriableError} If transaction has ended
        */
-      sendOffsets: transactionGuard(({ consumerGroupId, offsets }) => {
+      sendOffsets: transactionGuard(async ({ consumerGroupId, offsets }) => {
         const { topics } = offsets
-        transactionalEosManager.sendOffsets({ consumerGroupId, topics })
+
+        await transactionalEosManager.sendOffsets({ consumerGroupId, topics })
 
         for (const topicOffsets of topics) {
           const { topic, partitions } = topicOffsets

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -169,9 +169,7 @@ module.exports = ({
        *
        * @throws {KafkaJSNonRetriableError} If transaction has ended
        */
-      sendOffsets: transactionGuard(async ({ consumerGroupId, offsets }) => {
-        const { topics } = offsets
-
+      sendOffsets: transactionGuard(async ({ consumerGroupId, topics }) => {
         await transactionalEosManager.sendOffsets({ consumerGroupId, topics })
 
         for (const topicOffsets of topics) {

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -678,29 +678,27 @@ describe('Producer', () => {
       await producer.connect()
 
       const consumerGroupId = `consumer-group-id-${secureRandom()}`
-      const offsets = {
-        topics: [
-          {
-            topic: topicName,
-            partitions: [
-              {
-                partition: 0,
-                offset: '5',
-              },
-              {
-                partition: 1,
-                offset: '10',
-              },
-            ],
-          },
-        ],
-      }
+      const topics = [
+        {
+          topic: topicName,
+          partitions: [
+            {
+              partition: 0,
+              offset: '5',
+            },
+            {
+              partition: 1,
+              offset: '10',
+            },
+          ],
+        },
+      ]
       const txn = await producer.transaction()
-      await txn.sendOffsets({ consumerGroupId, offsets })
+      await txn.sendOffsets({ consumerGroupId, topics })
 
       expect(sendOffsetsSpy).toHaveBeenCalledWith({
         consumerGroupId,
-        topics: offsets.topics,
+        topics,
       })
       expect(markOffsetAsCommittedSpy).toHaveBeenCalledTimes(2)
       expect(markOffsetAsCommittedSpy.mock.calls[0][0]).toEqual({
@@ -721,7 +719,7 @@ describe('Producer', () => {
       const coordinator = await cluster.findGroupCoordinator({ groupId: consumerGroupId })
       const { responses: consumerOffsets } = await coordinator.offsetFetch({
         groupId: consumerGroupId,
-        topics: offsets.topics,
+        topics,
       })
 
       expect(consumerOffsets).toEqual([

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -665,6 +665,8 @@ describe('Producer', () => {
         })
       )
 
+      const markOffsetAsCommittedSpy = jest.spyOn(cluster, 'markOffsetAsCommitted')
+
       await createTopic({ topic: topicName })
 
       producer = createProducer({
@@ -685,6 +687,10 @@ describe('Producer', () => {
                 partition: 0,
                 offset: '1',
               },
+              {
+                partition: 1,
+                offset: '2',
+              },
             ],
           },
         ],
@@ -694,6 +700,19 @@ describe('Producer', () => {
       expect(sendOffsetsSpy).toHaveBeenCalledWith({
         consumerGroupId,
         topics: offsets.topics,
+      })
+      expect(markOffsetAsCommittedSpy).toHaveBeenCalledTimes(2)
+      expect(markOffsetAsCommittedSpy.mock.calls[0][0]).toEqual({
+        groupId: consumerGroupId,
+        topic: topicName,
+        partition: 0,
+        offset: '1',
+      })
+      expect(markOffsetAsCommittedSpy.mock.calls[1][0]).toEqual({
+        groupId: consumerGroupId,
+        topic: topicName,
+        partition: 1,
+        offset: '2',
       })
     })
   })

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -105,7 +105,7 @@ const createModPartitioner = () => ({ partitionMetadata, message }) => {
   return ((key || 0) % 3) % numPartitions
 }
 
-const testWaitFor = async (fn, opts = {}) => waitFor(fn, { ...opts, ignoreTimeout: true })
+const testWaitFor = async (fn, opts = {}) => waitFor(fn, { ignoreTimeout: true, ...opts })
 
 const retryProtocol = (errorType, fn) =>
   waitFor(

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -190,16 +190,20 @@ const unsupportedVersionResponse = () => Buffer.from({ type: 'Buffer', data: [0,
 const unsupportedVersionResponseWithTimeout = () =>
   Buffer.from({ type: 'Buffer', data: [0, 0, 0, 0, 0, 35] })
 
-const generateMessages = ({ prefix = 'generated', number = 100 }) =>
-  Array(number)
+const generateMessages = options => {
+  const { prefix, number = 100 } = options || {}
+  const prefixOrEmpty = prefix ? `-${prefix}` : ''
+
+  return Array(number)
     .fill()
     .map((v, i) => {
       const value = secureRandom()
       return {
-        key: `key-${prefix}-${i}-${value}`,
-        value: `value-${prefix}-${i}-${value}`,
+        key: `key${prefixOrEmpty}-${i}-${value}`,
+        value: `value${prefixOrEmpty}-${i}-${value}`,
       }
     })
+}
 
 module.exports = {
   secureRandom,


### PR DESCRIPTION
### Changes

**Features**
- New transactional method `sendOffsets`
- New consumer `run` option `autoCommit: boolean`
- New `eachBatch` callback option `uncommittedOffsets`

### Summary

This PR implements a new transactional method, `sendOffsets`, which allows us to conditionally commit offsets depending on the outcome of a transaction. Additionally we allow users to disable auto-committing of offsets, so that they may instead manually provide offsets to the `sendOffsets` method. We provide the a new method, `uncommittedOffsets`, in the `eachBatch` options, so that users may access offsets marked as resolved but not committed.

This review is somewhat preemptive, as I would like some feedback on the API changes thusfar, ~~and additionally suspect **there may be a race-condition in my test** "does not respect offsets sent by an aborted transaction".~~ **EDIT** I was incorrectly providing the autoCommit option to the consumer (which did cause a race condition).

If we agree on the interface for accessing uncommitted offsets, I think we should additionally add a new method to the consumer for committing arbitrary offsets, so that users have a way to manually commit offsets outside of transactions. I think that should be implemented in a separate ticket however.

A problem with the implementation as it exists is that the `sendOffsets` method will not communicate the result back to the offset manager, so resolved offsets will never be marked as committed. AFAIK the only real impact would be that we commit the same offsets unnecessarily, but it is misleading.