### PR TITLE
Include fetched offset metadata retrieved with admin.fetchOffsets

### DIFF
--- a/src/admin/__tests__/fetchOffsets.spec.js
+++ b/src/admin/__tests__/fetchOffsets.spec.js
@@ -43,7 +43,7 @@ describe('Admin', () => {
         topic: topicName,
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '-1' }])
+      expect(offsets).toEqual([{ partition: 0, offset: '-1', metadata: null }])
     })
 
     test('returns the current consumer group offset', async () => {
@@ -62,7 +62,7 @@ describe('Admin', () => {
         topic: topicName,
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '13' }])
+      expect(offsets).toEqual([{ partition: 0, offset: '13', metadata: null }])
     })
   })
 })

--- a/src/admin/__tests__/resetOffsets.spec.js
+++ b/src/admin/__tests__/resetOffsets.spec.js
@@ -56,7 +56,7 @@ describe('Admin', () => {
         topic: topicName,
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '-1' }])
+      expect(offsets).toEqual([{ partition: 0, offset: '-1', metadata: null }])
     })
 
     test('set the consumer group offsets to the earliest offsets', async () => {
@@ -81,7 +81,7 @@ describe('Admin', () => {
         topic: topicName,
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '-2' }])
+      expect(offsets).toEqual([{ partition: 0, offset: '-2', metadata: null }])
     })
 
     test('throws an error if the consumer group is runnig', async () => {

--- a/src/admin/__tests__/setOffsets.spec.js
+++ b/src/admin/__tests__/setOffsets.spec.js
@@ -58,7 +58,7 @@ describe('Admin', () => {
       })
 
       const offsets = await admin.fetchOffsets({ groupId, topic: topicName })
-      expect(offsets).toEqual([{ partition: 0, offset: '13' }])
+      expect(offsets).toEqual([{ partition: 0, offset: '13', metadata: null }])
     })
 
     test('throws an error if the consumer group is running', async () => {

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -251,7 +251,13 @@ module.exports = ({
 
     return responses
       .filter(response => response.topic === topic)
-      .map(({ partitions }) => partitions.map(({ partition, offset }) => ({ partition, offset })))
+      .map(({ partitions }) =>
+        partitions.map(({ partition, offset, metadata }) => ({
+          partition,
+          offset,
+          metadata: metadata || null,
+        }))
+      )
       .pop()
   }
 


### PR DESCRIPTION
Kafka supports a nullable string of `metadata` to be stored with a committed offset. KafkaJS actually supports this with it's protocol definitions, but `admin.fetchOffsets` filters it out just before returning the retrieved offsets to us. 