### PR TITLE
Change typing of logLevel argument to logCreator

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -364,7 +364,7 @@ export interface LoggerEntryContent {
 
 export type Logger = (entry: LogEntry) => void
 
-export type logCreator = (logLevel: number) => (entry: LogEntry) => void
+export type logCreator = (logLevel: logLevel) => (entry: LogEntry) => void
 
 export type Broker = {
   isConnected(): boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -364,7 +364,7 @@ export interface LoggerEntryContent {
 
 export type Logger = (entry: LogEntry) => void
 
-export type logCreator = (logLevel: string) => (entry: LogEntry) => void
+export type logCreator = (logLevel: number) => (entry: LogEntry) => void
 
 export type Broker = {
   isConnected(): boolean

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -7,6 +7,7 @@ import {
   CompressionTypes,
   CompressionCodecs,
   ResourceTypes,
+  LogEntry,
 } from './index'
 
 const { roundRobin } = PartitionAssigners
@@ -28,6 +29,7 @@ const kafka = new Kafka({
     username: 'test',
     password: 'testtest',
   },
+  logCreator: (logLevel: number) => (entry: LogEntry) => { },
 })
 
 // CONSUMER

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -29,7 +29,7 @@ const kafka = new Kafka({
     username: 'test',
     password: 'testtest',
   },
-  logCreator: (logLevel: number) => (entry: LogEntry) => { },
+  logCreator: (logLevel: logLevel) => (entry: LogEntry) => { },
 })
 
 // CONSUMER


### PR DESCRIPTION
The kafkajs log levels are numeric at runtime, but the typescript declarations for the logCreator function takes a string argument. This PR changes the argument's type and adds a test for it.