### PR TITLE
Add network instrumentation events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,6 +1249,34 @@ List of available events:
 
 * admin.events.DISCONNECT
 
+* admin.events.REQUEST
+  payload: {
+    `broker`,
+    `clientId`,
+    `correlationId`,
+    `size`,
+    `createdAt`,
+    `sentAt`,
+    `pendingDuration`,
+    `duration`,
+    `apiName`,
+    `apiKey`,
+    `apiVersion`
+  }
+
+* admin.events.REQUEST_TIMEOUT
+  payload: {
+    `broker`,
+    `clientId`,
+    `correlationId`,
+    `createdAt`,
+    `sentAt`,
+    `pendingDuration`,
+    `apiName`,
+    `apiKey`,
+    `apiVersion`
+  }
+
 ## <a name="custom-logging"></a> Custom logging
 
 The logger is customized using log creators. A log creator is a function which receives a log level and returns a log function. The log function receives namespace, level, label, and log.

--- a/README.md
+++ b/README.md
@@ -1181,11 +1181,67 @@ List of available events:
 * consumer.events.CRASH
   payload: {`error`, `groupId`}
 
+* consumer.events.REQUEST
+  payload: {
+    `broker`,
+    `clientId`,
+    `correlationId`,
+    `size`,
+    `createdAt`,
+    `sentAt`,
+    `pendingDuration`,
+    `duration`,
+    `apiName`,
+    `apiKey`,
+    `apiVersion`
+  }
+
+* consumer.events.REQUEST_TIMEOUT
+  payload: {
+    `broker`,
+    `clientId`,
+    `correlationId`,
+    `createdAt`,
+    `sentAt`,
+    `pendingDuration`,
+    `apiName`,
+    `apiKey`,
+    `apiVersion`
+  }
+
 ### <a name="instrumentation-producer"></a> Producer
 
 * producer.events.CONNECT
 
 * producer.events.DISCONNECT
