### PR TITLE
feat: add consume.patternSubscribe()

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -24,7 +24,29 @@ await consumer.subscribe({ topic: 'topic-B' })
 // await consumer.subscribe({ topic: 'topic-C', fromBeginning: true })
 ```
 
-KafkaJS offers you two ways to process your data: `eachMessage` and `eachBatch`
+Alternatively, you can subscribe to multiple topics at once using a pattern string:
+
+```javascript
+await consumer.connect()
+
+await consumer.patternSubscribe({ topic: 'topic-*' })
+```
+
+In the above example you'd subscribe to all topics starting with `topic-`. 
+You can use the wildcard character `*` multiple times:
+
+```javascript
+await consumer.patternSubscribe({ topic: '*pic*' })
+``` 
+
+Note that the pattern is expanded and matched against existing topics only when you call `consumer.patternSubscribe()`.
+No further attempts are made to auto subscribe your consumer to new topics matching the pattern.
+
+If your broker has `topic-A` and `topic-B`, you patternSubscribe to `topic-*`, then `topic-C` is created, your consumer would not be automatically subscribed to `topic-C`.
+You will have to manually call `consumer.patternSubscribe({ topic: 'topic-*' })` or `consumer.subscribe({ topic: 'topic-C' })` again.
+
+
+KafkaJS offers you two ways to process your data: `eachMessage` and `eachBatch`.
 
 ## <a name="each-message"></a> eachMessage
 

--- a/src/consumer/__tests__/subscribe.spec.js
+++ b/src/consumer/__tests__/subscribe.spec.js
@@ -26,4 +26,13 @@ describe('Consumer', () => {
       )
     })
   })
+
+  describe('when patternSubscribe', () => {
+    it('throws an error if the topic is invalid', async () => {
+      await expect(consumer.patternSubscribe({ topic: null })).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+  })
 })


### PR DESCRIPTION
This PR adds a new consumer method to allow subscribing to multiple matching topics at once by using a wildcard character.
It doesn't watch the list of topics to auto-subscribe to new added topics - this is by design and, as far as I can tell, the same with the java consumer.