### PR TITLE
Prevent consumer#run to override running consumer

### DIFF
--- a/src/consumer/__tests__/index.spec.js
+++ b/src/consumer/__tests__/index.spec.js
@@ -1,0 +1,52 @@
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  newLogger,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+const createConsumer = require('../index')
+
+describe('Consumer', () => {
+  let topicName, groupId, consumer
+
+  describe('#run', () => {
+    beforeEach(async () => {
+      topicName = `test-topic-${secureRandom()}`
+      groupId = `consumer-group-id-${secureRandom()}`
+
+      await createTopic({ topic: topicName })
+      consumer = createConsumer({
+        cluster: createCluster({ metadataMaxAge: 50 }),
+        groupId,
+        heartbeatInterval: 100,
+        maxWaitTimeInMs: 100,
+        logger: newLogger(),
+      })
+    })
+
+    afterEach(async () => {
+      consumer && (await consumer.disconnect())
+    })
+
+    describe('when the consumer is already running', () => {
+      it('ignores the call', async () => {
+        await consumer.connect()
+        await consumer.subscribe({ topic: topicName, fromBeginning: true })
+        const eachMessage = jest.fn()
+
+        Promise.all([
+          consumer.run({ eachMessage }),
+          consumer.run({ eachMessage }),
+          consumer.run({ eachMessage }),
+        ])
+
+        // Since the consumer gets overridden, it will fail to join the group
+        // as three other consumers will also try to join. This case is hard to write a test
+        // since we can only assert the symptoms of the problem, but we can't assert that
+        // we don't initialize the consumer.
+        await waitForConsumerToJoinGroup(consumer)
+      })
+    })
+  })
+})

--- a/src/consumer/__tests__/instrumentationEvents.spec.js
+++ b/src/consumer/__tests__/instrumentationEvents.spec.js
@@ -390,6 +390,19 @@ describe('Consumer > Instrumentation Events', () => {
         .catch(e => e),
     ])
 
+    // add more concurrent requests to make we increate the requests
+    // on the queue
+    await Promise.all([
+      consumer.describeGroup(),
+      consumer.describeGroup(),
+      consumer.describeGroup(),
+      consumer.describeGroup(),
+      consumer2.describeGroup(),
+      consumer2.describeGroup(),
+      consumer2.describeGroup(),
+      consumer2.describeGroup(),
+    ])
+
     await consumer2.disconnect()
 
     expect(requestListener).toHaveBeenCalledWith({

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -161,6 +161,11 @@ module.exports = ({
     eachBatch = null,
     eachMessage = null,
   } = {}) => {
+    if (consumerGroup) {
+      logger.warn('consumer#run was called, but the consumer is already running', { groupId })
+      return
+    }
+
     consumerGroup = createConsumerGroup({
       autoCommitInterval,
       autoCommitThreshold,
@@ -207,8 +212,10 @@ module.exports = ({
         const retryTime = e.retryTime || retry.initialRetryTime || initialRetryTime
         logger.error(`Restarting the consumer in ${retryTime}ms`, {
           retryCount: e.retryCount,
+          retryTime,
           groupId,
         })
+
         setTimeout(() => restart(onCrash), retryTime)
       }
     }


### PR DESCRIPTION
Some users accidentally called `consumer#run` several times after having a running consumer, this can cause a lot of issues since run will override the reference of the running consumer and create a new one. This PR adds a check for this case and turns run into a noOp if the consumer is already running. 