### PR TITLE
Clarify the behavior in the partition assigner protocol

### DIFF
--- a/src/consumer/__tests__/assignerProtocolIntegration.spec.js
+++ b/src/consumer/__tests__/assignerProtocolIntegration.spec.js
@@ -1,0 +1,100 @@
+const { MemberMetadata, MemberAssignment } = require('../assignerProtocol')
+
+const createConsumer = require('../index')
+
+const {
+  secureRandom,
+  createCluster,
+  createTopic,
+  newLogger,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+
+describe('Consumer > assignerProtocol > integration', () => {
+  let topicName, groupId, cluster1, cluster2, consumer1, consumer2
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupId = `consumer-group-id-${secureRandom()}`
+
+    await createTopic({ topic: topicName })
+
+    cluster1 = createCluster()
+    cluster2 = createCluster()
+  })
+
+  afterEach(async () => {
+    await consumer1.disconnect()
+    await consumer2.disconnect()
+  })
+
+  test('provides member user data', async () => {
+    const assignmentMemberUserData = {}
+    function createAssigner(id) {
+      return () => ({
+        name: 'TestAssigner',
+        version: 1,
+        protocol({ topics }) {
+          // Encode the id as user data
+          return {
+            name: this.name,
+            metadata: MemberMetadata.encode({
+              version: this.version,
+              topics,
+              userData: Buffer.from(id),
+            }),
+          }
+        },
+        async assign({ members }) {
+          // Dummy assignment: just assign nothing to each member, but keep the
+          // user data for each member for checking it later.
+          return members.map(({ memberId, memberMetadata }) => {
+            const decodedMetadata = MemberMetadata.decode(memberMetadata)
+            assignmentMemberUserData[memberId] = decodedMetadata.userData.toString('utf8')
+
+            return {
+              memberId,
+              memberAssignment: MemberAssignment.encode({
+                version: this.version,
+                assignment: [],
+              }),
+            }
+          })
+        },
+      })
+    }
+    // Connect the two consumers to their respective clusters
+    consumer1 = createConsumer({
+      cluster: cluster1,
+      groupId,
+      maxWaitTimeInMs: 1,
+      logger: newLogger(),
+      partitionAssigners: [createAssigner('consumer1')],
+    })
+
+    consumer2 = createConsumer({
+      cluster: cluster2,
+      groupId,
+      maxWaitTimeInMs: 1,
+      logger: newLogger(),
+      partitionAssigners: [createAssigner('consumer2')],
+    })
+
+    // Wait until the consumers are connected
+    await Promise.all([consumer1.connect(), consumer2.connect()])
+
+    // Subscribe both consumers to the same topic, and start the consumer groups
+    consumer1.subscribe({ topic: topicName })
+    consumer1.run({ eachMessage: () => {} })
+    consumer2.subscribe({ topic: topicName })
+    consumer2.run({ eachMessage: () => {} })
+
+    await Promise.all([
+      waitForConsumerToJoinGroup(consumer1),
+      waitForConsumerToJoinGroup(consumer2),
+    ])
+
+    // Check that we now have seen for each member a matching entry
+    expect(Object.values(assignmentMemberUserData).sort()).toEqual(['consumer1', 'consumer2'])
+  })
+})

--- a/src/consumer/assigners/roundRobinAssigner/index.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.js
@@ -10,11 +10,15 @@ module.exports = ({ cluster }) => ({
   version: 1,
 
   /**
+   * Assign the topics to the provided members.
+   *
+   * The members array contains information about each member, `memberMetadata` is the result of the
+   * `protocol` operation.
+   *
    * This process can result in imbalanced assignments
    * @param {array} members array of members, e.g:
-                              [{ memberId: 'test-5f93f5a3' }]
+                              [{ memberId: 'test-5f93f5a3', memberMetadata: Buffer }]
    * @param {array} topics
-   * @param {Buffer} userData
    * @returns {array} object partitions per topic per member, e.g:
    *                   [
    *                     {
@@ -33,7 +37,7 @@ module.exports = ({ cluster }) => ({
    *                     }
    *                   ]
    */
-  async assign({ members, topics, userData }) {
+  async assign({ members, topics }) {
     const membersCount = members.length
     const sortedMembers = members.map(({ memberId }) => memberId).sort()
     const assignment = {}
@@ -59,18 +63,16 @@ module.exports = ({ cluster }) => ({
       memberAssignment: MemberAssignment.encode({
         version: this.version,
         assignment: assignment[memberId],
-        userData,
       }),
     }))
   },
 
-  protocol({ topics, userData }) {
+  protocol({ topics }) {
     return {
       name: this.name,
       metadata: MemberMetadata.encode({
         version: this.version,
         topics,
-        userData,
       }),
     }
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -143,7 +143,7 @@ export type Cluster = {
 
 export type Assignment = { [topic: string]: number[] }
 
-export type GroupMember = { memberId: string }
+export type GroupMember = { memberId: string, memberMetadata: Buffer }
 
 export type GroupMemberAssignment = { memberId: string; memberAssignment: Buffer }
 
@@ -155,9 +155,8 @@ export type Assigner = {
   assign(group: {
     members: GroupMember[]
     topics: string[]
-    userData: Buffer
   }): Promise<GroupMemberAssignment[]>
-  protocol(subscription: { topics: string[]; userData: Buffer }): GroupState
+  protocol(subscription: { topics: string[] }): GroupState
 }
 
 export interface RetryOptions {


### PR DESCRIPTION
The existing typing was off, and made it look like the user data would be provided _to_ the `protocol` and `assign` functions as argument fields.

Reading through https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-GroupMembershipAPI and the KafkaJS code is not true at all. What actually happens is that
1. each assigners' `protocol` function _can_ provide user data (by encoding it into the result), then
2. Kafka will select a leader, and provide that one in the JoinGroupResponse with an array of all members _and the metadata they provided_, which
3. the group leader will then process through the `assign` function. At this point it can take the user data into account, and it can produce new user data* 

The first commit in this PR updates the TypeScript types to match this behavior and adds a integration test to demonstrate it, the second commit then cleans up the roundRobinAssigner's code to remove the "obviously unused" argument fields.

---
* From what I can see and read in the documentation the user data in the response is unused for the 'consumer' protocol, but likely is used for more fancier protocols, for example in the 'connect' protocol (https://www.confluent.io/blog/incremental-cooperative-rebalancing-in-kafka is fancy!)