### PR TITLE
Handle an empty assignment for a group member correctly

### DIFF
--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -157,7 +157,8 @@ module.exports = class ConsumerGroup {
       groupAssignment: assignment,
     })
 
-    const decodedAssignment = MemberAssignment.decode(memberAssignment).assignment
+    const decodedAssignment =
+      memberAssignment.length === 0 ? {} : MemberAssignment.decode(memberAssignment).assignment
     this.logger.debug('Received assignment', {
       groupId,
       generationId,


### PR DESCRIPTION
Fixes #550

The argument for checking this here, rather than in the decode() function: Here we know that we don't care about the `version` property, but only about the actual assignment. Checking here is easy therefore, while in the decode() function I would have to come up with a reasonable return value, which would lead to possibly more changes to handle these. 