### PR TITLE
Prevent changes in the subscriptions for running consumers

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -145,12 +145,12 @@ module.exports = ({
    * @return {Promise}
    */
   const subscribe = async ({ topic, fromBeginning = false }) => {
-    if (!topic) {
-      throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
+    if (consumerGroup) {
+      throw new KafkaJSNonRetriableError('Cannot subscribe to topic while consumer is running')
     }
 
-    if (consumerGroup) {
-      throw new KafkaJSNonRetriableError(`Cannot change subscription for running consumer`)
+    if (!topic) {
+      throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
     }
 
     const isRegExp = topic instanceof RegExp

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -149,6 +149,10 @@ module.exports = ({
       throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
     }
 
+    if (consumerGroup) {
+      throw new KafkaJSNonRetriableError(`Cannot change subscription for running consumer`)
+    }
+
     const isRegExp = topic instanceof RegExp
     if (typeof topic !== 'string' && !isRegExp) {
       throw new KafkaJSNonRetriableError(


### PR DESCRIPTION
Such changes would be ignored by the consumer, so we better fail very on.

---
This is mainly to avoid frustration for users, an issue for being able to change the subscriptions for a running consumer will come as well