### PR TITLE
fix: handle null keys on isAbortMarker

### DIFF
--- a/src/consumer/__tests__/filterAbortedMessages.spec.js
+++ b/src/consumer/__tests__/filterAbortedMessages.spec.js
@@ -30,6 +30,23 @@ describe('filterAbortedMessages', () => {
     ])
   })
 
+  test('filters out aborted messages with malformed keys', () => {
+    const { messages, abortedTransactions } = abortedBatch
+    const { messages: nontransactionalMessages } = nontransactionalBatch
+    messages[messages.length - 2].key = null
+    expect(
+      filterAbortedMessages({
+        messages: [...messages, ...nontransactionalMessages],
+        abortedTransactions,
+      })
+    ).toStrictEqual([
+      expect.objectContaining({
+        key: Buffer.from([0, 0, 0, 0]),
+      }),
+      ...nontransactionalMessages,
+    ])
+  })
+
   test('returns all committed messages', () => {
     const { messages, abortedTransactions } = committedBatch
     expect(messages).toHaveLength(4)

--- a/src/consumer/filterAbortedMessages.js
+++ b/src/consumer/filterAbortedMessages.js
@@ -2,6 +2,8 @@ const Long = require('long')
 const ABORTED_MESSAGE_KEY = Buffer.from([0, 0, 0, 0])
 
 const isAbortMarker = ({ key }) => {
+  // Handle null/undefined keys.
+  if (!key) return false
   // Cast key to buffer defensively
   return Buffer.from(key).equals(ABORTED_MESSAGE_KEY)
 }


### PR DESCRIPTION
As silly as it sounds, I ran into this issue while testing transactional failures.
I made the producer throw an error after sending a message to the topic, then aborted the transaction.

Consequently, when I started up my consumer process, I began to see crashes like this:
```
{"level":"ERROR","timestamp":"2019-03-11T19:53:03.496Z","logger":"kafkajs",
  "message":"[Consumer] Crash: KafkaJSNumberOfRetriesExceeded: The first argument must be 
  one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type 
  object","groupId":"payment-processor","retryCount":5,
  "stack":"KafkaJSNumberOfRetriesExceeded
  Caused by: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be one of type string, 
  Buffer, ArrayBuffer, Array, or Array-like Object. Received type object
    at Function.from (buffer.js:207:11)
    at isAbortMarker (snip/node_modules/kafkajs/src/consumer/filterAbortedMessages.js:10:17)
    at messages.filter.message (snip/node_modules/kafkajs/src/consumer/filterAbortedMessages.js:59:9)
    at Array.filter (<anonymous>)
    at module.exports (snip/node_modules/kafkajs/src/consumer/filterAbortedMessages.js:44:19)
    at new Batch (snip/node_modules/kafkajs/src/consumer/batch.js:29:21)
    at partitions.map.partitionData (snip/node_modules/kafkajs/src/consumer/consumerGroup.js:381:20)
    at Array.map (<anonymous>)
    at responses.map (snip/node_modules/kafkajs/src/consumer/consumerGroup.js:374:29)
    at Array.map (<anonymous>)"}
```

While I know the data itself is malformed, it was tripping up the `isAbortMarker` function due to the key being null. Since `null` doesn't equal `Buffer.from([0,0,0,0])`, I figured this patch makes sense.