### PR TITLE
Add way to commit offsets with Consumer

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -150,11 +150,44 @@ consumer.run({
 
 Having both flavors at the same time is also possible, the consumer will commit the offsets if any of the use cases (interval or number of messages) happens.
 
-`autoCommit`: Advanced option to disable auto committing altogether. If auto committing is disabled you must manually commit message offsets, either by using the `commitOffsetsIfNecessary` method available in the `eachBatch` callback, or by [sending message offsets in a transaction](Transactions.md#offsets). The `commitOffsetsIfNecessary` method will still respect the other autoCommit options if set. Default: `true`
+`autoCommit`: Advanced option to disable auto committing altogether. Instead, you can [manually commit offsets](#manual-commits). Default: `true`
+
+## <a name="manual-commits"></a> Manual committing
+
+When disabling [`autoCommit`](#auto-commit) you can still manually commit message offsets, in a couple of different ways:
+
+- By using the `commitOffsetsIfNecessary` method available in the `eachBatch` callback. The `commitOffsetsIfNecessary` method will still respect the other autoCommit options if set.
+- By [sending message offsets in a transaction](Transactions.md#offsets). 
+- By using [the `commitOffsets` method](#commit-offsets) of the consumer.
+
+The `consumer.commitOffsets` is the lowest-level option and will ignore all other auto commit settings, but in doing so allows the committed offset to be set to any offset and committing various offsets at once. This can be useful, for example, for building an processing reset tool. It can only be called after `consumer.run`. Committing offsets does not change what message we'll consume next once we've started consuming, but instead is only used to determine **from which place to start**. To immediately change from what offset you're consuming messages, you'll want to [seek](#seek), instead.
+
+```javascript
+consumer.run({
+    autoCommit: false,
+    eachMessage: async ({ topic, partition, message }) => {
+        // Process the message somehow
+    },
+})
+
+consumer.commitOffsets([
+  { topic: 'topic-A', partition: 0, offset: '1' },
+  { topic: 'topic-A', partition: 1, offset: '3' },
+  { topic: 'topic-B', partition: 0, offset: '2' }
+])
+```
+
+Note that you don't *have* to store consumed offsets in Kafka, but instead store it in a storage mechanism of your own choosing. That's an especially useful approach when the results of consuming a message is written to a datastore that allows atomically writing the consumed offset with it, like for example PostgreSQL. When possible it can make the consumption fully atomic and give "exactly once" semantics that are stronger than the default "at-least once" semantics you get with Kafka's offset commit functionality. 
+
+The usual usage pattern for offsets stored outside of Kafka is as follows:
+
+- Run the consumer with `autoCommit` disabled.
+- Store a message's `offset + 1` in the store together with the results of processing. `1` is added to prevent that same message from being consumed again.
+- Use the externally stored offset on restart to [seek](#seek) the consumer to it.
 
 ## <a name="from-beginning"></a> fromBeginning
 
-The consumer group will use the latest committed offset when fetching messages. If the offset is invalid or not defined, `fromBeginning` defines the behavior of the consumer group. This can be configured when subscribing to a topic:
+The consumer group will use the latest committed offset when starting to fetch messages. If the offset is invalid or not defined, `fromBeginning` defines the behavior of the consumer group. This can be configured when subscribing to a topic:
 
 ```javascript
 await consumer.subscribe({ topic: 'test-topic', fromBeginning: true })

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -158,7 +158,7 @@ When disabling [`autoCommit`](#auto-commit) you can still manually commit messag
 
 - By using the `commitOffsetsIfNecessary` method available in the `eachBatch` callback. The `commitOffsetsIfNecessary` method will still respect the other autoCommit options if set.
 - By [sending message offsets in a transaction](Transactions.md#offsets). 
-- By using [the `commitOffsets` method](#commit-offsets) of the consumer.
+- By using the `commitOffsets` method of the consumer (see below).
 
 The `consumer.commitOffsets` is the lowest-level option and will ignore all other auto commit settings, but in doing so allows the committed offset to be set to any offset and committing various offsets at once. This can be useful, for example, for building an processing reset tool. It can only be called after `consumer.run`. Committing offsets does not change what message we'll consume next once we've started consuming, but instead is only used to determine **from which place to start**. To immediately change from what offset you're consuming messages, you'll want to [seek](#seek), instead.
 
@@ -177,7 +177,7 @@ consumer.commitOffsets([
 ])
 ```
 
-Note that you don't *have* to store consumed offsets in Kafka, but instead store it in a storage mechanism of your own choosing. That's an especially useful approach when the results of consuming a message is written to a datastore that allows atomically writing the consumed offset with it, like for example PostgreSQL. When possible it can make the consumption fully atomic and give "exactly once" semantics that are stronger than the default "at-least once" semantics you get with Kafka's offset commit functionality. 
+Note that you don't *have* to store consumed offsets in Kafka, but instead store it in a storage mechanism of your own choosing. That's an especially useful approach when the results of consuming a message are written to a datastore that allows atomically writing the consumed offset with it, like for example a SQL database. When possible it can make the consumption fully atomic and give "exactly once" semantics that are stronger than the default "at-least once" semantics you get with Kafka's offset commit functionality. 
 
 The usual usage pattern for offsets stored outside of Kafka is as follows:
 

--- a/src/consumer/__tests__/commitOffsets.spec.js
+++ b/src/consumer/__tests__/commitOffsets.spec.js
@@ -1,0 +1,111 @@
+const createProducer = require('../../producer')
+const createConsumer = require('../index')
+const { KafkaJSNonRetriableError } = require('../../errors')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  createModPartitioner,
+  newLogger,
+  waitForMessages,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+
+describe('Consumer', () => {
+  let topicName, groupId, cluster, producer, consumer
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+
+    cluster = createCluster()
+    producer = createProducer({
+      cluster,
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    consumer && (await consumer.disconnect())
+    producer && (await producer.disconnect())
+  })
+
+  describe('when commitOffsets', () => {
+    it('throws an error if any of the topics is invalid', () => {
+      expect(() => consumer.commitOffsets([{ topic: null }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid topic null'
+      )
+    })
+
+    it('throws an error if anyof the partitions is not a number', () => {
+      expect(() => consumer.commitOffsets([{ topic: topicName, partition: 'ABC' }])).toThrow(
+        KafkaJSNonRetriableError,
+        'Invalid partition, expected a number received ABC'
+      )
+    })
+
+    it('throws an error if any of the offsets is not a number', () => {
+      expect(() =>
+        consumer.commitOffsets([{ topic: topicName, partition: 0, offset: 'ABC' }])
+      ).toThrow(KafkaJSNonRetriableError, 'Invalid offset, expected a long received ABC')
+    })
+
+    it('throws an error if any of the offsets is not an absolute offset', () => {
+      expect(() =>
+        consumer.commitOffsets([{ topic: topicName, partition: 0, offset: '-1' }])
+      ).toThrow(KafkaJSNonRetriableError, 'Offset must not be a negative number')
+    })
+
+    it('throws an error if called before consumer run', () => {
+      expect(() =>
+        consumer.commitOffsets([{ topic: topicName, partition: 0, offset: '1' }])
+      ).toThrow(
+        KafkaJSNonRetriableError,
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    })
+
+    it('updates the partition committed offset to the given offset', async () => {
+      await consumer.connect()
+      await producer.connect()
+
+      const key1 = secureRandom()
+      const message1 = { key: `key-${key1}`, value: `value-${key1}` }
+      const key2 = secureRandom()
+      const message2 = { key: `key-${key2}`, value: `value-${key2}` }
+      const key3 = secureRandom()
+      const message3 = { key: `key-${key3}`, value: `value-${key3}` }
+
+      await producer.send({ acks: 1, topic: topicName, messages: [message1, message2, message3] })
+
+      const messagesConsumed = []
+
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+      consumer.run({
+        autoCommit: false,
+        eachMessage: async event => {
+          messagesConsumed.push(event)
+          if (messagesConsumed.length >= 3) {
+            consumer.commitOffset([
+              { topic: topicName, partition: 0, offset: parseInt(event.offset) + 1 },
+            ])
+          }
+        },
+      })
+
+      await waitForConsumerToJoinGroup(consumer)
+      await waitForMessages(messagesConsumed, { number: 3 })
+    })
+  })
+})

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -290,7 +290,7 @@ module.exports = ({
    * @param {Array<TopicPartitionOffsetAndMetadata>} topicPartitions
    *   Example: [{ topic: 'topic-name', partition: 0, offset: '1', metadata: 'event-id-3' }]
    */
-  const commitOffsets = (topicPartitions = []) => {
+  const commitOffsets = async (topicPartitions = []) => {
     const commitsByTopic = topicPartitions.reduce(
       (payload, { topic, partition, offset, metadata = null }) => {
         if (!topic) {
@@ -335,7 +335,7 @@ module.exports = ({
       )
     }
 
-    const topics = Object.keyes(commitsByTopic)
+    const topics = Object.keys(commitsByTopic)
 
     return consumerGroup.commitOffsets({
       topics: topics.map(topic => {

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -337,7 +337,7 @@ module.exports = ({
 
     const topics = Object.keys(commitsByTopic)
 
-    return consumerGroup.commitOffsets({
+    return runner.commitOffsets({
       topics: topics.map(topic => {
         return {
           topic,

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -287,6 +287,67 @@ module.exports = ({
   }
 
   /**
+   * @param {Array<TopicPartitionOffsetAndMetadata>} topicPartitions
+   *   Example: [{ topic: 'topic-name', partition: 0, offset: '1', metadata: 'event-id-3' }]
+   */
+  const commitOffsets = (topicPartitions = []) => {
+    const commitsByTopic = topicPartitions.reduce(
+      (payload, { topic, partition, offset, metadata = null }) => {
+        if (!topic) {
+          throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
+        }
+
+        if (isNaN(partition)) {
+          throw new KafkaJSNonRetriableError(
+            `Invalid partition, expected a number received ${partition}`
+          )
+        }
+
+        let commitOffset
+        try {
+          commitOffset = Long.fromValue(offset)
+        } catch (_) {
+          throw new KafkaJSNonRetriableError(`Invalid offset, expected a long received ${offset}`)
+        }
+
+        if (commitOffset.lessThan(0)) {
+          throw new KafkaJSNonRetriableError('Offset must not be a negative number')
+        }
+
+        if (metadata !== null && typeof metadata !== 'string') {
+          throw new KafkaJSNonRetriableError(
+            `Invalid offset metatadta, expected string or null, received ${metadata}`
+          )
+        }
+
+        const topicCommits = payload[topic] || []
+
+        topicCommits.push({ partition, offset: commitOffset, metadata })
+
+        return { ...payload, [topic]: topicCommits }
+      },
+      {}
+    )
+
+    if (!consumerGroup) {
+      throw new KafkaJSNonRetriableError(
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    }
+
+    const topics = Object.keyes(commitsByTopic)
+
+    return consumerGroup.commitOffsets({
+      topics: topics.map(topic => {
+        return {
+          topic,
+          partitions: commitsByTopic[topic],
+        }
+      }),
+    })
+  }
+
+  /**
    * @param {string} topic
    * @param {number} partition
    * @param {string} offset
@@ -429,6 +490,7 @@ module.exports = ({
     subscribe,
     stop,
     run,
+    commitOffsets,
     seek,
     describeGroup,
     pause,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -493,6 +493,12 @@ export type GroupDescription = {
 }
 
 export type TopicPartitions = { topic: string; partitions: number[] }
+export type TopicPartitionOffsetAndMedata = {
+  topic: string
+  partition: number
+  offset: string
+  metadata?: string | null
+}
 
 export type Batch = {
   topic: string
@@ -619,6 +625,7 @@ export type Consumer = {
     eachBatch?: (payload: EachBatchPayload) => Promise<void>
     eachMessage?: (payload: EachMessagePayload) => Promise<void>
   }): Promise<void>
+  commitOffsets(topicPartitions: Array<TopicPartitionOffsetAndMedata>): Promise<void>
   seek(topicPartition: { topic: string; partition: number; offset: string }): void
   describeGroup(): Promise<GroupDescription>
   pause(topics: Array<{ topic: string; partitions?: number[] }>): void

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -64,6 +64,13 @@ const runConsumer = async () => {
   consumer.pause([{ topic: 'topic2', partitions: [1, 2] }])
   consumer.resume([{ topic: 'topic1' }])
   consumer.resume([{ topic: 'topic1', partitions: [2] }])
+  await consumer.commitOffsets([{ topic: 'topic-name', partition: 0, offset: '500' }])
+  await consumer.commitOffsets([
+    { topic: 'topic-name', partition: 0, offset: '501', metadata: null },
+  ])
+  await consumer.commitOffsets([
+    { topic: 'topic-name', partition: 0, offset: '501', metadata: 'some-metadata' },
+  ])
   await consumer.disconnect()
 }
 


### PR DESCRIPTION
Closes #378. 

> In various other clients, like the official KafkaConsumer, arbitrary offsets can be committed through an interface like consumer.commit. So far, the only way to do this in KafkaJS is through commitOffsetIfNecessary function exposed as part of the eachBatch mechanism.
> 
> This limitation prevents the committing of offsets before a message has been consumed, which is a time and place where in stream processing tasks it's desirable to do so. While in most cases a consumer.seek operation is desirable, there are situations where you just want to set the progress made and not consume any messages at all.


