### PR TITLE
Accept any "Failed to connect" error

### DIFF
--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -58,8 +58,8 @@ describe('Network > Connection', () => {
 
       test('rejects the Promise in case of errors', async () => {
         connection.ssl.cert = 'invalid'
-        const message = 'Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line'
-        await expect(connection.connect()).rejects.toHaveProperty('message', message)
+        const messagePattern = /Failed to connect/
+        await expect(connection.connect()).rejects.toThrow(messagePattern)
         expect(connection.connected).toEqual(false)
       })
     })


### PR DESCRIPTION
This fixes the tests failing with NodeJS 10.16.3 on Linux:
~~~~
    Expected value: "Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line"
    Received value: "Failed to connect: error:0909006C:PEM routines:get_name:no start line"
~~~~

---
`npm test` output:
~~~~
$ npm test

> kafkajs@1.11.0 test /home/andreas/project/kafkajs
> yarn lint && JEST_JUNIT_OUTPUT=test-report.xml ./scripts/testWithKafka.sh 'yarn jest --ci --maxWorkers=4 --no-watchman --forceExit'

yarn run v1.19.1
warning You don't appear to have an internet connection. Try the --offline flag to use the cache for registry queries.
$ find . -path ./node_modules -prune -o -path ./coverage -prune -o -path ./website -prune -o -name '*.js' -print0 | xargs -0 ./node_modules/.bin/eslint
Done in 8.18s.
+ testCommand='yarn jest --ci --maxWorkers=4 --no-watchman --forceExit'
+ extraArgs=
+ export COMPOSE_FILE=docker-compose.2_2.yml
+ COMPOSE_FILE=docker-compose.2_2.yml
+ export KAFKAJS_DEBUG_PROTOCOL_BUFFERS=1
+ KAFKAJS_DEBUG_PROTOCOL_BUFFERS=1
+ '[' -z ']'
+ trap quit ERR
++ find_container_id
+++ docker ps --filter status=running --filter label=custom.project=kafkajs --filter label=custom.service=kafka1 --no-trunc -q
++ echo
+ '[' -z '' ']'
+ echo -e 'Start kafka docker container'
Start kafka docker container
+ NO_LOGS=1
+ /home/andreas/project/kafkajs/scripts/dockerComposeUp.sh
Running compose file: docker-compose.2_2.yml:
Creating network "kafkajs_default" with the default driver
Creating zookeeper ... done
Creating kafka1    ... done
Creating kafka2    ... done
Creating kafka3    ... done
+ '[' 1 = 0 ']'
+ /home/andreas/project/kafkajs/scripts/waitForKafka.js

Finding container ids...
kafka1: e34c74f455e16a94ec56fcd22431ca173cd20e90d5baf9829a9b8e1a7bea6e1c
kafka2: 3417796ae87a04b61cde0d8cbcfefb377538de7571d4eb3e1d7a9089a29674bf
kafka3: 1e90922c0d9fd6b579c1ea4bd9c0988f281d8a788b3379ebe8a9509ef681c950

Waiting for nodes...
Kafka container e34c74f455e16a94ec56fcd22431ca173cd20e90d5baf9829a9b8e1a7bea6e1c is running
Kafka container 3417796ae87a04b61cde0d8cbcfefb377538de7571d4eb3e1d7a9089a29674bf is running
Kafka container 1e90922c0d9fd6b579c1ea4bd9c0988f281d8a788b3379ebe8a9509ef681c950 is running

All nodes up:
  Name               Command            State                                                                               Ports                                                                             
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
kafka1      /etc/confluent/docker/run   Up      0.0.0.0:29092->29092/tcp, 0.0.0.0:29093->29093/tcp, 0.0.0.0:29094->29094/tcp, 0.0.0.0:9092->9092/tcp, 0.0.0.0:9093->9093/tcp, 0.0.0.0:9094->9094/tcp          
kafka2      /etc/confluent/docker/run   Up      0.0.0.0:29095->29095/tcp, 0.0.0.0:29096->29096/tcp, 0.0.0.0:29097->29097/tcp, 9092/tcp, 0.0.0.0:9095->9095/tcp, 0.0.0.0:9096->9096/tcp, 0.0.0.0:9097->9097/tcp
kafka3      /etc/confluent/docker/run   Up      0.0.0.0:29098->29098/tcp, 0.0.0.0:29099->29099/tcp, 0.0.0.0:29100->29100/tcp, 9092/tcp, 0.0.0.0:9098->9098/tcp, 0.0.0.0:9099->9099/tcp, 0.0.0.0:9100->9100/tcp
zookeeper   /etc/confluent/docker/run   Up      0.0.0.0:2181->2181/tcp, 2888/tcp, 3888/tcp                                                                                                                    

