### PR TITLE
Abort old transactions on protocol error CONCURRENT_TRANSACTIONS

### DIFF
--- a/src/producer/__tests__/concurrentTransaction.spec.js
+++ b/src/producer/__tests__/concurrentTransaction.spec.js
@@ -1,0 +1,52 @@
+const {
+  secureRandom,
+  newLogger,
+  createCluster,
+  testIfKafka_0_11,
+  createTopic,
+} = require('testHelpers')
+const createProducer = require('../index')
+
+describe('Producer > Transactional producer', () => {
+  let producer1, producer2, topicName, transactionalId, message
+
+  const newProducer = () =>
+    createProducer({
+      cluster: createCluster(),
+      logger: newLogger(),
+      idempotent: true,
+      transactionalId,
+      transactionTimeout: 100,
+    })
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    transactionalId = `transactional-id-${secureRandom()}`
+    message = { key: `key-${secureRandom()}`, value: `value-${secureRandom()}` }
+
+    await createTopic({ topic: topicName })
+  })
+
+  afterEach(async () => {
+    producer1 && (await producer1.disconnect())
+    producer2 && (await producer2.disconnect())
+  })
+
+  describe('when there is an ongoing transaction on connect', () => {
+    testIfKafka_0_11('retries initProducerId to cancel the ongoing transaction', async () => {
+      // Producer 1 will create a transaction and "crash", it will never commit or abort the connection
+      producer1 = newProducer()
+      await producer1.connect()
+      const transaction1 = await producer1.transaction()
+      await transaction1.send({ topic: topicName, messages: [message] })
+
+      // Producer 2 starts with the same transactional id to cause the concurrent transactions error
+      producer2 = newProducer()
+      await producer2.connect()
+      let transaction2
+      await expect(producer2.transaction().then(t => (transaction2 = t))).resolves.toBeTruthy()
+      await transaction2.send({ topic: topicName, messages: [message] })
+      await transaction2.commit()
+    })
+  })
+})


### PR DESCRIPTION
Fixes #296 

This PR "aborts" old transactions when creating a new transaction, Kafka is responsible for the cleanup, so a simple retry is sufficient to terminate the old transaction (as indicated in the Java API https://github.com/apache/kafka/blob/201da0542726472d954080d54bc585b111aaf86f/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1001-L1002).

I also took the opportunity to retry on other protocol errors, as indicated in the Java API.