### PR TITLE
make NodeJS REPL get correct randomBytes()

### DIFF
--- a/src/producer/partitioners/default/randomBytes.js
+++ b/src/producer/partitioners/default/randomBytes.js
@@ -6,7 +6,8 @@ const toNodeCompatible = crypto => ({
 
 let cryptoImplementation = null
 if (global && global.crypto) {
-  cryptoImplementation = toNodeCompatible(global.crypto)
+  cryptoImplementation =
+    global.crypto.randomBytes === undefined ? toNodeCompatible(global.crypto) : global.crypto
 } else if (global && global.msCrypto) {
   cryptoImplementation = toNodeCompatible(global.msCrypto)
 } else if (global && !global.crypto) {


### PR DESCRIPTION
NodeJS REPL imports crypto by default, this breaks the original logic.