### PR TITLE
fix built-in partitioners type definition error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -65,8 +65,8 @@ export interface PartitionerArgs {
 }
 
 export type ICustomPartitioner = () => (args: PartitionerArgs) => number
-export type DefaultPartitioner = (args: PartitionerArgs) => number
-export type JavaCompatiblePartitioner = (args: PartitionerArgs) => number
+export type DefaultPartitioner = ICustomPartitioner
+export type JavaCompatiblePartitioner = ICustomPartitioner
 
 export const Partitioners: {
   DefaultPartitioner: DefaultPartitioner


### PR DESCRIPTION
```ts
export type ICustomPartitioner = () => (args: PartitionerArgs) => number
export type DefaultPartitioner = (args: PartitionerArgs) => number
export type JavaCompatiblePartitioner = (args: PartitionerArgs) => number
```

`DefaultPartitioner` and `JavaCompatiblePartitioner` are, in fact, `ICustomPartitioner`s.