### PR TITLE
add type boolean in ssl KafkaConfig

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@ export class Kafka {
 
 export interface KafkaConfig {
   brokers: string[]
-  ssl?: tls.ConnectionOptions
+  ssl?: tls.ConnectionOptions | boolean
   sasl?: SASLOptions
   clientId?: string
   connectionTimeout?: number


### PR DESCRIPTION
according to your [documentation](https://kafka.js.org/docs/configuration), we could add ssl config as boolean:

```javascript
new Kafka({
  clientId: 'my-app',
  brokers: ['kafka1:9092', 'kafka2:9092'],
  // authenticationTimeout: 1000,
  // reauthenticationThreshold: 10000,
  ssl: true,
  sasl: {
    mechanism: 'plain', // scram-sha-256 or scram-sha-512
    username: 'my-username',
    password: 'my-password'
  },
})
```


 so we should update type for boolean too.