+
+* producer.events.REQUEST
+  payload: {
+    `broker`,
+    `clientId`,
+    `correlationId`,
+    `size`,
+    `createdAt`,
+    `sentAt`,
+    `pendingDuration`,
+    `duration`,
+    `apiName`,
+    `apiKey`,
+    `apiVersion`
+  }
+
+* producer.events.REQUEST_TIMEOUT
+  payload: {
+    `broker`,
+    `clientId`,
+    `correlationId`,
+    `createdAt`,
+    `sentAt`,
+    `pendingDuration`,
+    `apiName`,
+    `apiKey`,
+    `apiVersion`
+  }
 
 ### <a name="instrumentation-admin"></a> Admin
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ KafkaJS is battle-tested and ready for production.
   - [SSL](#configuration-ssl)
   - [SASL](#configuration-sasl)
   - [Connection timeout](#configuration-connection-timeout)
+  - [Request timeout](#configuration-request-timeout)
   - [Default retry](#configuration-default-retry)
   - [Logging](#configuration-logging)
 - [Producing messages](#producing-messages)
@@ -137,6 +138,18 @@ new Kafka({
   clientId: 'my-app',
   brokers: ['kafka1:9092', 'kafka2:9092'],
   connectionTimeout: 3000
+})
+```
+
+### <a name="configuration-request-timeout"></a> Request Timeout
+
+Time in milliseconds to wait for a successful request. The default value is: `30000`.
+
+```javascript
+new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  requestTimeout: 25000
 })
 ```
 

--- a/src/admin/index.spec.js
+++ b/src/admin/index.spec.js
@@ -1,5 +1,6 @@
 const createAdmin = require('./index')
-const { createCluster, newLogger } = require('testHelpers')
+const InstrumentationEventEmitter = require('../instrumentation/emitter')
+const { createCluster, newLogger, secureRandom } = require('testHelpers')
 
 describe('Admin', () => {
   it('gives access to its logger', () => {
@@ -16,6 +17,7 @@ describe('Admin', () => {
       cluster: createCluster(),
       logger: newLogger(),
     })
+
     const connectListener = jest.fn().mockName('connect')
     const disconnectListener = jest.fn().mockName('disconnect')
     admin.on(admin.events.CONNECT, connectListener)
@@ -26,6 +28,82 @@ describe('Admin', () => {
 
     await admin.disconnect()
     expect(disconnectListener).toHaveBeenCalled()
+  })
+
+  test('emits the request event', async () => {
+    const emitter = new InstrumentationEventEmitter()
+    const admin = createAdmin({
+      cluster: createCluster({ instrumentationEmitter: emitter }),
+      logger: newLogger(),
+      instrumentationEmitter: emitter,
+    })
+
+    const requestListener = jest.fn().mockName('request')
+    admin.on(admin.events.REQUEST, requestListener)
+
+    await admin.connect()
+    expect(requestListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'admin.network.request',
+      payload: {
+        apiKey: expect.any(Number),
+        apiName: 'ApiVersions',
+        apiVersion: expect.any(Number),
+        broker: expect.any(String),
+        clientId: expect.any(String),
+        correlationId: expect.any(Number),
+        createdAt: expect.any(Number),
+        duration: expect.any(Number),
+        pendingDuration: expect.any(Number),
+        sentAt: expect.any(Number),
+        size: expect.any(Number),
+      },
+    })
+  })
+
+  test('emits the request timeout event', async () => {
+    const emitter = new InstrumentationEventEmitter()
+    const cluster = createCluster({
+      requestTimeout: 1,
+      instrumentationEmitter: emitter,
+    })
+
+    const admin = createAdmin({
+      cluster,
+      logger: newLogger(),
+      instrumentationEmitter: emitter,
+    })
+
+    const requestListener = jest.fn().mockName('request_timeout')
+    admin.on(admin.events.REQUEST_TIMEOUT, requestListener)
+
+    await admin
+      .connect()
+      .then(() =>
+        admin.createTopics({
+          waitForLeaders: false,
+          topics: [{ topic: `test-topic-${secureRandom()}` }],
+        })
+      )
+      .catch(e => e)
+
+    expect(requestListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'admin.network.request_timeout',
+      payload: {
+        apiKey: expect.any(Number),
+        apiName: expect.any(String),
+        apiVersion: expect.any(Number),
+        broker: expect.any(String),
+        clientId: expect.any(String),
+        correlationId: expect.any(Number),
+        createdAt: expect.any(Number),
+        pendingDuration: expect.any(Number),
+        sentAt: expect.any(Number),
+      },
+    })
   })
 
   test('on throws an error when provided with an invalid event name', () => {

--- a/src/admin/instrumentationEvents.js
+++ b/src/admin/instrumentationEvents.js
@@ -1,5 +1,5 @@
 const swapObject = require('../utils/swapObject')
-const networkEvents = require('../network/InstrumentationEvents')
+const networkEvents = require('../network/instrumentationEvents')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const adminType = InstrumentationEventType('admin')
 

--- a/src/admin/instrumentationEvents.js
+++ b/src/admin/instrumentationEvents.js
@@ -1,7 +1,26 @@
+const swapObject = require('../utils/swapObject')
+const networkEvents = require('../network/InstrumentationEvents')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const adminType = InstrumentationEventType('admin')
 
-module.exports = {
+const events = {
   CONNECT: adminType('connect'),
   DISCONNECT: adminType('disconnect'),
+  REQUEST: adminType(networkEvents.NETWORK_REQUEST),
+  REQUEST_TIMEOUT: adminType(networkEvents.NETWORK_REQUEST_TIMEOUT),
+}
+
+const wrappedEvents = {
+  [events.REQUEST]: networkEvents.NETWORK_REQUEST,
+  [events.REQUEST_TIMEOUT]: networkEvents.NETWORK_REQUEST_TIMEOUT,
+}
+
+const reversedWrappedEvents = swapObject(wrappedEvents)
+const unwrap = eventName => wrappedEvents[eventName] || eventName
+const wrap = eventName => reversedWrappedEvents[eventName] || eventName
+
+module.exports = {
+  events,
+  wrap,
+  unwrap,
 }

--- a/src/cluster/connectionBuilder.js
+++ b/src/cluster/connectionBuilder.js
@@ -5,10 +5,12 @@ module.exports = ({
   ssl,
   sasl,
   clientId,
+  requestTimeout,
   connectionTimeout,
   maxInFlightRequests,
   retry,
   logger,
+  instrumentationEmitter = null,
 }) => {
   const size = brokers.length
   let index = 0
@@ -30,7 +32,9 @@ module.exports = ({
         sasl,
         clientId,
         connectionTimeout,
+        requestTimeout,
         maxInFlightRequests,
+        instrumentationEmitter,
         retry,
         logger,
       })

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -26,11 +26,14 @@ const mergeTopics = (obj, { topic, partitions }) => ({
  * @param {string} clientId
  * @param {number} connectionTimeout - in milliseconds
  * @param {number} authenticationTimeout - in milliseconds
+ * @param {number} requestTimeout - in milliseconds
  * @param {number} metadataMaxAge - in milliseconds
  * @param {boolean} allowAutoTopicCreation
  * @param {number} maxInFlightRequests
+ * @param {IsolationLevel} isolationLevel
  * @param {Object} retry
- * @param {Object} logger
+ * @param {Logger} logger
+ * @param {InstrumentationEventEmitter} [instrumentationEmitter=null]
  */
 module.exports = class Cluster {
   constructor({
@@ -41,8 +44,10 @@ module.exports = class Cluster {
     clientId,
     connectionTimeout,
     authenticationTimeout,
+    requestTimeout,
     metadataMaxAge,
     retry,
+    instrumentationEmitter = null,
     allowExperimentalV011,
     allowAutoTopicCreation,
     maxInFlightRequests,
@@ -53,11 +58,13 @@ module.exports = class Cluster {
     this.retrier = createRetry({ ...retry })
     this.connectionBuilder = connectionBuilder({
       logger: rootLogger,
+      instrumentationEmitter,
       brokers,
       ssl,
       sasl,
       clientId,
       connectionTimeout,
+      requestTimeout,
       maxInFlightRequests,
       retry,
     })

--- a/src/consumer/__tests__/instrumentationEvents.spec.js
+++ b/src/consumer/__tests__/instrumentationEvents.spec.js
@@ -337,7 +337,7 @@ describe('Consumer > Instrumentation Events', () => {
       type: 'consumer.network.request_timeout',
       payload: {
         apiKey: 18,
-        apiName: 'ApiVersions',
+        apiName: expect.any(String),
         apiVersion: expect.any(Number),
         broker: expect.any(String),
         clientId: expect.any(String),

--- a/src/consumer/__tests__/instrumentationEvents.spec.js
+++ b/src/consumer/__tests__/instrumentationEvents.spec.js
@@ -326,7 +326,11 @@ describe('Consumer > Instrumentation Events', () => {
     const requestListener = jest.fn().mockName('request')
     consumer.on(consumer.events.REQUEST_TIMEOUT, requestListener)
 
-    await consumer.connect().catch(e => e)
+    await consumer
+      .connect()
+      .then(() => consumer.run({ eachMessage: () => true }))
+      .catch(e => e)
+
     expect(requestListener).toHaveBeenCalledWith({
       id: expect.any(Number),
       timestamp: expect.any(Number),

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -273,14 +273,15 @@ module.exports = class ConsumerGroup {
   async heartbeat({ interval }) {
     const { groupId, generationId, memberId } = this
     const now = Date.now()
-    if (now >= this.lastRequest + interval) {
+
+    if (memberId && now >= this.lastRequest + interval) {
       const payload = {
         groupId,
         memberId,
         groupGenerationId: generationId,
       }
-      await this.coordinator.heartbeat(payload)
 
+      await this.coordinator.heartbeat(payload)
       this.instrumentationEmitter.emit(HEARTBEAT, payload)
       this.lastRequest = Date.now()
     }

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -5,7 +5,9 @@ const OffsetManager = require('./offsetManager')
 const Batch = require('./batch')
 const SeekOffsets = require('./seekOffsets')
 const SubscriptionState = require('./subscriptionState')
-const { HEARTBEAT } = require('./instrumentationEvents')
+const {
+  events: { HEARTBEAT },
+} = require('./instrumentationEvents')
 const { MemberAssignment } = require('./assignerProtocol')
 const {
   KafkaJSError,

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -33,13 +33,12 @@ module.exports = ({
   minBytes = 1,
   maxBytes = 10485760, // 10MB
   maxWaitTimeInMs = 5000,
-  retry = {
-    retries: 10,
-  },
+  retry = { retries: 10 },
   isolationLevel = ISOLATION_LEVEL.READ_COMMITTED,
+  instrumentationEmitter: rootInstrumentationEmitter,
 }) => {
   const logger = rootLogger.namespace('Consumer')
-  const instrumentationEmitter = new InstrumentationEventEmitter()
+  const instrumentationEmitter = rootInstrumentationEmitter || new InstrumentationEventEmitter()
   const assigners = partitionAssigners.map(createAssigner =>
     createAssigner({ groupId, logger, cluster })
   )
@@ -208,8 +207,8 @@ module.exports = ({
 
   /**
    * @param {string} eventName
-   * @param {Function} listener
-   * @return {Function}
+   * @param {AsyncFunction} listener
+   * @return {Function} removeListener
    */
   const on = (eventName, listener) => {
     if (!eventNames.includes(eventName)) {

--- a/src/consumer/instrumentationEvents.js
+++ b/src/consumer/instrumentationEvents.js
@@ -1,7 +1,9 @@
+const swapObject = require('../utils/swapObject')
 const InstrumentationEventType = require('../instrumentation/eventType')
+const networkEvents = require('../network/InstrumentationEvents')
 const consumerType = InstrumentationEventType('consumer')
 
-module.exports = {
+const events = {
   HEARTBEAT: consumerType('heartbeat'),
   COMMIT_OFFSETS: consumerType('commit_offsets'),
   GROUP_JOIN: consumerType('group_join'),
@@ -12,4 +14,21 @@ module.exports = {
   DISCONNECT: consumerType('disconnect'),
   STOP: consumerType('stop'),
   CRASH: consumerType('crash'),
+  REQUEST: consumerType(networkEvents.NETWORK_REQUEST),
+  REQUEST_TIMEOUT: consumerType(networkEvents.NETWORK_REQUEST_TIMEOUT),
+}
+
+const wrappedEvents = {
+  [events.REQUEST]: networkEvents.NETWORK_REQUEST,
+  [events.REQUEST_TIMEOUT]: networkEvents.NETWORK_REQUEST_TIMEOUT,
+}
+
+const reversedWrappedEvents = swapObject(wrappedEvents)
+const unwrap = eventName => wrappedEvents[eventName] || eventName
+const wrap = eventName => reversedWrappedEvents[eventName] || eventName
+
+module.exports = {
+  events,
+  wrap,
+  unwrap,
 }

--- a/src/consumer/instrumentationEvents.js
+++ b/src/consumer/instrumentationEvents.js
@@ -1,6 +1,6 @@
 const swapObject = require('../utils/swapObject')
 const InstrumentationEventType = require('../instrumentation/eventType')
-const networkEvents = require('../network/InstrumentationEvents')
+const networkEvents = require('../network/instrumentationEvents')
 const consumerType = InstrumentationEventType('consumer')
 
 const events = {

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -2,7 +2,9 @@ const Long = require('long')
 const flatten = require('../../utils/flatten')
 const isInvalidOffset = require('./isInvalidOffset')
 const initializeConsumerOffsets = require('./initializeConsumerOffsets')
-const { COMMIT_OFFSETS } = require('../instrumentationEvents')
+const {
+  events: { COMMIT_OFFSETS },
+} = require('../instrumentationEvents')
 
 const { keys, assign } = Object
 const indexTopics = topics => topics.reduce((obj, topic) => assign(obj, { [topic]: {} }), {})

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -1,10 +1,7 @@
 const createRetry = require('../retry')
 const { KafkaJSError } = require('../errors')
 const {
-  GROUP_JOIN,
-  FETCH,
-  START_BATCH_PROCESS,
-  END_BATCH_PROCESS,
+  events: { GROUP_JOIN, FETCH, START_BATCH_PROCESS, END_BATCH_PROCESS },
 } = require('./instrumentationEvents')
 
 const isTestMode = process.env.NODE_ENV === 'test'

--- a/src/index.js
+++ b/src/index.js
@@ -142,10 +142,16 @@ module.exports = class Client {
    * @public
    */
   admin({ retry } = {}) {
-    const cluster = this[PRIVATE.CREATE_CLUSTER]({ allowAutoTopicCreation: false })
+    const instrumentationEmitter = new InstrumentationEventEmitter()
+    const cluster = this[PRIVATE.CREATE_CLUSTER]({
+      allowAutoTopicCreation: false,
+      instrumentationEmitter,
+    })
+
     return createAdmin({
       retry: { ...cluster.retry, retry },
       logger: this[PRIVATE.LOGGER],
+      instrumentationEmitter,
       cluster,
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -70,10 +70,12 @@ module.exports = class Client {
     transactionTimeout,
     maxInFlightRequests,
   } = {}) {
+    const instrumentationEmitter = new InstrumentationEventEmitter()
     const cluster = this[PRIVATE.CREATE_CLUSTER]({
       metadataMaxAge,
       allowAutoTopicCreation,
       maxInFlightRequests,
+      instrumentationEmitter,
     })
 
     return createProducer({
@@ -84,6 +86,7 @@ module.exports = class Client {
       idempotent,
       transactionalId,
       transactionTimeout,
+      instrumentationEmitter,
     })
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const {
   LEVELS: { INFO },
 } = require('./loggers')
 
+const InstrumentationEventEmitter = require('./instrumentation/emitter')
 const LoggerConsole = require('./loggers/console')
 const Cluster = require('./cluster')
 const createProducer = require('./producer')
@@ -23,6 +24,7 @@ module.exports = class Client {
     clientId,
     connectionTimeout,
     authenticationTimeout,
+    requestTimeout,
     retry,
     logLevel = INFO,
     logCreator = LoggerConsole,
@@ -33,6 +35,7 @@ module.exports = class Client {
       metadataMaxAge = 300000,
       allowAutoTopicCreation = true,
       maxInFlightRequests = null,
+      instrumentationEmitter = null,
       isolationLevel,
     }) =>
       new Cluster({
@@ -43,7 +46,9 @@ module.exports = class Client {
         clientId,
         connectionTimeout,
         authenticationTimeout,
+        requestTimeout,
         metadataMaxAge,
+        instrumentationEmitter,
         retry,
         allowAutoTopicCreation,
         allowExperimentalV011,
@@ -104,11 +109,13 @@ module.exports = class Client {
       ? ISOLATION_LEVEL.READ_UNCOMMITTED
       : ISOLATION_LEVEL.READ_COMMITTED
 
+    const instrumentationEmitter = new InstrumentationEventEmitter()
     const cluster = this[PRIVATE.CREATE_CLUSTER]({
       metadataMaxAge,
       allowAutoTopicCreation,
       maxInFlightRequests,
       isolationLevel,
+      instrumentationEmitter,
     })
 
     return createConsumer({
@@ -124,6 +131,7 @@ module.exports = class Client {
       maxBytes,
       maxWaitTimeInMs,
       isolationLevel,
+      instrumentationEmitter,
     })
   }
 

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -23,6 +23,7 @@ describe('Client', () => {
       idempotent: true,
       transactionalId: 'transactional-id',
       transactionTimeout: 1,
+      instrumentationEmitter: expect.any(Object),
     }
     client.producer(options)
 

--- a/src/instrumentation/emitter.js
+++ b/src/instrumentation/emitter.js
@@ -2,11 +2,18 @@ const EventEmitter = require('events')
 const InstrumentationEvent = require('./event')
 const { KafkaJSError } = require('../errors')
 
+/**
+ * @typedef InstrumentationEventEmitter
+ */
 module.exports = class InstrumentationEventEmitter {
   constructor() {
     this.emitter = new EventEmitter()
   }
 
+  /**
+   * @param {string} eventName
+   * @param {Object} payload
+   */
   emit(eventName, payload) {
     if (!eventName) {
       throw new KafkaJSError('Invalid event name', { retriable: false })
@@ -16,6 +23,11 @@ module.exports = class InstrumentationEventEmitter {
     this.emitter.emit(eventName, event)
   }
 
+  /**
+   * @param {string} eventName
+   * @param {Function} listener
+   * @returns {Function} removeListener
+   */
   addListener(eventName, listener) {
     this.emitter.addListener(eventName, listener)
     return () => this.emitter.removeListener(eventName, listener)

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -29,6 +29,7 @@ const requestInfo = ({ apiName, apiKey, apiVersion }) =>
  *                              retry module inside network
  * @param {number} [maxInFlightRequests=null] The maximum number of unacknowledged requests on a connection before
  *                                            enqueuing
+ * @param {InstrumentationEventEmitter} [instrumentationEmitter=null]
  */
 module.exports = class Connection {
   constructor({
@@ -42,6 +43,7 @@ module.exports = class Connection {
     connectionTimeout = 1000,
     requestTimeout = 30000,
     maxInFlightRequests = null,
+    instrumentationEmitter = null,
     retry = {},
   }) {
     this.host = host
@@ -63,6 +65,7 @@ module.exports = class Connection {
     this.connected = false
     this.correlationId = 0
     this.requestQueue = new RequestQueue({
+      instrumentationEmitter,
       maxInFlightRequests,
       requestTimeout,
       clientId,

--- a/src/network/instrumentationEvents.js
+++ b/src/network/instrumentationEvents.js
@@ -1,0 +1,7 @@
+const InstrumentationEventType = require('../instrumentation/eventType')
+const eventType = InstrumentationEventType('network')
+
+module.exports = {
+  NETWORK_REQUEST: eventType('request'),
+  NETWORK_REQUEST_TIMEOUT: eventType('request_timeout'),
+}

--- a/src/network/instrumentationEvents.js
+++ b/src/network/instrumentationEvents.js
@@ -4,4 +4,5 @@ const eventType = InstrumentationEventType('network')
 module.exports = {
   NETWORK_REQUEST: eventType('request'),
   NETWORK_REQUEST_TIMEOUT: eventType('request_timeout'),
+  NETWORK_REQUEST_QUEUE_SIZE: eventType('request_queue_size'),
 }

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -59,8 +59,8 @@ module.exports = ({
 
   /**
    * @param {string} eventName
-   * @param {Function} listener
-   * @return {Function}
+   * @param {AsyncFunction} listener
+   * @return {Function} removeListener
    */
   const on = (eventName, listener) => {
     if (!eventNames.includes(eventName)) {

--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -17,6 +17,7 @@ jest.mock('../retry', () => {
   return spy
 })
 
+const InstrumentationEventEmitter = require('../instrumentation/emitter')
 const createProducer = require('./index')
 const {
   secureRandom,
@@ -213,6 +214,83 @@ describe('Producer', () => {
 
     await producer.disconnect()
     expect(disconnectListener).toHaveBeenCalled()
+  })
+
+  test('emits the request event', async () => {
+    const emitter = new InstrumentationEventEmitter()
+    producer = createProducer({
+      logger: newLogger(),
+      cluster: createCluster({ instrumentationEmitter: emitter }),
+      instrumentationEmitter: emitter,
+    })
+
+    const requestListener = jest.fn().mockName('request')
+    producer.on(producer.events.REQUEST, requestListener)
+
+    await producer.connect()
+    expect(requestListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'producer.network.request',
+      payload: {
+        apiKey: expect.any(Number),
+        apiName: 'ApiVersions',
+        apiVersion: expect.any(Number),
+        broker: expect.any(String),
+        clientId: expect.any(String),
+        correlationId: expect.any(Number),
+        createdAt: expect.any(Number),
+        duration: expect.any(Number),
+        pendingDuration: expect.any(Number),
+        sentAt: expect.any(Number),
+        size: expect.any(Number),
+      },
+    })
+  })
+
+  test('emits the request timeout event', async () => {
+    const emitter = new InstrumentationEventEmitter()
+    const cluster = createCluster({
+      requestTimeout: 1,
+      instrumentationEmitter: emitter,
+    })
+
+    producer = createProducer({
+      cluster,
+      logger: newLogger(),
+      instrumentationEmitter: emitter,
+    })
+
+    const requestListener = jest.fn().mockName('request_timeout')
+    producer.on(producer.events.REQUEST_TIMEOUT, requestListener)
+
+    await producer
+      .connect()
+      .then(() =>
+        producer.send({
+          acks: -1,
+          topic: topicName,
+          messages: [{ key: 'key-0', value: 'value-0' }],
+        })
+      )
+      .catch(e => e)
+
+    expect(requestListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'producer.network.request_timeout',
+      payload: {
+        apiKey: expect.any(Number),
+        apiName: expect.any(String),
+        apiVersion: expect.any(Number),
+        broker: expect.any(String),
+        clientId: expect.any(String),
+        correlationId: expect.any(Number),
+        createdAt: expect.any(Number),
+        pendingDuration: expect.any(Number),
+        sentAt: expect.any(Number),
+      },
+    })
   })
 
   describe('when acks=0', () => {

--- a/src/producer/instrumentationEvents.js
+++ b/src/producer/instrumentationEvents.js
@@ -1,7 +1,26 @@
+const swapObject = require('../utils/swapObject')
+const networkEvents = require('../network/InstrumentationEvents')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const producerType = InstrumentationEventType('producer')
 
-module.exports = {
+const events = {
   CONNECT: producerType('connect'),
   DISCONNECT: producerType('disconnect'),
+  REQUEST: producerType(networkEvents.NETWORK_REQUEST),
+  REQUEST_TIMEOUT: producerType(networkEvents.NETWORK_REQUEST_TIMEOUT),
+}
+
+const wrappedEvents = {
+  [events.REQUEST]: networkEvents.NETWORK_REQUEST,
+  [events.REQUEST_TIMEOUT]: networkEvents.NETWORK_REQUEST_TIMEOUT,
+}
+
+const reversedWrappedEvents = swapObject(wrappedEvents)
+const unwrap = eventName => wrappedEvents[eventName] || eventName
+const wrap = eventName => reversedWrappedEvents[eventName] || eventName
+
+module.exports = {
+  events,
+  wrap,
+  unwrap,
 }

--- a/src/producer/instrumentationEvents.js
+++ b/src/producer/instrumentationEvents.js
@@ -1,5 +1,5 @@
 const swapObject = require('../utils/swapObject')
-const networkEvents = require('../network/InstrumentationEvents')
+const networkEvents = require('../network/instrumentationEvents')
 const InstrumentationEventType = require('../instrumentation/eventType')
 const producerType = InstrumentationEventType('producer')
 

--- a/src/protocol/isolationLevel.js
+++ b/src/protocol/isolationLevel.js
@@ -1,3 +1,8 @@
+/**
+ * Enum for isolation levels
+ * @readonly
+ * @enum {IsolationLevel}
+ */
 module.exports = {
   // Makes all records visible
   READ_UNCOMMITTED: 0,

--- a/src/utils/swapObject.js
+++ b/src/utils/swapObject.js
@@ -1,0 +1,3 @@
+const { keys } = Object
+module.exports = object =>
+  keys(object).reduce((result, key) => ({ ...result, [object[key]]: key }), {})

--- a/src/utils/swapObject.spec.js
+++ b/src/utils/swapObject.spec.js
@@ -1,0 +1,17 @@
+const swapObject = require('./swapObject')
+
+describe('Utils > swapObject', () => {
+  it('swaps keys with values', () => {
+    const obj = {
+      a1: 'a2',
+      b1: 'b2',
+      c1: 'c2',
+    }
+
+    expect(swapObject(obj)).toEqual({
+      a2: 'a1',
+      b2: 'b1',
+      c2: 'c1',
+    })
+  })
+})


### PR DESCRIPTION
This PR makes the request timeout configurable, and it introduces network instrumentation events to all clients (producers, consumers and admin). We want to write an easy to use prometheus/statsd/datadog plugin that collects metrics directly from KafkaJS, and we want to use the instrumentation events for that. Issue #175 describes what the official client does but after some research; we concluded that it was too much work and after talking to some people using the java client they mentioned that they don't use the built-in features and have separate integrations with the same providers.

I want to measure the impact of the request queue before defining a default value and making it enabled by default.