### PR TITLE
Add custom requestTimeout for protocol fetch

### DIFF
--- a/src/broker/__tests__/fetch.spec.js
+++ b/src/broker/__tests__/fetch.spec.js
@@ -18,7 +18,7 @@ const ISOLATION_LEVEL = require('../../protocol/isolationLevel')
 const minBytes = 1
 const maxBytes = 10485760 // 10MB
 const maxBytesPerPartition = 1048576 // 1MB
-const maxWaitTime = 5
+const maxWaitTime = 100
 const timestamp = 1509827900073
 
 describe('Broker > Fetch', () => {

--- a/src/protocol/requests/fetch/index.js
+++ b/src/protocol/requests/fetch/index.js
@@ -2,27 +2,51 @@ const ISOLATION_LEVEL = require('../../isolationLevel')
 
 // For normal consumers, use -1
 const REPLICA_ID = -1
+const NETWORK_DELAY = 100
+
+/**
+ * The FETCH request can block up to maxWaitTime, which can be bigger than the configured
+ * request timeout. It's safer to always use the maxWaitTime
+ **/
+const requestTimeout = timeout =>
+  Number.isSafeInteger(timeout + NETWORK_DELAY) ? timeout + NETWORK_DELAY : timeout
 
 const versions = {
   0: ({ replicaId = REPLICA_ID, maxWaitTime, minBytes, topics }) => {
     const request = require('./v0/request')
     const response = require('./v0/response')
-    return { request: request({ replicaId, maxWaitTime, minBytes, topics }), response }
+    return {
+      request: request({ replicaId, maxWaitTime, minBytes, topics }),
+      response,
+      requestTimeout: requestTimeout(maxWaitTime),
+    }
   },
   1: ({ replicaId = REPLICA_ID, maxWaitTime, minBytes, topics }) => {
     const request = require('./v1/request')
     const response = require('./v1/response')
-    return { request: request({ replicaId, maxWaitTime, minBytes, topics }), response }
+    return {
+      request: request({ replicaId, maxWaitTime, minBytes, topics }),
+      response,
+      requestTimeout: requestTimeout(maxWaitTime),
+    }
   },
   2: ({ replicaId = REPLICA_ID, maxWaitTime, minBytes, topics }) => {
     const request = require('./v2/request')
     const response = require('./v2/response')
-    return { request: request({ replicaId, maxWaitTime, minBytes, topics }), response }
+    return {
+      request: request({ replicaId, maxWaitTime, minBytes, topics }),
+      response,
+      requestTimeout: requestTimeout(maxWaitTime),
+    }
   },
   3: ({ replicaId = REPLICA_ID, maxWaitTime, minBytes, maxBytes, topics }) => {
     const request = require('./v3/request')
     const response = require('./v3/response')
-    return { request: request({ replicaId, maxWaitTime, minBytes, maxBytes, topics }), response }
+    return {
+      request: request({ replicaId, maxWaitTime, minBytes, maxBytes, topics }),
+      response,
+      requestTimeout: requestTimeout(maxWaitTime),
+    }
   },
   4: ({
     replicaId = REPLICA_ID,
@@ -37,6 +61,7 @@ const versions = {
     return {
       request: request({ replicaId, isolationLevel, maxWaitTime, minBytes, maxBytes, topics }),
       response,
+      requestTimeout: requestTimeout(maxWaitTime),
     }
   },
 }

--- a/src/protocol/requests/fetch/index.spec.js
+++ b/src/protocol/requests/fetch/index.spec.js
@@ -1,0 +1,45 @@
+const FetchVersions = require('./index')
+
+describe('Protocol > Requests > Fetch', () => {
+  for (let version of FetchVersions.versions) {
+    describe(version, () => {
+      const Fetch = FetchVersions.protocol({ version })
+      const maxBytes = 1048576 // 1MB
+      const topics = [
+        {
+          topic: 'test-topic',
+          partitions: [
+            {
+              partition: 0,
+              fetchOffset: 0,
+              maxBytes,
+            },
+          ],
+        },
+      ]
+
+      it('returns the requestTimeout', () => {
+        const maxWaitTime = 1000
+        const protocol = Fetch({
+          maxWaitTime,
+          minBytes: 1,
+          maxBytes: 1024,
+          topics,
+        })
+
+        expect(protocol.requestTimeout).toBeGreaterThan(maxWaitTime)
+      })
+
+      it('does not use numbers large than MAX_SAFE_INTEGER', () => {
+        const protocol = Fetch({
+          maxWaitTime: Number.MAX_SAFE_INTEGER,
+          minBytes: 1,
+          maxBytes: 1024,
+          topics,
+        })
+
+        expect(protocol.requestTimeout).toEqual(Number.MAX_SAFE_INTEGER)
+      })
+    })
+  }
+})


### PR DESCRIPTION
The FETCH request can block up to `maxWaitTime`, which can be bigger than the configured request timeout. It's safer always to use the `maxWaitTime`.