### PR TITLE
Add FAQ entry for receiving data from unsubscribed topics

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -190,12 +190,12 @@ await admin.describeConfigs({
 Returning all configs for a given resource:
 
 ```javascript
-const { RESOURCE_TYPES } = require('kafkajs')
+const { ResourceTypes } = require('kafkajs')
 
 await admin.describeConfigs({
     resources: [
         {
-            type: RESOURCE_TYPES.TOPIC,
+            type: ResourceTypes.TOPIC,
             name: 'topic-name'
         }
     ]
@@ -205,12 +205,12 @@ await admin.describeConfigs({
 Returning specific configs for a given resource:
 
 ```javascript
-const { RESOURCE_TYPES } = require('kafkajs')
+const { ResourceTypes } = require('kafkajs')
 
 await admin.describeConfigs({
     resources: [
         {
-            type: RESOURCE_TYPES.TOPIC,
+            type: ResourceTypes.TOPIC,
             name: 'topic-name',
             configNames: ['cleanup.policy']
         }
@@ -276,11 +276,11 @@ await admin.alterConfigs({
 Example:
 
 ```javascript
-const { RESOURCE_TYPES } = require('kafkajs')
+const { ResourceTypes } = require('kafkajs')
 
 await admin.alterConfigs({
     resources: [{
-        type: RESOURCE_TYPES.TOPIC,
+        type: ResourceTypes.TOPIC,
         name: 'topic-name',
         configEntries: [{ name: 'cleanup.policy', value: 'compact' }]
     }]

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,7 +11,7 @@ title: Frequently Asked Questions
 
 ## Why am I receiving messages for topics I'm not subscribed to?
 
-If you are seeing the warning `[ConsumerGroup]  Consumer group received unsubscribed topics`, it likely means that some members of your consumer group are subscribed to some topics, and some other members of the group are subscribed to a different set of topics. In our experience, the most common cause is re-using `groupId` across several applications or several different independent deployments of the same application. This is normal while deploying a new version of an application where the new version subscribes to a new topic, and the warning will go away once the group stabilizes on a single version.
+If you are seeing the warning `[ConsumerGroup] Consumer group received unsubscribed topics`, it likely means that some members of your consumer group are subscribed to some topics, and some other members of the group are subscribed to a different set of topics. In our experience, the most common cause is re-using `groupId` across several applications or several different independent deployments of the same application. This is normal while deploying a new version of an application where the new version subscribes to a new topic, and the warning will go away once the group stabilizes on a single version.
 
 Ensure that your `groupId` is not used by any other application. A simple way to verify this is to [describe the consumer group](Consuming.md#describe-group) and verify that there are no unexpected members.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,6 +9,12 @@ title: Frequently Asked Questions
 
 > **Note**: If you are using KafkaJS in production, [we would love to hear about what you are doing!](https://github.com/tulios/kafkajs/issues/289)
 
+## Why am I receiving messages for topics I'm not subscribed to?
+
+If you are seeing the warning `[ConsumerGroup]  Consumer group received unsubscribed topics`, it likely means that some members of your consumer group are subscribed to some topics, and some other members of the group are subscribed to a different set of topics. In our experience, the most common cause is re-using `groupId` across several applications or several different independent deployments of the same application. This is normal while deploying a new version of an application where the new version subscribes to a new topic, and the warning will go away once the group stabilizes on a single version.
+
+Ensure that your `groupId` is not used by any other application. A simple way to verify this is to [describe the consumer group](Consuming.md#describe-group) and verify that there are no unexpected members.
+
 ## Didn't find what you were looking for?
 
 Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -1,5 +1,6 @@
 const flatten = require('../utils/flatten')
 const sleep = require('../utils/sleep')
+const websiteUrl = require('../utils/websiteUrl')
 const arrayDiff = require('../utils/arrayDiff')
 const OffsetManager = require('./offsetManager')
 const Batch = require('./batch')
@@ -169,6 +170,10 @@ module.exports = class ConsumerGroup {
         assignedTopics,
         topicsSubscribed,
         topicsNotSubscribed,
+        helpUrl: websiteUrl(
+          'docs/faq',
+          'why-am-i-receiving-messages-for-topics-i-m-not-subscribed-to'
+        ),
       })
 
       // Remove unsubscribed topics from the list

--- a/src/utils/websiteUrl.js
+++ b/src/utils/websiteUrl.js
@@ -1,0 +1,3 @@
+const BASE_URL = 'https://kafka.js.org'
+
+module.exports = (path, hash) => `${BASE_URL}/${path}${hash ? '#' + hash : ''}`

--- a/src/utils/websiteUrl.spec.js
+++ b/src/utils/websiteUrl.spec.js
@@ -1,0 +1,15 @@
+const websiteUrl = require('./websiteUrl')
+
+describe('Utils > websiteUrl', () => {
+  it('generates links to the website', () => {
+    expect(websiteUrl('docs/faq')).toEqual('https://kafka.js.org/docs/faq')
+  })
+
+  it('allows specifying a hash', () => {
+    expect(
+      websiteUrl('docs/faq', 'why-am-i-receiving-messages-for-topics-i-m-not-subscribed-to')
+    ).toEqual(
+      'https://kafka.js.org/docs/faq#why-am-i-receiving-messages-for-topics-i-m-not-subscribed-to'
+    )
+  })
+})


### PR DESCRIPTION
This is something that comes up often, so although it's not really related to KafkaJS, I though I should add a FAQ section to link to.

One slightly controversial change, which I'm actually pretty enthusiastic about, is to add a `helpUrl` field to the warning that links to the FAQ entry.