Creating default topics...

Warming up Kafka...
  -> creating 10 random topics...
  -> running consumer describe
+ echo

+ echo -e 'Create SCRAM credentials'
Create SCRAM credentials
+ /home/andreas/project/kafkajs/scripts/createScramCredentials.sh
Completed Updating config for entity: user-principal 'testscram'.
+ echo

+ eval 'yarn jest --ci --maxWorkers=4 --no-watchman --forceExit '
++ yarn jest --ci --maxWorkers=4 --no-watchman --forceExit
yarn run v1.19.1
$ export KAFKA_VERSION=${KAFKA_VERSION:='2.2'} && NODE_ENV=test echo "KAFKA_VERSION: ${KAFKA_VERSION}" && KAFKAJS_DEBUG_PROTOCOL_BUFFERS=1 ./node_modules/.bin/jest --ci --maxWorkers=4 --no-watchman --forceExit
KAFKA_VERSION: 2.2
 PASS  src/consumer/__tests__/errorRecovery.spec.js
 PASS  src/consumer/__tests__/seek.spec.js
 PASS  src/broker/__tests__/fetch.spec.js
 PASS  src/producer/index.spec.js (9.277s)
 PASS  src/consumer/__tests__/commitOffsets.spec.js
 PASS  src/consumer/__tests__/consumeMessages.spec.js (11.38s)
 PASS  src/cluster/__tests__/brokerPool.spec.js
 PASS  src/admin/__tests__/fetchOffsets.spec.js (6.032s)
 PASS  src/admin/__tests__/setOffsets.spec.js (5.99s)
 FAIL  src/network/connection.spec.js
  ● Network > Connection › #connect › SSL › rejects the Promise in case of errors

    expect(received).rejects.toHaveProperty(path, value)

    Expected path: "message"

    Expected value: "Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line"
    Received value: "Failed to connect: error:0909006C:PEM routines:get_name:no start line"

      60 |         connection.ssl.cert = 'invalid'
      61 |         const message = 'Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line'
    > 62 |         await expect(connection.connect()).rejects.toHaveProperty('message', message)
         |                                                    ^
      63 |         expect(connection.connected).toEqual(false)
      64 |       })
      65 |     })

      at Object.args [as toHaveProperty] (node_modules/expect/build/index.js:242:20)
      at Object.toHaveProperty (src/network/connection.spec.js:62:52)

Summary of all failing tests
 FAIL  src/network/connection.spec.js
Accept any "Failed to connect" error
  ● Network > Connection › #connect › SSL › rejects the Promise in case of errors

    expect(received).rejects.toHaveProperty(path, value)

    Expected path: "message"

    Expected value: "Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line"
    Received value: "Failed to connect: error:0909006C:PEM routines:get_name:no start line"

      60 |         connection.ssl.cert = 'invalid'
      61 |         const message = 'Failed to connect: error:0906D06C:PEM routines:PEM_read_bio:no start line'
    > 62 |         await expect(connection.connect()).rejects.toHaveProperty('message', message)
         |                                                    ^
      63 |         expect(connection.connected).toEqual(false)
      64 |       })
      65 |     })

      at Object.args [as toHaveProperty] (node_modules/expect/build/index.js:242:20)
      at Object.toHaveProperty (src/network/connection.spec.js:62:52)


Test Suites: 1 failed, 9 passed, 10 of 238 total
Tests:       1 failed, 146 passed, 147 total
Snapshots:   1 passed, 1 total
Time:        17.528s, estimated 49s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+++ quit
+++ docker-compose -f docker-compose.2_2.yml down --remove-orphans
Stopping kafka2    ... done
Stopping kafka3    ... done
Stopping kafka1    ... done
Stopping zookeeper ... done
Removing kafka2    ... done
Removing kafka3    ... done
Removing kafka1    ... done
Removing zookeeper ... done
Removing network kafkajs_default
+++ exit 1
npm ERR! Test failed.  See above for more details.
~~~~

Complete versions as reported by `node -p process.versions`:
```js
{ http_parser: '2.8.0',
  node: '10.16.3',
  v8: '6.8.275.32-node.54',
  uv: '1.28.0',
  zlib: '1.2.11',
  brotli: '1.0.7',
  ares: '1.15.0',
  modules: '64',
  nghttp2: '1.39.2',
  napi: '4',
  openssl: '1.1.1c',
  icu: '64.2',
  unicode: '12.1',
  cldr: '35.1',
  tz: '2019a' }
```