### PR TITLE
Improve browser compatibility

### DIFF
--- a/src/producer/partitioners/default/index.js
+++ b/src/producer/partitioners/default/index.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto')
+const randomBytes = require('./randomBytes')
 const murmur2 = require('./murmur2')
 
 // Based on the java client 0.10.2
@@ -19,7 +19,7 @@ const toPositive = x => x & 0x7fffffff
  *  - If no partition or key is present choose a partition in a round-robin fashion
  */
 module.exports = () => {
-  let counter = crypto.randomBytes(32).readUInt32BE()
+  let counter = randomBytes(32).readUInt32BE(0)
 
   return ({ topic, partitionMetadata, message }) => {
     const numPartitions = partitionMetadata.length

--- a/src/producer/partitioners/default/randomBytes.js
+++ b/src/producer/partitioners/default/randomBytes.js
@@ -1,11 +1,32 @@
-const crypto = global.crypto
-  ? {
-      randomBytes: size => {
-        let bytes = Buffer.allocUnsafe(size)
-        global.crypto.getRandomValues(bytes)
-        return bytes
-      },
-    }
-  : require('crypto')
+const { KafkaJSNonRetriableError } = require('../../../errors')
 
-module.exports = size => crypto.randomBytes(size)
+if (typeof global !== 'undefined' && !global.crypto) {
+  global.crypto = require('crypto')
+}
+
+const MAX_BYTES = 65536
+
+module.exports = size => {
+  if (size > MAX_BYTES) {
+    throw new KafkaJSNonRetriableError(
+      `Byte length (${size}) exceeds the max number of bytes of entropy available (${MAX_BYTES})`
+    )
+  }
+
+  if (typeof global.crypto !== 'undefined' && global.crypto.randomBytes) {
+    return global.crypto.randomBytes(size)
+  }
+
+  let cryptoImplementation
+  if (typeof global.crypto !== 'undefined') {
+    cryptoImplementation = global.crypto
+  } else if (typeof global.msCrypto !== 'undefined') {
+    cryptoImplementation = global.msCrypto
+  }
+
+  if (!cryptoImplementation) {
+    throw new KafkaJSNonRetriableError('No available crypto implementation')
+  }
+
+  return cryptoImplementation.getRandomValues(Buffer.allocUnsafe(size))
+}

--- a/src/producer/partitioners/default/randomBytes.js
+++ b/src/producer/partitioners/default/randomBytes.js
@@ -1,0 +1,11 @@
+const crypto = global.crypto
+  ? {
+      randomBytes: size => {
+        let bytes = Buffer.allocUnsafe(size)
+        global.crypto.getRandomValues(bytes)
+        return bytes
+      },
+    }
+  : require('crypto')
+
+module.exports = size => crypto.randomBytes(size)

--- a/src/producer/partitioners/default/randomBytes.spec.js
+++ b/src/producer/partitioners/default/randomBytes.spec.js
@@ -1,0 +1,18 @@
+const { KafkaJSNonRetriableError } = require('../../../errors')
+const randomBytes = require('./randomBytes')
+
+describe('Producer > Partitioner > Default > RandomBytes', () => {
+  test('it throws when requesting more bytes than entry allows', () => {
+    expect(() => randomBytes(65537)).toThrowError(
+      new KafkaJSNonRetriableError(
+        'Byte length (65537) exceeds the max number of bytes of entropy available (65536)'
+      )
+    )
+  })
+
+  test('it returns random bytes of the desired length', () => {
+    const bytes = randomBytes(32)
+    expect(bytes).toEqual(expect.any(Buffer))
+    expect(bytes.byteLength).toBe(32)
+  })
+})

--- a/src/protocol/requests/fetch/v4/response.js
+++ b/src/protocol/requests/fetch/v4/response.js
@@ -35,7 +35,7 @@ const decodeMessages = async decoder => {
 
   const messagesBuffer = decoder.readBytes(messagesSize)
   const messagesDecoder = new Decoder(messagesBuffer)
-  const magicByte = messagesBuffer.slice(MAGIC_OFFSET).readInt8()
+  const magicByte = messagesBuffer.slice(MAGIC_OFFSET).readInt8(0)
 
   if (magicByte === MAGIC_BYTE) {
     let records = []


### PR DESCRIPTION
Using a custom socket factory with #263 I can run KafkaJS in the browser, but there are some compatibility issues that need to be fixed.

This PR fixes two things:

1. It makes the default partitioner use `global.crypto` where available instead of importing `crypto`. They are not equivalent, but for our purposes they work.
2. Whenever we read from a buffer, we need to specify `offset`. Most of the time we do it using `Decoder`, which maintains an internal offset that gets passed in, but there are some places where we operate directly on buffers and are not passing in an offset. In Node this seems to work, with it implicitly meaning offset = 0, but in the browser we get an exception.