### PR TITLE
Handle undefined message key when producing with 0.11

### DIFF
--- a/src/producer/index.spec.js
+++ b/src/producer/index.spec.js
@@ -537,6 +537,32 @@ describe('Producer', () => {
       ])
     })
 
+    testIfKafka_0_11('produce messages for Kafka 0.11 without specifying message key', async () => {
+      const cluster = createCluster(
+        Object.assign(connectionOpts(), {
+          allowExperimentalV011: true,
+          createPartitioner: createModPartitioner,
+        })
+      )
+
+      await createTopic({ topic: topicName })
+
+      producer = createProducer({ cluster, logger: newLogger(), idempotent })
+      await producer.connect()
+
+      await expect(
+        producer.send({
+          acks,
+          topic: topicName,
+          messages: [
+            {
+              value: 'test-value',
+            },
+          ],
+        })
+      ).toResolve()
+    })
+
     testIfKafka_0_11('produce messages for Kafka 0.11 with headers', async () => {
       const cluster = createCluster(
         Object.assign(connectionOpts(), {

--- a/src/protocol/encoder.js
+++ b/src/protocol/encoder.js
@@ -45,7 +45,7 @@ module.exports = class Encoder {
   }
 
   static sizeOfVarIntBytes(value) {
-    const size = value === null ? -1 : Buffer.byteLength(value)
+    const size = value == null ? -1 : Buffer.byteLength(value)
 
     if (size < 0) {
       return Encoder.sizeOfVarInt(-1)


### PR DESCRIPTION
Fixes #193 

This was a regression in Produce V3, when encoding an `undefined` key we would try to get the length of it, when it should have had a length of `-1`.