### PR TITLE
Allow offset metadata to be written as part of OffsetCommit requests

### DIFF
--- a/src/protocol/requests/offsetCommit/v0/request.js
+++ b/src/protocol/requests/offsetCommit/v0/request.js
@@ -25,9 +25,9 @@ const encodeTopic = ({ topic, partitions }) => {
   return new Encoder().writeString(topic).writeArray(partitions.map(encodePartition))
 }
 
-const encodePartition = ({ partition, offset }) => {
+const encodePartition = ({ partition, offset, metadata = null }) => {
   return new Encoder()
     .writeInt32(partition)
     .writeInt64(offset)
-    .writeString(null)
+    .writeString(metadata)
 }

--- a/src/protocol/requests/offsetCommit/v1/request.js
+++ b/src/protocol/requests/offsetCommit/v1/request.js
@@ -32,10 +32,10 @@ const encodeTopic = ({ topic, partitions }) => {
   return new Encoder().writeString(topic).writeArray(partitions.map(encodePartition))
 }
 
-const encodePartition = ({ partition, offset, timestamp = Date.now() }) => {
+const encodePartition = ({ partition, offset, timestamp = Date.now(), metadata = null }) => {
   return new Encoder()
     .writeInt32(partition)
     .writeInt64(offset)
     .writeInt64(timestamp)
-    .writeString(null)
+    .writeString(metadata)
 }

--- a/src/protocol/requests/offsetCommit/v2/request.js
+++ b/src/protocol/requests/offsetCommit/v2/request.js
@@ -33,9 +33,9 @@ const encodeTopic = ({ topic, partitions }) => {
   return new Encoder().writeString(topic).writeArray(partitions.map(encodePartition))
 }
 
-const encodePartition = ({ partition, offset }) => {
+const encodePartition = ({ partition, offset, metadata = null }) => {
   return new Encoder()
     .writeInt32(partition)
     .writeInt64(offset)
-    .writeString(null)
+    .writeString(metadata)
 }


### PR DESCRIPTION
Following #389, where we can retrieve the `nullable string` metadata with an offset, it would make a lot of sense if it could be written, too.