### PR TITLE
Adding Consumer GROUP_JOIN information in the docs

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -35,6 +35,8 @@ The consumer will not match topics created after the subscription. If your broke
 
 KafkaJS offers you two ways to process your data: `eachMessage` and `eachBatch`
 
+The consumer will be ready to process incoming messages to the topic after joining the consumer group, when it sends the `GROUP_JOIN` event.
+
 ## <a name="each-message"></a> eachMessage
 
 The `eachMessage` handler provides a convenient and easy to use API, feeding your function one message at a time. It is implemented on top of `eachBatch`, and it will automatically commit your offsets and heartbeat at the configured interval for you. If you are just looking to get started with Kafka consumers this a good place to start.


### PR DESCRIPTION
The purpose of this is to make people aware that only `connect()` is not enough to actually being able to consume messages. After running into some issues with integration tests, this knowledge would have been really helpful, so it might be interesting for other people as well :)