### PR TITLE
Change consumer examples to start from beginning

### DIFF
--- a/docs/ConsumerExample.md
+++ b/docs/ConsumerExample.md
@@ -24,7 +24,7 @@ const consumer = kafka.consumer({ groupId: 'test-group' })
 
 const run = async () => {
   await consumer.connect()
-  await consumer.subscribe({ topic })
+  await consumer.subscribe({ topic, fromBeginning: true })
   await consumer.run({
     // eachBatch: async ({ batch }) => {
     //   console.log(batch)
@@ -96,7 +96,7 @@ const consumer = kafka.consumer({ groupId: 'test-group' })
 
 const run = async () => {
   await consumer.connect()
-  await consumer.subscribe({ topic })
+  await consumer.subscribe({ topic, fromBeginning: true })
   await consumer.run({
     // eachBatch: async ({ batch }) => {
     //   console.log(batch)

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -16,12 +16,14 @@ Subscribing to some topics:
 ```javascript
 await consumer.connect()
 
-// Subscribe can be called several times
 await consumer.subscribe({ topic: 'topic-A' })
-await consumer.subscribe({ topic: 'topic-B' })
 
-// It's possible to start from the beginning:
-// await consumer.subscribe({ topic: 'topic-C', fromBeginning: true })
+// Subscribe can be called several times
+await consumer.subscribe({ topic: 'topic-B')
+await consumer.subscribe({ topic: 'topic-C')
+
+// It's possible to start from the beginning of the topic
+await consumer.subscribe({ topic: 'topic-D', fromBeginning: true })
 ```
 
 Alternatively, you can subscribe to multiple topics at once using a RegExp:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -49,7 +49,7 @@ Finally, to verify that our message has indeed been produced to the topic, let's
 const consumer = kafka.consumer({ groupId: 'test-group' })
 
 await consumer.connect()
-await consumer.subscribe({ topic: 'test-topic' })
+await consumer.subscribe({ topic: 'test-topic', fromBeginning: true })
 
 await consumer.run({
   eachMessage: async ({ topic, partition, message }) => {

--- a/examples/consumer.js
+++ b/examples/consumer.js
@@ -26,7 +26,7 @@ const consumer = kafka.consumer({ groupId: 'test-group' })
 
 const run = async () => {
   await consumer.connect()
-  await consumer.subscribe({ topic })
+  await consumer.subscribe({ topic, fromBeginning: true })
   await consumer.run({
     // eachBatch: async ({ batch }) => {
     //   console.log(batch)


### PR DESCRIPTION
We get so many people reporting that they can't consume messages with
KafkaJS, because they don't set `fromBeginning`, so the consumer starts
from the end of the topic. Maybe making the "getting started" examples
use `fromBeginning: true` will help with this.