### PR TITLE
Set log level after instantiation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -128,6 +128,28 @@ const kafka = new Kafka({
 })
 ```
 
+To override the log level after instantiation, call `setLogLevel` on the individual logger.
+
+```javascript
+const { Kafka, logLevel } = require('kafkajs')
+
+const kafka = new Kafka({
+  clientId: 'my-app',
+  brokers: ['kafka1:9092', 'kafka2:9092'],
+  logLevel: logLevel.ERROR
+})
+kafka.logger().setLogLevel(logLevel.WARN)
+
+const producer = kafka.producer(...)
+producer.logger().setLogLevel(logLevel.INFO)
+
+const consumer = kafka.consumer(...)
+consumer.logger().setLogLevel(logLevel.DEBUG)
+
+const amin = kafka.admin(...)
+admin.logger().setLogLevel(logLevel.NOTHING)
+```
+
 The environment variable `KAFKAJS_LOG_LEVEL` can also be used and it has precedence over the configuration in code, example:
 
 ```sh

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -6,6 +6,7 @@ Object {
   "error": [Function],
   "info": [Function],
   "namespace": [Function],
+  "setLogLevel": [Function],
   "warn": [Function],
 }
 `;

--- a/src/admin/__snapshots__/index.spec.js.snap
+++ b/src/admin/__snapshots__/index.spec.js.snap
@@ -6,6 +6,7 @@ Object {
   "error": [Function],
   "info": [Function],
   "namespace": [Function],
+  "setLogLevel": [Function],
   "warn": [Function],
 }
 `;

--- a/src/consumer/__tests__/__snapshots__/logger.spec.js.snap
+++ b/src/consumer/__tests__/__snapshots__/logger.spec.js.snap
@@ -6,6 +6,7 @@ Object {
   "error": [Function],
   "info": [Function],
   "namespace": [Function],
+  "setLogLevel": [Function],
   "warn": [Function],
 }
 `;

--- a/src/loggers/index.js
+++ b/src/loggers/index.js
@@ -12,7 +12,7 @@ const createLevel = (label, level, currentLevel, namespace, logFunction) => (
   message,
   extra = {}
 ) => {
-  if (level > currentLevel) return
+  if (level > currentLevel()) return
   logFunction({
     namespace,
     level,
@@ -34,7 +34,7 @@ const evaluateLogLevel = logLevel => {
 }
 
 const createLogger = ({ level = LEVELS.INFO, logCreator = null } = {}) => {
-  const logLevel = evaluateLogLevel(level)
+  let logLevel = evaluateLogLevel(level)
   const logFunction = logCreator(logLevel)
 
   const createNamespace = (namespace, logLevel = null) => {
@@ -43,7 +43,7 @@ const createLogger = ({ level = LEVELS.INFO, logCreator = null } = {}) => {
   }
 
   const createLogFunctions = (namespace, namespaceLogLevel = null) => {
-    const currentLogLevel = namespaceLogLevel == null ? logLevel : namespaceLogLevel
+    const currentLogLevel = () => (namespaceLogLevel == null ? logLevel : namespaceLogLevel)
     const logger = {
       info: createLevel('INFO', LEVELS.INFO, currentLogLevel, namespace, logFunction),
       error: createLevel('ERROR', LEVELS.ERROR, currentLogLevel, namespace, logFunction),
@@ -51,7 +51,12 @@ const createLogger = ({ level = LEVELS.INFO, logCreator = null } = {}) => {
       debug: createLevel('DEBUG', LEVELS.DEBUG, currentLogLevel, namespace, logFunction),
     }
 
-    return assign(logger, { namespace: createNamespace })
+    return assign(logger, {
+      namespace: createNamespace,
+      setLogLevel: newLevel => {
+        logLevel = newLevel
+      },
+    })
   }
 
   return createLogFunctions()

--- a/src/loggers/index.spec.js
+++ b/src/loggers/index.spec.js
@@ -88,4 +88,24 @@ describe('Loggers', () => {
     newLogger.debug('<test custom logLevel for namespaced logger>')
     expect(myLogger).not.toHaveBeenCalled()
   })
+
+  it('allows overriding the logLevel after instantiation', () => {
+    logger.setLogLevel(LEVELS.INFO)
+
+    logger.debug('Debug message that never gets logged')
+    expect(myLogger).not.toHaveBeenCalled()
+
+    logger.info('Info message', { extra: true })
+    expect(myLogger).toHaveBeenCalledWith(LEVELS.DEBUG, {
+      namespace: 'MyNamespace',
+      level: LEVELS.INFO,
+      label: 'INFO',
+      log: {
+        timestamp: timeNow.toISOString(),
+        logger: 'kafkajs',
+        message: 'Info message',
+        extra: true,
+      },
+    })
+  })
 })

--- a/src/producer/__snapshots__/index.spec.js.snap
+++ b/src/producer/__snapshots__/index.spec.js.snap
@@ -6,6 +6,7 @@ Object {
   "error": [Function],
   "info": [Function],
   "namespace": [Function],
+  "setLogLevel": [Function],
   "warn": [Function],
 }
 `;


### PR DESCRIPTION
Adds a new method `setLogLevel` on the `Logger`, accessible on the client, consumer, producer and admin via the `logger` method.

Fixes #277