### PR TITLE
Avoid copying the (potentially large) rest of the decoder buffer

### DIFF
--- a/src/protocol/decoder.js
+++ b/src/protocol/decoder.js
@@ -117,11 +117,9 @@ module.exports = class Decoder {
   }
 
   readAll() {
-    const currentSize = Buffer.byteLength(this.buffer)
-    const remainingBytes = currentSize - this.offset
-    const newBuffer = Buffer.alloc(remainingBytes)
-    this.buffer.copy(newBuffer, 0, this.offset, currentSize)
-    return newBuffer
+    const result = this.buffer.slice(this.offset)
+    this.offset += Buffer.byteLength(this.buffer)
+    return result
   }
 
   readArray(reader) {


### PR DESCRIPTION
This aligns 'readAll' with other 'read' methods, which do not produce a copy unless needed.
This avoids a couple of likely very expensive copy operations in the network receive path.

Signed-off-by: Andreas Kohn <andreas.kohn@gmail.com>