### PR TITLE
Remove normalisation of the password when using SCRAM auth

### DIFF
--- a/scripts/createScramCredentials.sh
+++ b/scripts/createScramCredentials.sh
@@ -10,8 +10,8 @@ find_container_id() {
 }
 
 USERNAME=${USERNAME:='testscram'}
-PASSWORD_256=${PASSWORD_256:='testtestscram256'}
-PASSWORD_512=${PASSWORD_512:='testtestscram512'}
+PASSWORD_256=${PASSWORD_256:='testtestscram=256'}
+PASSWORD_512=${PASSWORD_512:='testtestscram=512'}
 
 docker exec \
   $(find_container_id) \

--- a/src/broker/saslAuthenticator/scram.js
+++ b/src/broker/saslAuthenticator/scram.js
@@ -296,7 +296,7 @@ class SCRAM {
    */
   encodedPassword() {
     const { password } = this.connection.sasl
-    return SCRAM.sanitizeString(password).toString('utf-8')
+    return password.toString('utf-8')
   }
 
   /**

--- a/testHelpers/index.js
+++ b/testHelpers/index.js
@@ -65,7 +65,7 @@ const saslSCRAM256ConnectionOpts = () =>
     sasl: {
       mechanism: 'scram-sha-256',
       username: 'testscram',
-      password: 'testtestscram256',
+      password: 'testtestscram=256',
     },
   })
 
@@ -75,7 +75,7 @@ const saslSCRAM512ConnectionOpts = () =>
     sasl: {
       mechanism: 'scram-sha-512',
       username: 'testscram',
-      password: 'testtestscram512',
+      password: 'testtestscram=512',
     },
   })
 


### PR DESCRIPTION
KafkaJS was incorrectly normalised the SCRAM password, resulting in `,` and `=` characters being encoded causing authentication failures.

According to the cited RFC in the source code (https://tools.ietf.org/html/rfc5802#section-5.1), just the username needs to be normalised.

Closes #506 