### PR TITLE
Fix the connection error test to work with NodeJS 12.x

### DIFF
--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -30,10 +30,8 @@ describe('Network > Connection', () => {
 
       test('rejects the Promise in case of errors', async () => {
         connection.host = invalidHost
-        await expect(connection.connect()).rejects.toHaveProperty(
-          'message',
-          'Connection error: getaddrinfo ENOTFOUND kafkajs.test kafkajs.test:9092'
-        )
+        const messagePattern = /Connection error: getaddrinfo ENOTFOUND kafkajs.test/
+        await expect(connection.connect()).rejects.toThrow(messagePattern)
         expect(connection.connected).toEqual(false)
       })
     })


### PR DESCRIPTION
NodeJS 12.x removed the (useless) 'host:port' part of the connection errors with
https://github.com/nodejs/node/pull/26751, adapt the code here to check with a pattern
that handles both NodeJS 12.x and earlier versions.