### PR TITLE
bug(types) IHeaders interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -82,7 +82,7 @@ export type PartitionMetadata = {
 }
 
 export interface IHeaders {
-  [key: string]: string
+  [key: string]: Buffer
 }
 
 export interface ConsumerConfig {


### PR DESCRIPTION
The existing IHeaders interface defined the property values as a string when they are actually buffers.

```
{ topic: 'math.sum',
  partition: 0,
  message:
   { magicByte: 2,
     attributes: 0,
     timestamp: '1565801225655',
     offset: '10',
     key:
      <Buffer 32 61 62 63 39 34 65 31 2d 30 65 66 34 2d 34 33 36 34 2d 39 38 63 66 2d 31 34 34 66 37 63 64 32 39 38 66 39>,
     value: <Buffer 31>,
     headers:
      { 'correlation-id':
         <Buffer 32 61 62 63 39 34 65 31 2d 30 65 66 34 2d 34 33 36 34 2d 39 38 63 66 2d 31 34 34 66 37 63 64 32 39 38 66 39> },
     isControlRecord: false,
     batchContext:
      { firstOffset: '10',
        firstTimestamp: '1565801225655',
        partitionLeaderEpoch: 0,
        inTransaction: false,
        isControlBatch: false,
        lastOffsetDelta: 4,
        producerId: '-1',
        producerEpoch: 0,
        firstSequence: 0,
        maxTimestamp: '1565801225655',
        magicByte: 2 } } }
```