### PR TITLE
Add Consumer.commitOffsets

### DIFF
--- a/src/consumer/__tests__/commitOffsets.spec.js
+++ b/src/consumer/__tests__/commitOffsets.spec.js
@@ -1,0 +1,111 @@
+const createProducer = require('../../producer')
+const createConsumer = require('../index')
+const { KafkaJSNonRetriableError } = require('../../errors')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  createModPartitioner,
+  newLogger,
+  waitForMessages,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+
+describe('Consumer', () => {
+  let topicName, groupId, cluster, producer, consumer
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+
+    cluster = createCluster()
+    producer = createProducer({
+      cluster,
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    consumer && (await consumer.disconnect())
+    producer && (await producer.disconnect())
+  })
+
+  describe('when commitOffsets', () => {
+    it('throws an error if any of the topics is invalid', () => {
+      expect(() => consumer.commitOffsets([{ topic: null }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid topic null'
+      )
+    })
+
+    it('throws an error if anyof the partitions is not a number', () => {
+      expect(() => consumer.commitOffsets([{ topic: topicName, partition: 'ABC' }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid partition, expected a number received ABC'
+      )
+    })
+
+    it('throws an error if any of the offsets is not a number', () => {
+      expect(() =>
+        consumer.commitOffsets([{ topic: topicName, partition: 0, offset: 'ABC' }])
+      ).toThrow(KafkaJSNonRetriableError, 'Invalid offset, expected a long received ABC')
+    })
+
+    it('throws an error if any of the offsets is not an absolute offset', () => {
+      expect(() =>
+        consumer.commitOffsets([{ topic: topicName, partition: 0, offset: '-1' }])
+      ).toThrow(KafkaJSNonRetriableError, 'Offset must not be a negative number')
+    })
+
+    it('throws an error if called before consumer run', () => {
+      expect(() =>
+        consumer.commitOffsets([{ topic: topicName, partition: 0, offset: '1' }])
+      ).toThrow(
+        KafkaJSNonRetriableError,
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    })
+
+    it('updates the partition committed offset to the given offset', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key1 = secureRandom()
+      const message1 = { key: `key-${key1}`, value: `value-${key1}` }
+      const key2 = secureRandom()
+      const message2 = { key: `key-${key2}`, value: `value-${key2}` }
+      const key3 = secureRandom()
+      const message3 = { key: `key-${key3}`, value: `value-${key3}` }
+
+      await producer.send({ acks: 1, topic: topicName, messages: [message1, message2, message3] })
+
+      const messagesConsumed = []
+
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+      consumer.run({
+        autoCommit: false,
+        eachMessage: async event => {
+          messagesConsumed.push(event)
+          if (messagesConsumed.length >= 3) {
+            consumer.commitOffset([
+              { topic: topicName, partition: 0, offset: parseInt(event.offset) + 1 },
+            ])
+          }
+        },
+      })
+
+      await waitForConsumerToJoinGroup(consumer)
+      await waitForMessages(messagesConsumed, { number: 3 })
+    })
+  })
+})

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -287,6 +287,67 @@ module.exports = ({
   }
 
   /**
+   * @param {Array<TopicPartitionOffsetAndMetadata>} topicPartitions
+   *   Example: [{ topic: 'topic-name', partition: 0, offset: '1', metadata: 'event-id-3' }]
+   */
+  const commitOffsets = (topicPartitions = []) => {
+    const commitsByTopic = topicPartitions.reduce(
+      (payload, { topic, partition, offset, metadata = null }) => {
+        if (!topic) {
+          throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
+        }
+
+        if (isNaN(partition)) {
+          throw new KafkaJSNonRetriableError(
+            `Invalid partition, expected a number received ${partition}`
+          )
+        }
+
+        let commitOffset
+        try {
+          commitOffset = Long.fromValue(offset)
+        } catch (_) {
+          throw new KafkaJSNonRetriableError(`Invalid offset, expected a long received ${offset}`)
+        }
+
+        if (commitOffset.lessThan(0)) {
+          throw new KafkaJSNonRetriableError('Offset must not be a negative number')
+        }
+
+        if (metadata !== null && typeof metadata !== 'string') {
+          throw new KafkaJSNonRetriableError(
+            `Invalid offset metatadta, expected string or null, received ${metadata}`
+          )
+        }
+
+        const topicCommits = payload[topic] || []
+
+        topicCommits.push({ partition, offset: commitOffset, metadata })
+
+        return { ...payload, [topic]: topicCommits }
+      },
+      {}
+    )
+
+    if (!consumerGroup) {
+      throw new KafkaJSNonRetriableError(
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    }
+
+    const topics = Object.keyes(commitsByTopic)
+
+    return consumerGroup.commitOffsets({
+      topics: topics.map(topic => {
+        return {
+          topic,
+          partitions: commitsByTopic[topic],
+        }
+      }),
+    })
+  }
+
+  /**
    * @param {string} topic
    * @param {number} partition
    * @param {string} offset
@@ -429,6 +490,7 @@ module.exports = ({
     subscribe,
     stop,
     run,
+    commitOffsets,
     seek,
     describeGroup,
     pause,


### PR DESCRIPTION
Closes #378. 

> In various other clients, like the official KafkaConsumer, arbitrary offsets can be committed through an interface like consumer.commit. So far, the only way to do this in KafkaJS is through commitOffsetIfNecessary function exposed as part of the eachBatch mechanism.
> 
> This limitation prevents the committing of offsets before a message has been consumed, which is a time and place where in stream processing tasks it's desirable to do so. While in most cases a consumer.seek operation is desirable, there are situations where you just want to set the progress made and not consume any messages at all.


