### PR TITLE
Encode non-buffer key as string by default

### DIFF
--- a/src/producer/partitioners/default/murmur2.js
+++ b/src/producer/partitioners/default/murmur2.js
@@ -10,8 +10,8 @@ const SEED = 0x9747b28c
 const M = 0x5bd1e995
 const R = 24
 
-module.exports = string => {
-  const data = Buffer.from(string)
+module.exports = key => {
+  const data = Buffer.isBuffer(key) ? key : Buffer.from(String(key))
   const length = data.length
 
   // Initialize the hash to a random value

--- a/src/producer/partitioners/default/murmur2.spec.js
+++ b/src/producer/partitioners/default/murmur2.spec.js
@@ -6,6 +6,14 @@ describe('Producer > Partitioner > Default > murmur2', () => {
       expect(murmur2(key)).toEqual(testData[key])
     })
   })
+
+  test('it handles numeric input', () => {
+    expect(murmur2(0)).toEqual(272173970)
+  })
+
+  test('it handles buffer input', () => {
+    expect(murmur2(Buffer.from('1'))).toEqual(1311020360)
+  })
 })
 
 const testData = {


### PR DESCRIPTION
The message value is already treated this way in `Encoder.writeBytes`.

Fixes #281