### PR TITLE
feat: allow sasl option to be provider function

### DIFF
--- a/src/broker/saslAuthenticator/index.js
+++ b/src/broker/saslAuthenticator/index.js
@@ -28,7 +28,12 @@ module.exports = class SASLAuthenticator {
   }
 
   async authenticate() {
-    const mechanism = this.connection.sasl.mechanism.toUpperCase()
+    let mechanism
+    if (typeof this.connection.sasl === 'function') {
+      mechanism = this.connection.sasl().mechanism.toUpperCase()
+    } else {
+      mechanism = this.connection.sasl.mechanism.toUpperCase()
+    }
     if (!SUPPORTED_MECHANISMS.includes(mechanism)) {
       throw new KafkaJSSASLAuthenticationError(
         `SASL ${mechanism} mechanism is not supported by the client`

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -1,4 +1,8 @@
-const { connectionOpts, sslConnectionOpts } = require('../../testHelpers')
+const {
+  connectionOpts,
+  sslConnectionOpts,
+  saslConnectionDynamicOpts,
+} = require('../../testHelpers')
 const sleep = require('../utils/sleep')
 const { requests } = require('../protocol/requests')
 const Decoder = require('../protocol/decoder')
@@ -61,6 +65,14 @@ describe('Network > Connection', () => {
         const message = 'Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line'
         await expect(connection.connect()).rejects.toHaveProperty('message', message)
         expect(connection.connected).toEqual(false)
+      })
+    })
+
+    describe('SASL with Provider', () => {
+      test('correctly handles a sasl provider function in place of object', async () => {
+        connection = new Connection(saslConnectionDynamicOpts())
+        await expect(connection.connect()).resolves.toEqual(true)
+        expect(connection.connected).toEqual(true)
       })
     })
   })

--- a/src/protocol/sasl/awsIam/request.js
+++ b/src/protocol/sasl/awsIam/request.js
@@ -2,10 +2,16 @@ const Encoder = require('../../encoder')
 
 const US_ASCII_NULL_CHAR = '\u0000'
 
-module.exports = ({ authorizationIdentity, accessKeyId, secretAccessKey, sessionToken = '' }) => ({
+module.exports = sasl => ({
   encode: async () => {
+    const props = typeof sasl === 'function' ? sasl() : sasl
     return new Encoder().writeBytes(
-      [authorizationIdentity, accessKeyId, secretAccessKey, sessionToken].join(US_ASCII_NULL_CHAR)
+      [
+        props.authorizationIdentity,
+        props.accessKeyId,
+        props.secretAccessKey,
+        props.sessionToken,
+      ].join(US_ASCII_NULL_CHAR)
     )
   },
 })

--- a/src/protocol/sasl/plain/request.js
+++ b/src/protocol/sasl/plain/request.js
@@ -19,10 +19,11 @@ const Encoder = require('../../encoder')
 
 const US_ASCII_NULL_CHAR = '\u0000'
 
-module.exports = ({ authorizationIdentity = null, username, password }) => ({
+module.exports = sasl => ({
   encode: async () => {
+    const props = typeof sasl === 'function' ? sasl() : sasl
     return new Encoder().writeBytes(
-      [authorizationIdentity, username, password].join(US_ASCII_NULL_CHAR)
+      [props.authorizationIdentity, props.username, props.password].join(US_ASCII_NULL_CHAR)
     )
   },
 })

--- a/src/protocol/sasl/scram/finalMessage/request.js
+++ b/src/protocol/sasl/scram/finalMessage/request.js
@@ -1,5 +1,8 @@
 const Encoder = require('../../../encoder')
 
-module.exports = ({ finalMessage }) => ({
-  encode: async () => new Encoder().writeBytes(finalMessage),
+module.exports = sasl => ({
+  encode: async () => {
+    const props = typeof sasl === 'function' ? sasl() : sasl
+    new Encoder().writeBytes(props.finalMessage)
+  },
 })

--- a/src/protocol/sasl/scram/firstMessage/request.js
+++ b/src/protocol/sasl/scram/firstMessage/request.js
@@ -17,6 +17,9 @@
 
 const Encoder = require('../../../encoder')
 
-module.exports = ({ clientFirstMessage }) => ({
-  encode: async () => new Encoder().writeBytes(clientFirstMessage),
+module.exports = sasl => ({
+  encode: async () => {
+    const props = typeof sasl === 'function' ? sasl() : sasl
+    new Encoder().writeBytes(props.clientFirstMessage)
+  },
 })

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -59,6 +59,17 @@ const saslConnectionOpts = () =>
     },
   })
 
+const saslConnectionDynamicOpts = () =>
+  Object.assign(saslConnectionOpts(), {
+    sasl: () => {
+      return {
+        mechanism: 'plain',
+        username: 'test',
+        password: 'testtest',
+      }
+    },
+  })
+
 const saslSCRAM256ConnectionOpts = () =>
   Object.assign(sslConnectionOpts(), {
     port: 9094,
@@ -224,6 +235,7 @@ module.exports = {
   connectionOpts,
   sslConnectionOpts,
   saslConnectionOpts,
+  saslConnectionDynamicOpts,
   saslSCRAM256ConnectionOpts,
   saslSCRAM512ConnectionOpts,
   createConnection,


### PR DESCRIPTION
fixes #423 

You may now use a function for the sasl property of Client
configuration, as long as it returns an object of the same format.

Note: I think there's probably a type definition in here somewhere that will need updating to allow this.