### PR TITLE
Add `consumer.heartbeat()`

### DIFF
--- a/src/consumer/__tests__/consumerHeartbeat.spec.js
+++ b/src/consumer/__tests__/consumerHeartbeat.spec.js
@@ -1,0 +1,65 @@
+const createConsumer = require('../index')
+const { KafkaJSNonRetriableError } = require('../../errors')
+const sleep = require('../../utils/sleep')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  newLogger,
+  waitFor,
+  waitForMessages,
+  waitForNextEvent,
+  testIfKafka_0_11,
+  waitForConsumerToJoinGroup,
+  generateMessages,
+} = require('testHelpers')
+
+describe('Consumer > Heartbeat', () => {
+  let topicName, groupId, cluster, consumer
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    // await createTopic({ topic: topicName })
+
+    cluster = createCluster()
+
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      maxWaitTimeInMs: 100,
+      heartbeatInterval: 0,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    await consumer.disconnect()
+  })
+
+  it('throws an error if the consumer group is not initialized', async () => {
+    await expect(consumer.heartbeat()).rejects.toEqual(
+      new KafkaJSNonRetriableError(
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    )
+  })
+
+  it('heartbeats when called', async () => {
+    const onHeartbeat = jest.fn()
+    consumer.on(consumer.events.HEARTBEAT, onHeartbeat)
+
+    await consumer.connect()
+    consumer.run({
+      eachMessage: async () => {
+        await sleep(10000)
+      },
+    })
+    await waitForConsumerToJoinGroup(consumer)
+    expect(onHeartbeat).not.toHaveBeenCalled()
+
+    await consumer.heartbeat()
+    expect(onHeartbeat).toHaveBeenCalled()
+  })
+})

--- a/src/consumer/__tests__/consumerHeartbeat.spec.js
+++ b/src/consumer/__tests__/consumerHeartbeat.spec.js
@@ -5,29 +5,18 @@ const sleep = require('../../utils/sleep')
 const {
   secureRandom,
   createCluster,
-  createTopic,
   newLogger,
-  waitFor,
-  waitForMessages,
-  waitForNextEvent,
-  testIfKafka_0_11,
   waitForConsumerToJoinGroup,
-  generateMessages,
 } = require('testHelpers')
 
 describe('Consumer > Heartbeat', () => {
-  let topicName, groupId, cluster, consumer
+  let consumer
   beforeEach(async () => {
-    topicName = `test-topic-${secureRandom()}`
-    groupId = `consumer-group-id-${secureRandom()}`
-
-    // await createTopic({ topic: topicName })
-
-    cluster = createCluster()
+    const cluster = createCluster()
 
     consumer = createConsumer({
       cluster,
-      groupId,
+      groupId: `consumer-group-id-${secureRandom()}`,
       maxWaitTimeInMs: 100,
       heartbeatInterval: 0,
       logger: newLogger(),

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -351,7 +351,9 @@ module.exports = class ConsumerGroup {
       await this.offsetManager.resolveOffsets()
 
       this.logger.debug(
-        `Fetching from ${activePartitions.length} partitions for ${activeTopics.length} out of ${topics.length} topics`,
+        `Fetching from ${activePartitions.length} partitions for ${activeTopics.length} out of ${
+          topics.length
+        } topics`,
         {
           topics,
           activeTopicPartitions,

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -351,9 +351,7 @@ module.exports = class ConsumerGroup {
       await this.offsetManager.resolveOffsets()
 
       this.logger.debug(
-        `Fetching from ${activePartitions.length} partitions for ${activeTopics.length} out of ${
-          topics.length
-        } topics`,
+        `Fetching from ${activePartitions.length} partitions for ${activeTopics.length} out of ${topics.length} topics`,
         {
           topics,
           activeTopicPartitions,

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -441,9 +441,7 @@ module.exports = ({
         (!Array.isArray(topicPartition.partitions) || topicPartition.partitions.some(isNaN))
       ) {
         throw new KafkaJSNonRetriableError(
-          `Array of valid partitions required to pause specific partitions instead of ${
-            topicPartition.partitions
-          }`
+          `Array of valid partitions required to pause specific partitions instead of ${topicPartition.partitions}`
         )
       }
     }
@@ -489,9 +487,7 @@ module.exports = ({
         (!Array.isArray(topicPartition.partitions) || topicPartition.partitions.some(isNaN))
       ) {
         throw new KafkaJSNonRetriableError(
-          `Array of valid partitions required to resume specific partitions instead of ${
-            topicPartition.partitions
-          }`
+          `Array of valid partitions required to resume specific partitions instead of ${topicPartition.partitions}`
         )
       }
     }

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -287,6 +287,19 @@ module.exports = ({
   }
 
   /**
+   * @returns Promise
+   */
+  const heartbeat = async () => {
+    if (!consumerGroup) {
+      throw new KafkaJSNonRetriableError(
+        'Consumer group was not initialized, consumer#run must be called first'
+      )
+    }
+
+    return runner.heartbeat()
+  }
+
+  /**
    * @param {Array<TopicPartitionOffsetAndMetadata>} topicPartitions
    *   Example: [{ topic: 'topic-name', partition: 0, offset: '1', metadata: 'event-id-3' }]
    */
@@ -428,7 +441,9 @@ module.exports = ({
         (!Array.isArray(topicPartition.partitions) || topicPartition.partitions.some(isNaN))
       ) {
         throw new KafkaJSNonRetriableError(
-          `Array of valid partitions required to pause specific partitions instead of ${topicPartition.partitions}`
+          `Array of valid partitions required to pause specific partitions instead of ${
+            topicPartition.partitions
+          }`
         )
       }
     }
@@ -474,7 +489,9 @@ module.exports = ({
         (!Array.isArray(topicPartition.partitions) || topicPartition.partitions.some(isNaN))
       ) {
         throw new KafkaJSNonRetriableError(
-          `Array of valid partitions required to resume specific partitions instead of ${topicPartition.partitions}`
+          `Array of valid partitions required to resume specific partitions instead of ${
+            topicPartition.partitions
+          }`
         )
       }
     }
@@ -499,6 +516,7 @@ module.exports = ({
     subscribe,
     stop,
     run,
+    heartbeat,
     commitOffsets,
     seek,
     describeGroup,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -625,6 +625,7 @@ export type Consumer = {
     eachBatch?: (payload: EachBatchPayload) => Promise<void>
     eachMessage?: (payload: EachMessagePayload) => Promise<void>
   }): Promise<void>
+  heartbeat(): Promise<void>
   commitOffsets(topicPartitions: Array<TopicPartitionOffsetAndMedata>): Promise<void>
   seek(topicPartition: { topic: string; partition: number; offset: string }): void
   describeGroup(): Promise<GroupDescription>

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -56,6 +56,7 @@ const runConsumer = async () => {
       console.log(batch.offsetLagLow())
     },
     eachMessage: async ({ topic, partition, message }) => {
+      await consumer.heartbeat()
       const prefix = `${topic}[${partition} | ${message.offset}] / ${message.timestamp}`
       console.log(`- ${prefix} ${message.key}#${message.value}`)
     },


### PR DESCRIPTION
Fixes #387

I was looking into how to implement rate limiting if using the `eachMessage` interface and realized that there needs to be a way to heartbeat manually. Seems we have the same need in #387, so I took a punt at implementing it.