### PR TITLE
Fix JSDoc documentation for MemberMetadata.encode

### DIFF
--- a/src/consumer/assignerProtocol.js
+++ b/src/consumer/assignerProtocol.js
@@ -3,9 +3,10 @@ const Decoder = require('../protocol/decoder')
 
 const MemberMetadata = {
   /**
-   * @param {number} version
-   * @param {Array<string>} topics
-   * @param {Buffer} [userData=Buffer.alloc(0)]
+   * @param {Object} metadata
+   * @param {number} metadata.version
+   * @param {Array<string>} metadata.topics
+   * @param {Buffer} [metadata.userData=Buffer.alloc(0)]
    *
    * @returns Buffer
    */


### PR DESCRIPTION
This helps the TypeScript compiler to understand the signature of the function.