### PR TITLE
Discard messages for toppars that saw a seek operation during a fetch or batch processing

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -85,7 +85,7 @@ await consumer.run({
 * `resolveOffset()` is used to mark a message in the batch as processed. In case of errors, the consumer will automatically commit the resolved offsets.
 * `commitOffsetsIfNecessary(offsets?)` is used to commit offsets based on the autoCommit configurations (`autoCommitInterval` and `autoCommitThreshold`). Note that auto commit won't happen in `eachBatch` if `commitOffsetsIfNecessary` is not invoked. Take a look at [autoCommit](#auto-commit) for more information.
 * `uncommittedOffsets()` returns all offsets by topic-partition which have not yet been committed.
-* `isStale()` returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling `[consumer.seek](#seek)` the messages in the batch should be discarded, as they are not at the offset we seeked to.
+* `isStale()` returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling [`consumer.seek`](#seek) the messages in the batch should be discarded, as they are not at the offset we seeked to.
 
 ### Example
 

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -490,7 +490,6 @@ describe('Consumer', () => {
 
       await consumer.connect()
       await producer.connect()
-      // console.log(`producing to ${topicName}`)
       await producer.send({ acks: 1, topic: topicName, messages })
       await consumer.subscribe({ topic: topicName, fromBeginning: true })
 

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -188,9 +188,16 @@ describe('Consumer', () => {
     const batchesConsumed = []
     const functionsExposed = []
     consumer.run({
-      eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning, uncommittedOffsets }) => {
+      eachBatch: async ({
+        batch,
+        resolveOffset,
+        heartbeat,
+        isRunning,
+        isStale,
+        uncommittedOffsets,
+      }) => {
         batchesConsumed.push(batch)
-        functionsExposed.push(resolveOffset, heartbeat, isRunning, uncommittedOffsets)
+        functionsExposed.push(resolveOffset, heartbeat, isRunning, isStale, uncommittedOffsets)
       },
     })
 
@@ -224,6 +231,7 @@ describe('Consumer', () => {
     ])
 
     expect(functionsExposed).toEqual([
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
       expect.any(Function),

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -469,55 +469,145 @@ describe('Consumer', () => {
     expect(calls).toEqual(1)
   })
 
-  it('skips messages fetched while seek was called', async () => {
-    consumer = createConsumer({
-      cluster: createCluster(),
-      groupId,
-      maxWaitTimeInMs: 1000,
-      logger: newLogger(),
+  describe('discarding messages after seeking', () => {
+    it('stops consuming messages when fetched batch has gone stale', async () => {
+      consumer = createConsumer({
+        cluster: createCluster(),
+        groupId,
+        logger: newLogger(),
+
+        // make sure we fetch a batch of messages
+        minBytes: 1024,
+        maxWaitTimeInMs: 500,
+      })
+
+      const messages = Array(10)
+        .fill()
+        .map(() => {
+          const value = secureRandom()
+          return { key: `key-${value}`, value: `value-${value}` }
+        })
+
+      await consumer.connect()
+      await producer.connect()
+      // console.log(`producing to ${topicName}`)
+      await producer.send({ acks: 1, topic: topicName, messages })
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+      let offsetsConsumed = []
+
+      consumer.run({
+        eachMessage: async ({ message }) => {
+          offsetsConsumed.push(message.offset)
+
+          if (offsetsConsumed.length === 1) {
+            consumer.seek({ topic: topicName, partition: 0, offset: message.offset })
+          }
+        },
+      })
+
+      await waitFor(() => offsetsConsumed.length >= 2, { delay: 50 })
+
+      expect(offsetsConsumed[0]).toEqual(offsetsConsumed[1])
     })
 
-    const messages = Array(10)
-      .fill()
-      .map(() => {
-        const value = secureRandom()
-        return { key: `key-${value}`, value: `value-${value}` }
+    it('resolves a batch as stale when seek was called while processing it', async () => {
+      consumer = createConsumer({
+        cluster: createCluster(),
+        groupId,
+        logger: newLogger(),
+
+        // make sure we fetch a batch of messages
+        minBytes: 1024,
+        maxWaitTimeInMs: 500,
       })
-    await producer.connect()
-    await producer.send({ acks: 1, topic: topicName, messages })
 
-    await consumer.connect()
+      const messages = Array(10)
+        .fill()
+        .map(() => {
+          const value = secureRandom()
+          return { key: `key-${value}`, value: `value-${value}` }
+        })
 
-    await consumer.subscribe({ topic: topicName, fromBeginning: true })
+      await consumer.connect()
+      await producer.connect()
+      await producer.send({ acks: 1, topic: topicName, messages })
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
 
-    const sleep = value => waitFor(delay => delay >= value)
-    let offsetsConsumed = []
+      let offsetsConsumed = []
 
-    const eachBatch = async ({ batch, heartbeat }) => {
-      for (const message of batch.messages) {
-        offsetsConsumed.push(message.offset)
+      consumer.run({
+        eachBatch: async ({ batch, isStale, heartbeat, resolveOffset }) => {
+          for (let message of batch.messages) {
+            if (isStale()) break
+
+            offsetsConsumed.push(message.offset)
+
+            if (offsetsConsumed.length === 1) {
+              consumer.seek({ topic: topicName, partition: 0, offset: message.offset })
+            }
+
+            await resolveOffset(message.offset)
+            await heartbeat()
+          }
+        },
+      })
+
+      await waitFor(() => offsetsConsumed.length >= 2, { delay: 50 })
+
+      expect(offsetsConsumed[0]).toEqual(offsetsConsumed[1])
+    })
+
+    it('skips messages fetched while seek was called', async () => {
+      consumer = createConsumer({
+        cluster: createCluster(),
+        groupId,
+        maxWaitTimeInMs: 1000,
+        logger: newLogger(),
+      })
+
+      const messages = Array(10)
+        .fill()
+        .map(() => {
+          const value = secureRandom()
+          return { key: `key-${value}`, value: `value-${value}` }
+        })
+      await producer.connect()
+      await producer.send({ acks: 1, topic: topicName, messages })
+
+      await consumer.connect()
+
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+      const sleep = value => waitFor(delay => delay >= value)
+      let offsetsConsumed = []
+
+      const eachBatch = async ({ batch, heartbeat }) => {
+        for (const message of batch.messages) {
+          offsetsConsumed.push(message.offset)
+        }
+
+        await heartbeat()
       }
 
-      await heartbeat()
-    }
+      consumer.run({
+        eachBatch,
+      })
 
-    consumer.run({
-      eachBatch,
+      await waitForConsumerToJoinGroup(consumer)
+
+      await waitFor(() => offsetsConsumed.length === messages.length, { delay: 50 })
+      await sleep(50)
+
+      // Hope that we're now in an active fetch state? Something like FETCH_START might help
+      const seekedOffset = offsetsConsumed[Math.floor(messages.length / 2)]
+      consumer.seek({ topic: topicName, partition: 0, offset: seekedOffset })
+      await producer.send({ acks: 1, topic: topicName, messages }) // trigger completion of fetch
+
+      await waitFor(() => offsetsConsumed.length > messages.length, { delay: 50 })
+
+      expect(offsetsConsumed[messages.length]).toEqual(seekedOffset)
     })
-
-    await waitForConsumerToJoinGroup(consumer)
-
-    await waitFor(() => offsetsConsumed.length === messages.length, { delay: 50 })
-    await sleep(50)
-
-    // Hope that we're now in an active fetch state? Something like FETCH_START might help
-    const seekedOffset = offsetsConsumed[Math.floor(messages.length / 2)]
-    consumer.seek({ topic: topicName, partition: 0, offset: seekedOffset })
-    await producer.send({ acks: 1, topic: topicName, messages }) // trigger completion of fetch
-
-    await waitFor(() => offsetsConsumed.length > messages.length, { delay: 50 })
-
-    expect(offsetsConsumed[messages.length]).toEqual(seekedOffset)
   })
 
   describe('transactions', () => {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -486,4 +486,8 @@ module.exports = class ConsumerGroup {
       }
     }
   }
+
+  hasSeekOffset({ topic, partition }) {
+    return this.seekOffset.has(topic, partition)
+  }
 }

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -374,15 +374,17 @@ module.exports = class ConsumerGroup {
             ({ topic }) => topic === topicName
           )
 
-          return partitions.map(partitionData => {
-            const partitionRequestData = topicRequestData.partitions.find(
-              ({ partition }) => partition === partitionData.partition
-            )
+          return partitions
+            .filter(partitionData => !this.seekOffset.has(topicName, partitionData.partition))
+            .map(partitionData => {
+              const partitionRequestData = topicRequestData.partitions.find(
+                ({ partition }) => partition === partitionData.partition
+              )
 
-            const fetchedOffset = partitionRequestData.fetchOffset
+              const fetchedOffset = partitionRequestData.fetchOffset
 
-            return new Batch(topicName, fetchedOffset, partitionData)
-          })
+              return new Batch(topicName, fetchedOffset, partitionData)
+            })
         })
 
         return flatten(batchesPerPartition)

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -187,7 +187,7 @@ module.exports = class Runner {
         },
         uncommittedOffsets: () => this.consumerGroup.uncommittedOffsets(),
         isRunning: () => this.running,
-        isStale: ({ topic, partition }) => this.consumerGroup.hasSeekOffset({ topic, partition }),
+        isStale: () => this.consumerGroup.hasSeekOffset({ topic, partition }),
       })
     } catch (e) {
       if (!isKafkaJSError(e)) {

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -135,7 +135,7 @@ module.exports = class Runner {
     const { topic, partition } = batch
 
     for (let message of batch.messages) {
-      if (!this.running) {
+      if (!this.running || this.consumerGroup.hasSeekOffset({ topic, partition })) {
         break
       }
 

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -187,6 +187,7 @@ module.exports = class Runner {
         },
         uncommittedOffsets: () => this.consumerGroup.uncommittedOffsets(),
         isRunning: () => this.running,
+        isStale: ({ topic, partition }) => this.consumerGroup.hasSeekOffset({ topic, partition }),
       })
     } catch (e) {
       if (!isKafkaJSError(e)) {

--- a/src/consumer/seekOffsets.js
+++ b/src/consumer/seekOffsets.js
@@ -3,6 +3,10 @@ module.exports = class SeekOffsets extends Map {
     super.set([topic, partition], offset)
   }
 
+  has(topic, partition) {
+    return Array.from(this.keys()).some(([t, p]) => t === topic && p === partition)
+  }
+
   pop() {
     if (this.size === 0) {
       return


### PR DESCRIPTION
After calling `consumer.seek`, any new messages processed should be from the sought to offset. 

Before attempting a fetch, the `consumerGroup` of the `consumer` takes into account any `consumer.seek` calls, fetching messages at the right offset. However, since fetching is an async operation, if `consumer.seek` is called while the fetch is in progress, the fetched messages are still returned for processing with `consumer.run`.

To fix this, we can get pretty far by filtering the messages once again after the response of a fetch is received. By checking whether the topic and partition of a batch has a pending seek operation, we know to discard the messages.

Another situation is that a batch of messages might currently be processed. To get the behaviour we're after, we'll have to check for each message whether a seek operation is pending (similar to how you check whether we're still running). In the case of `eachMessage` we can do this for the user, for `eachBatch` we expose a `isStale` function (like `isRunning)`.