### PR TITLE
types: Improve definition of SASLOptions by adding a SASLMechanism type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,8 +33,10 @@ export type ISocketFactory = (
   onConnect: () => void
 ) => net.Socket
 
+export type SASLMechanism = 'plain' | 'scram-sha-256' | 'scram-sha-512' | 'aws'
+
 export interface SASLOptions {
-  mechanism: 'plain' | 'scram-sha-256' | 'scram-sha-512' | 'aws'
+  mechanism: SASLMechanism
   username: string
   password: string
 }


### PR DESCRIPTION
Previously if you tried to assign an environment variable to the mechanism option, then you'd get a typescript error of "cannot assign string to 'plain' | 'scram-sha-256' | 'scram-sha-512' | 'aws'" and the only workaround was to declare a type which copied the string union.