### PR TITLE
Skip control records without auto-resolve

### DIFF
--- a/docs/Transactions.md
+++ b/docs/Transactions.md
@@ -30,7 +30,7 @@ const producer = client.producer({ maxInFlightRequests: 1, idempotent: true })
 Within a transaction, you can produce one or more messages. If `transaction.abort` is called, all messages will be rolled back.
 
 ```javascript
-const  transaction = await producer.transaction()
+const transaction = await producer.transaction()
 
 try {
   await transaction.send({ topic, messages })

--- a/src/consumer/__tests__/batch.spec.js
+++ b/src/consumer/__tests__/batch.spec.js
@@ -141,4 +141,46 @@ describe('Consumer > Batch', () => {
       expect(batch.offsetLagLow()).toEqual('0')
     })
   })
+
+  describe('#isEmptyControlRecord', () => {
+    it('returns false for regular batches', () => {
+      const batch = new Batch(topic, 0, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{ offset: '3' }, { offset: '4' }],
+      })
+
+      expect(batch.isEmptyControlRecord()).toEqual(false)
+    })
+
+    it('returns false for regular empty batches', () => {
+      const batch = new Batch(topic, 0, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [],
+      })
+
+      expect(batch.isEmptyControlRecord()).toEqual(false)
+    })
+
+    it('returns false if there is a control record but some messages are available', () => {
+      const batch = new Batch(topic, 0, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{ offset: '3' }, { offset: '4' }, { isControlRecord: true, offset: '5' }],
+      })
+
+      expect(batch.isEmptyControlRecord()).toEqual(false)
+    })
+
+    it('returns true if the batch only contains a control record', () => {
+      const batch = new Batch(topic, 0, {
+        partition: 0,
+        highWatermark: '100',
+        messages: [{ isControlRecord: true, offset: '5' }],
+      })
+
+      expect(batch.isEmptyControlRecord()).toEqual(true)
+    })
+  })
 })

--- a/src/consumer/__tests__/controlBatches.spec.js
+++ b/src/consumer/__tests__/controlBatches.spec.js
@@ -1,0 +1,84 @@
+jest.setTimeout(5000)
+const createProducer = require('../../producer')
+const createConsumer = require('../index')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  createModPartitioner,
+  newLogger,
+  testIfKafka_0_11,
+  waitForMessages,
+  generateMessages,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+
+describe('Consumer', () => {
+  let topicName, groupId, transactionalId, cluster, producer, consumer
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+    transactionalId = `transaction-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+
+    cluster = createCluster({
+      allowExperimentalV011: true,
+      maxInFlightRequests: 1,
+    })
+
+    producer = createProducer({
+      cluster,
+      transactionalId,
+      idempotent: true,
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+
+    consumer = createConsumer({
+      cluster,
+      groupId,
+      maxWaitTimeInMs: 100,
+      logger: newLogger(),
+    })
+  })
+
+  afterEach(async () => {
+    await consumer.disconnect()
+    await producer.disconnect()
+  })
+
+  testIfKafka_0_11('forwards empty control batches to eachBatch', async () => {
+    jest.spyOn(cluster, 'refreshMetadataIfNecessary')
+
+    await consumer.connect()
+    await producer.connect()
+    await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+    const messagesConsumed = []
+    consumer.run({
+      eachBatchAutoResolve: false,
+      eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning, isStale }) => {
+        for (const message of batch.messages) {
+          if (!isRunning() || isStale()) break
+          messagesConsumed.push(message)
+          await resolveOffset(message.offset)
+          await heartbeat()
+        }
+      },
+    })
+
+    await waitForConsumerToJoinGroup(consumer)
+    const messagesTransaction1 = generateMessages({ number: 20 })
+
+    const transaction = await producer.transaction()
+    for (const message of messagesTransaction1) {
+      await transaction.send({ topic: topicName, messages: [message] })
+    }
+
+    await transaction.commit()
+    await waitForMessages(messagesConsumed, { number: 20 })
+  })
+})

--- a/src/consumer/__tests__/controlBatches.spec.js
+++ b/src/consumer/__tests__/controlBatches.spec.js
@@ -41,6 +41,7 @@ describe('Consumer', () => {
       cluster,
       groupId,
       maxWaitTimeInMs: 100,
+      maxBytes: 170,
       logger: newLogger(),
     })
   })
@@ -80,5 +81,8 @@ describe('Consumer', () => {
 
     await transaction.commit()
     await waitForMessages(messagesConsumed, { number: 20 })
+
+    producer.send({ topic: topicName, messages: generateMessages({ number: 2 }) })
+    await waitForMessages(messagesConsumed, { number: 22 })
   })
 })

--- a/src/consumer/batch.js
+++ b/src/consumer/batch.js
@@ -40,6 +40,10 @@ module.exports = class Batch {
     return this.unfilteredMessages.length === 0
   }
 
+  isEmptyControlRecord() {
+    return this.isEmpty() && this.unfilteredMessages.some(({ isControlRecord }) => isControlRecord)
+  }
+
   firstOffset() {
     return this.isEmptyIncludingFiltered() ? null : this.unfilteredMessages[0].offset
   }

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -406,8 +406,23 @@ module.exports = class ConsumerGroup {
               )
 
               const fetchedOffset = partitionRequestData.fetchOffset
+              const batch = new Batch(topicName, fetchedOffset, partitionData)
 
-              return new Batch(topicName, fetchedOffset, partitionData)
+              /**
+               * Resolve the offset to skip the control batch since `eachBatch` or `eachMessage` callbacks
+               * won't process empty batches
+               *
+               * @see https://github.com/apache/kafka/blob/9aa660786e46c1efbf5605a6a69136a1dac6edb9/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java#L1499-L1505
+               */
+              if (batch.isEmptyControlRecord()) {
+                this.resolveOffset({
+                  topic: batch.topic,
+                  partition: batch.partition,
+                  offset: batch.lastOffset(),
+                })
+              }
+
+              return batch
             })
         })
 


### PR DESCRIPTION
This PR solves issue #403.

It does two things:

1) Automatically resolve the control record offset when resolving the last non-filtered offset of the batch
2) When the batch is an empty control batch, automatically resolve the  offset

I wrote more on the code documentation; I will paste here for documentation purposes.

> The transactional producer generates a control record after committing the transaction.
> The control record is the last record on the RecordBatch, and it is filtered before it
> reaches the `eachBatch` callback. When disabling auto-resolve, the user-land code won't
> be able to resolve the control record offset, since it never reaches the callback,
> causing stuck consumers as the consumer will never move the offset marker.
> 
> When the last offset of the batch is resolved, we should automatically resolve
> the control record offset as this entry doesn't have any meaning to the user-land code,
> and won't interfere with the stream processing.

I am pinging the people in the original issue since it's a bit old and you might miss this PR.
@kkurten @drojas @JaapRood @jasine @brandonl