### PR TITLE
Feature: Commit arbitrary offset

### DIFF
--- a/src/consumer/__tests__/consumerGroup.spec.js
+++ b/src/consumer/__tests__/consumerGroup.spec.js
@@ -21,4 +21,15 @@ describe('ConsumerGroup', () => {
       expect(consumerGroup.offsetManager.uncommittedOffsets).toHaveBeenCalled()
     })
   })
+
+  describe('commitOffsets', () => {
+    it("calls the offset manager's commitOffsets", async () => {
+      consumerGroup.offsetManager = { commitOffsets: jest.fn(() => Promise.resolve()) }
+
+      const offsets = { topics: [{ partitions: [{ offset: '0', partition: 0 }] }] }
+      await consumerGroup.commitOffsets(offsets)
+      expect(consumerGroup.offsetManager.commitOffsets).toHaveBeenCalledTimes(1)
+      expect(consumerGroup.offsetManager.commitOffsets).toHaveBeenCalledWith(offsets)
+    })
+  })
 })

--- a/src/consumer/__tests__/runner.spec.js
+++ b/src/consumer/__tests__/runner.spec.js
@@ -87,14 +87,11 @@ describe('Consumer > Runner', () => {
       await runner.start()
       await runner.fetch() // Manually fetch for test
 
-      expect(eachBatch).toHaveBeenCalledWith({
-        batch: expect.any(Object),
-        commitOffsetsIfNecessary: expect.any(Function),
-        heartbeat: expect.any(Function),
-        isRunning: expect.any(Function),
-        resolveOffset: expect.any(Function),
-        uncommittedOffsets: expect.any(Function),
-      })
+      expect(eachBatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commitOffsetsIfNecessary: expect.any(Function),
+        })
+      )
 
       const { commitOffsetsIfNecessary } = eachBatch.mock.calls[0][0] // Access the callback
 

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -260,8 +260,8 @@ module.exports = class ConsumerGroup {
     return this.subscriptionState.paused()
   }
 
-  async commitOffsetsIfNecessary() {
-    await this.offsetManager.commitOffsetsIfNecessary()
+  async commitOffsetsIfNecessary(offsets) {
+    await this.offsetManager.commitOffsetsIfNecessary(offsets)
   }
 
   async commitOffsets() {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -260,12 +260,12 @@ module.exports = class ConsumerGroup {
     return this.subscriptionState.paused()
   }
 
-  async commitOffsetsIfNecessary(offsets) {
-    await this.offsetManager.commitOffsetsIfNecessary(offsets)
+  async commitOffsetsIfNecessary() {
+    await this.offsetManager.commitOffsetsIfNecessary()
   }
 
-  async commitOffsets() {
-    await this.offsetManager.commitOffsets()
+  async commitOffsets(offsets) {
+    await this.offsetManager.commitOffsets(offsets)
   }
 
   uncommittedOffsets() {

--- a/src/consumer/offsetManager/__tests__/commitOffsets.spec.js
+++ b/src/consumer/offsetManager/__tests__/commitOffsets.spec.js
@@ -93,4 +93,22 @@ describe('Consumer > OffsetMananger > commitOffsets', () => {
       },
     })
   })
+
+  it('commits any provided offsets', async () => {
+    const offset = Math.random().toString()
+    const offsets = { topics: [{ topic: topic1, partitions: [{ partition: '0', offset }] }] }
+    await offsetManager.commitOffsets(offsets)
+
+    expect(mockCoordinator.offsetCommit).toHaveBeenCalledWith({
+      groupId,
+      memberId,
+      groupGenerationId: generationId,
+      topics: [
+        {
+          topic: topic1,
+          partitions: [{ partition: '0', offset }],
+        },
+      ],
+    })
+  })
 })

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -176,7 +176,7 @@ module.exports = class OffsetManager {
     this.clearOffsets({ topic, partition })
   }
 
-  async commitOffsetsIfNecessary() {
+  async commitOffsetsIfNecessary(offsets) {
     const now = Date.now()
 
     const timeoutReached =
@@ -187,7 +187,7 @@ module.exports = class OffsetManager {
       this.countResolvedOffsets().gte(Long.fromValue(this.autoCommitThreshold))
 
     if (timeoutReached || thresholdReached) {
-      return this.commitOffsets()
+      return this.commitOffsets(offsets)
     }
   }
 
@@ -232,9 +232,9 @@ module.exports = class OffsetManager {
     return { topics: topicsWithPartitionsToCommit }
   }
 
-  async commitOffsets() {
+  async commitOffsets(offsets = {}) {
     const { groupId, generationId, memberId } = this
-    const { topics } = this.uncommittedOffsets()
+    const { topics = this.uncommittedOffsets().topics } = offsets
 
     if (topics.length === 0) {
       this.lastCommit = Date.now()

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -176,7 +176,7 @@ module.exports = class OffsetManager {
     this.clearOffsets({ topic, partition })
   }
 
-  async commitOffsetsIfNecessary(offsets) {
+  async commitOffsetsIfNecessary() {
     const now = Date.now()
 
     const timeoutReached =
@@ -187,7 +187,7 @@ module.exports = class OffsetManager {
       this.countResolvedOffsets().gte(Long.fromValue(this.autoCommitThreshold))
 
     if (timeoutReached || thresholdReached) {
-      return this.commitOffsets(offsets)
+      return this.commitOffsets()
     }
   }
 

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -175,13 +175,15 @@ module.exports = class Runner {
           await this.consumerGroup.heartbeat({ interval: this.heartbeatInterval })
         },
         /**
-         * Note that this method _does not_ heed the "autoCommit" option,
-         * since it will only ever be called manually by the user.
+         * Commit offsets if provided. Otherwise commit most recent resolved offsets
+         * if the autoCommit conditions are met.
          *
-         * @param {OffsetsByTopicPartition} [offsets] Optional. Offsets to commit for given topic partitions. If missing will commit all resolved but uncommitted offsets.
+         * @param {OffsetsByTopicPartition} [offsets] Optional.
          */
         commitOffsetsIfNecessary: async offsets => {
-          await this.consumerGroup.commitOffsetsIfNecessary(offsets)
+          return offsets
+            ? this.consumerGroup.commitOffsets(offsets)
+            : this.consumerGroup.commitOffsetsIfNecessary()
         },
         uncommittedOffsets: () => this.consumerGroup.uncommittedOffsets(),
         isRunning: () => this.running,

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -177,9 +177,11 @@ module.exports = class Runner {
         /**
          * Note that this method _does not_ heed the "autoCommit" option,
          * since it will only ever be called manually by the user.
+         *
+         * @param {OffsetsByTopicPartition} [offsets] Optional. Offsets to commit for given topic partitions. If missing will commit all resolved but uncommitted offsets.
          */
-        commitOffsetsIfNecessary: async () => {
-          await this.consumerGroup.commitOffsetsIfNecessary()
+        commitOffsetsIfNecessary: async offsets => {
+          await this.consumerGroup.commitOffsetsIfNecessary(offsets)
         },
         uncommittedOffsets: () => this.consumerGroup.uncommittedOffsets(),
         isRunning: () => this.running,


### PR DESCRIPTION
Addresses #122 by allowing users to provide offsets to the `commitOffsetsIfNecessary` method in the `eachBatch` callback.

Basically the existing API has no interface for committing an arbitrary offset outside a transaction. The recent transactional work in #232 adds an API for transactions to send offsets as participants in a transaction, but that doesn't help if the user wants to commit an offset without opening a transaction.

I'm open to hearing alternatives for exposing this functionality. This seemed the least disruptive for the existing API.