### PR TITLE
Expose consumer paused partitions

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -157,7 +157,7 @@ Having both flavors at the same time is also possible, the consumer will commit 
 When disabling [`autoCommit`](#auto-commit) you can still manually commit message offsets, in a couple of different ways:
 
 - By using the `commitOffsetsIfNecessary` method available in the `eachBatch` callback. The `commitOffsetsIfNecessary` method will still respect the other autoCommit options if set.
-- By [sending message offsets in a transaction](Transactions.md#offsets). 
+- By [sending message offsets in a transaction](Transactions.md#offsets).
 - By using the `commitOffsets` method of the consumer (see below).
 
 The `consumer.commitOffsets` is the lowest-level option and will ignore all other auto commit settings, but in doing so allows the committed offset to be set to any offset and committing various offsets at once. This can be useful, for example, for building an processing reset tool. It can only be called after `consumer.run`. Committing offsets does not change what message we'll consume next once we've started consuming, but instead is only used to determine **from which place to start**. To immediately change from what offset you're consuming messages, you'll want to [seek](#seek), instead.
@@ -177,7 +177,7 @@ consumer.commitOffsets([
 ])
 ```
 
-Note that you don't *have* to store consumed offsets in Kafka, but instead store it in a storage mechanism of your own choosing. That's an especially useful approach when the results of consuming a message are written to a datastore that allows atomically writing the consumed offset with it, like for example a SQL database. When possible it can make the consumption fully atomic and give "exactly once" semantics that are stronger than the default "at-least once" semantics you get with Kafka's offset commit functionality. 
+Note that you don't *have* to store consumed offsets in Kafka, but instead store it in a storage mechanism of your own choosing. That's an especially useful approach when the results of consuming a message are written to a datastore that allows atomically writing the consumed offset with it, like for example a SQL database. When possible it can make the consumption fully atomic and give "exactly once" semantics that are stronger than the default "at-least once" semantics you get with Kafka's offset commit functionality.
 
 The usual usage pattern for offsets stored outside of Kafka is as follows:
 
@@ -232,7 +232,7 @@ kafka.consumer({
 
 ## <a name="pause-resume"></a> Pause & Resume
 
-In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`. Note that pausing a topic means that it won't be fetched in the next cycle. You may still receive messages for the topic within the current batch.
+In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`. It also provides the `paused` method to get the list of all paused topics. Note that pausing a topic means that it won't be fetched in the next cycle. You may still receive messages for the topic within the current batch.
 
 Calling `pause` with a topic that the consumer is not subscribed to is a no-op, calling `resume` with a topic that is not paused is also a no-op.
 
@@ -256,7 +256,7 @@ await consumer.run({ eachMessage: async ({ topic, message }) => {
 }})
 ```
 
-For finer-grained control, specific partitions of topics can also be paused, rather than the whole topic. The ability to pause and resume on a per-partition basis, means it can be used to isolate the consuming (and processing) of messages. 
+For finer-grained control, specific partitions of topics can also be paused, rather than the whole topic. The ability to pause and resume on a per-partition basis, means it can be used to isolate the consuming (and processing) of messages.
 
 Example: in combination with [consuming messages per partition concurrently](#concurrent-processing), it can prevent having to stop processing all partitions because of a slow process in one of the other partitions.
 
@@ -270,7 +270,7 @@ consumer.run({
         } catch (e) {
             if (e instanceof TooManyRequestsError) {
                 consumer.pause([{ topic, partitions: [partition] }])
-                // Other partitions will keep fetching and processing, until if / when 
+                // Other partitions will keep fetching and processing, until if / when
                 // they also get throttled
                 setTimeout(() => {
                     consumer.resume([{ topic, partitions: [partition] }])
@@ -282,6 +282,17 @@ consumer.run({
         }
     },
 })
+```
+
+It's possible to access the list of paused topic partitions using the `paused` method.
+
+```javascript
+const pausedTopicPartitions = consumer.paused()
+
+for (const topicPartitions of pausedTopicPartitions) {
+  const { topic, partitions } = topicPartitions
+  console.log({ topic, partitions })
+}
 ```
 
 ## <a name="seek"></a> Seek

--- a/src/consumer/__tests__/pause.spec.js
+++ b/src/consumer/__tests__/pause.spec.js
@@ -43,6 +43,12 @@ describe('Consumer', () => {
     producer && (await producer.disconnect())
   })
 
+  describe('#paused', () => {
+    it('returns an empty array if consumer#run has not been called', () => {
+      expect(consumer.paused()).toEqual([])
+    })
+  })
+
   describe('when pausing', () => {
     it('throws an error if the topic is invalid', () => {
       expect(() => consumer.pause([{ topic: null, partitions: [0] }])).toThrow(
@@ -78,6 +84,7 @@ describe('Consumer', () => {
       await waitForConsumerToJoinGroup(consumer)
       await waitForMessages(messagesConsumed, { number: 2 })
 
+      expect(consumer.paused()).toEqual([])
       const [pausedTopic, activeTopic] = topics
       consumer.pause([{ topic: pausedTopic }])
 
@@ -110,6 +117,13 @@ describe('Consumer', () => {
           message: expect.objectContaining({ offset: '0' }),
         },
       ])
+
+      expect(consumer.paused()).toEqual([
+        {
+          topic: pausedTopic,
+          partitions: [0, 1],
+        },
+      ])
     })
 
     it('does not fetch messages for the paused partitions', async () => {
@@ -138,6 +152,7 @@ describe('Consumer', () => {
       await waitForConsumerToJoinGroup(consumer)
       await waitForMessages(messagesConsumed, { number: messages.length * partitions.length })
 
+      expect(consumer.paused()).toEqual([])
       const [pausedPartition, activePartition] = partitions
       consumer.pause([{ topic, partitions: [pausedPartition] }])
 
@@ -164,6 +179,13 @@ describe('Consumer', () => {
           message: expect.objectContaining({ offset: `${i}` }),
         }))
       )
+
+      expect(consumer.paused()).toEqual([
+        {
+          topic,
+          partitions: [pausedPartition],
+        },
+      ])
     })
   })
 
@@ -255,6 +277,8 @@ describe('Consumer', () => {
           message: expect.objectContaining({ offset: '0' }),
         },
       ])
+
+      expect(consumer.paused()).toEqual([])
     })
 
     it('resumes fetching from earlier paused partitions', async () => {
@@ -315,6 +339,8 @@ describe('Consumer', () => {
           message: expect.objectContaining({ offset: `${i}` }),
         }))
       )
+
+      expect(consumer.paused()).toEqual([])
     })
   })
 })

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -443,6 +443,19 @@ module.exports = ({
   }
 
   /**
+   * Returns the list of topic partitions paused on this consumer
+   *
+   * @returns {Array<TopicPartitions>}
+   */
+  const paused = () => {
+    if (!consumerGroup) {
+      return []
+    }
+
+    return consumerGroup.paused()
+  }
+
+  /**
    * @param {Array<TopicPartitions>} topicPartitions
    *  Example: [{ topic: 'topic-name', partitions: [1, 2] }]
    *
@@ -490,6 +503,7 @@ module.exports = ({
     seek,
     describeGroup,
     pause,
+    paused,
     resume,
     on,
     events,

--- a/src/consumer/subscriptionState.js
+++ b/src/consumer/subscriptionState.js
@@ -94,13 +94,16 @@ module.exports = class SubscriptionState {
   }
 
   /**
-   * @returns {Array<TopicPartitions>} topicPartitions Example: [{ topic: 'topic-name', partitions: [1, 2] }]
+   * @returns {Array<TopicPartitions>} topicPartitions
+   * Example: [{ topic: 'topic-name', partitions: [1, 2] }]
    */
   paused() {
-    return Object.values(this.assignedPartitionsByTopic).map(({ topic, partitions }) => ({
-      topic,
-      partitions: partitions.filter(partition => this.isPaused(topic, partition)),
-    }))
+    return Object.values(this.assignedPartitionsByTopic)
+      .map(({ topic, partitions }) => ({
+        topic,
+        partitions: partitions.filter(partition => this.isPaused(topic, partition)).sort(),
+      }))
+      .filter(({ partitions }) => partitions.length !== 0)
   }
 
   isPaused(topic, partition) {

--- a/src/consumer/subscriptionState.js
+++ b/src/consumer/subscriptionState.js
@@ -74,22 +74,24 @@ module.exports = class SubscriptionState {
   }
 
   /**
-   * @returns {Array<TopicPartitions>} topicPartitions Example: [{ topic: 'topic-name', partitions: [1, 2] }]
+   * @returns {Array<TopicPartitions>} topicPartitions
+   * Example: [{ topic: 'topic-name', partitions: [1, 2] }]
    */
   assigned() {
     return Object.values(this.assignedPartitionsByTopic).map(({ topic, partitions }) => ({
       topic,
-      partitions,
+      partitions: partitions.sort(),
     }))
   }
 
   /**
-   * @returns {Array<TopicPartitions>} topicPartitions Example: [{ topic: 'topic-name', partitions: [1, 2] }]
+   * @returns {Array<TopicPartitions>} topicPartitions
+   * Example: [{ topic: 'topic-name', partitions: [1, 2] }]
    */
   active() {
     return Object.values(this.assignedPartitionsByTopic).map(({ topic, partitions }) => ({
       topic,
-      partitions: partitions.filter(partition => !this.isPaused(topic, partition)),
+      partitions: partitions.filter(partition => !this.isPaused(topic, partition)).sort(),
     }))
   }
 

--- a/src/consumer/subscriptionState.spec.js
+++ b/src/consumer/subscriptionState.spec.js
@@ -32,7 +32,6 @@ describe('Consumer > SubscriptionState > pause / resume', () => {
 
     expect(subscriptionState.paused().sort(byTopic)).toEqual([
       { topic: 'topic1', partitions: [0, 1] },
-      { topic: 'topic2', partitions: [] },
     ])
   })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -629,6 +629,7 @@ export type Consumer = {
   seek(topicPartition: { topic: string; partition: number; offset: string }): void
   describeGroup(): Promise<GroupDescription>
   pause(topics: Array<{ topic: string; partitions?: number[] }>): void
+  paused(): TopicPartitions[]
   resume(topics: Array<{ topic: string; partitions?: number[] }>): void
   on(eventName: ValueOf<ConsumerEvents>, listener: (...args: any[]) => void): void
   logger(): Logger

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -60,10 +60,18 @@ const runConsumer = async () => {
       console.log(`- ${prefix} ${message.key}#${message.value}`)
     },
   })
+
   consumer.pause([{ topic: 'topic1' }])
   consumer.pause([{ topic: 'topic2', partitions: [1, 2] }])
+
   consumer.resume([{ topic: 'topic1' }])
   consumer.resume([{ topic: 'topic1', partitions: [2] }])
+
+  consumer.paused()
+  consumer.paused().length
+  consumer.paused()[0].topic
+  consumer.paused()[0].partitions
+
   await consumer.commitOffsets([{ topic: 'topic-name', partition: 0, offset: '500' }])
   await consumer.commitOffsets([
     { topic: 'topic-name', partition: 0, offset: '501', metadata: null },


### PR DESCRIPTION
I made a small change to the subscription state, @JaapRood can you take a look? I am filtering out paused topics without active partitions on the consumer. The method will always return an empty array if the consumer group isn't initialized, I think it makes more sense than throwing the error on this case.

CC @terebentina