### PR TITLE
Use the max between the default request timeout and the protocol override

### DIFF
--- a/src/network/requestQueue/index.js
+++ b/src/network/requestQueue/index.js
@@ -58,8 +58,10 @@ module.exports = class RequestQueue {
     const { correlationId } = pushedRequest.entry
     const defaultRequestTimeout = this.requestTimeout
     const customRequestTimeout = pushedRequest.requestTimeout
-    const requestTimeout =
-      customRequestTimeout == null ? defaultRequestTimeout : customRequestTimeout
+
+    // Some protocol requests have custom request timeouts (e.g JoinGroup, Fetch, etc). The custom
+    // timeouts are influenced by user configurations, which can be lower than the default requestTimeout
+    const requestTimeout = Math.max(defaultRequestTimeout, customRequestTimeout || 0)
 
     const socketRequest = new SocketRequest({
       entry: pushedRequest.entry,


### PR DESCRIPTION
PR #310 introduced a custom timeout for protocol Fetch, but `maxWaitTime` can be lower than the `requestTimeout`. This can also happen with other protocols; the custom timeouts are influenced by user configurations and can be lower than the default `requestTimeout`. This PR makes sure that the value is always the max between the specific timeout and the default.