### PR TITLE
changing the node engine to >=8.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Native support for Kafka `0.11` features.
 
 KafkaJS is battle-tested and ready for production.
 
+## Requirements
+
+- Minimum node version: v8.6.0
+
 ## Features
 
 - Producer

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "scram"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating the docs and the package.json to so the minimum node version is displayed to potential users of the module.

Ran into some issues:

```
node_modules/kafkajs/src/index.js:57
          retry: { ...cluster.retry, ...retry },
                   ^^^

    SyntaxError: Unexpected token ...

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:403:17)
      at Object.<anonymous> (node_modules/kafkajs/index.js:1:42)
```

Because the index.js uses object spread syntax without transpiling, users will get this error. Object spread was added to node without a flag in v8.6.0.
https://node.green/#ES2018-features-object-rest-spread-properties