### PR TITLE
Add the functionality to fetch topic offsets by timestamp

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -166,6 +166,18 @@ await admin.fetchTopicOffsets(topic)
 // ]
 ```
 
+## <a name="fetch-topic-offsets-by-timestamp"></a> Fetch topic offsets by timestamp
+
+Specify a `timestamp` to get the earliest offset on each partition where the message's timestamp is greater than or equal to the given timestamp.
+
+```javascript
+await admin.fetchTopicOffsetsByTimestamp(topic, timestamp)
+// [
+//   { partition: 0, offset: '3244' },
+//   { partition: 1, offset: '3113' },
+// ]
+```
+
 ## <a name="fetch-offsets"></a> Fetch consumer group offsets
 
 `fetchOffsets` returns the consumer group offset for a topic.
@@ -222,6 +234,15 @@ await admin.setOffsets({
         { partition: 3, offset: '19' },
     ]
 })
+```
+
+## <a name="reset-offsets-by-timestamp"></a> Reset consumer group offsets by timestamp
+
+Combining `fetchTopicOffsetsByTimestamp` and `setOffsets` can reset a consumer group's offsets on each partition to the earliest offset whose timestamp is greater than or equal to the given timestamp.
+The consumer group must have no running instances when performing the reset. Otherwise, the command will be rejected.
+
+```javascript
+await admin.setOffsets({ groupId, topic, partitions: await admin.fetchTopicOffsetsByTimestamp(topic, timestamp) })
 ```
 
 ## <a name="describe-cluster"></a> Describe cluster

--- a/src/admin/__tests__/fetchTopicOffsetsByTimestamp.spec.js
+++ b/src/admin/__tests__/fetchTopicOffsetsByTimestamp.spec.js
@@ -1,0 +1,113 @@
+const createAdmin = require('../index')
+const createProducer = require('../../producer')
+const createConsumer = require('../../consumer')
+
+const {
+  secureRandom,
+  createCluster,
+  newLogger,
+  createTopic,
+  createModPartitioner,
+  waitFor,
+  waitForConsumerToJoinGroup,
+} = require('testHelpers')
+
+describe('Admin', () => {
+  let topicName, admin, producer, cluster
+
+  beforeEach(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    await createTopic({ topic: topicName })
+
+    admin = createAdmin({ cluster, logger: newLogger() })
+
+    cluster = createCluster()
+    producer = createProducer({
+      cluster,
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+  })
+  afterEach(async () => {
+    admin && (await admin.disconnect())
+    producer && (await producer.disconnect())
+  })
+
+  describe('fetchTopicOffsetsByTimestamp', () => {
+    test('throws an error if the topic name is not a valid string', async () => {
+      admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
+      await expect(admin.fetchTopicOffsetsByTimestamp(null)).rejects.toHaveProperty(
+        'message',
+        'Invalid topic null'
+      )
+    })
+
+    const sendMessages = async n => {
+      await admin.connect()
+      await producer.connect()
+
+      const messages = Array(n)
+        .fill()
+        .map(() => {
+          const value = secureRandom()
+          return { key: `key-${value}`, value: `value-${value}` }
+        })
+
+      await producer.send({ acks: 1, topic: topicName, messages })
+    }
+
+    test('returns the offsets from timestamp', async () => {
+      await sendMessages(10)
+      const fromTimestamp = Date.now()
+      await sendMessages(10)
+      const futureTimestamp = Date.now()
+      const offsetsFromTimestamp = await admin.fetchTopicOffsetsByTimestamp(
+        topicName,
+        fromTimestamp
+      )
+      expect(offsetsFromTimestamp).toEqual([{ partition: 0, offset: '10' }])
+      const offsetsFutureTimestamp = await admin.fetchTopicOffsetsByTimestamp(
+        topicName,
+        futureTimestamp
+      )
+      expect(offsetsFutureTimestamp).toEqual([{ partition: 0, offset: '20' }])
+      const groupId = `consumer-group-id-${secureRandom()}`
+      const consumer = createConsumer({
+        cluster,
+        groupId,
+        maxWaitTimeInMs: 1,
+        maxBytesPerPartition: 180,
+        logger: newLogger(),
+      })
+      await consumer.connect()
+      await consumer.subscribe({ topic: topicName, fromBeginning: true })
+      /** real timestamp in messages after `fromTimestamp` */
+      let realTimestamp = 0
+      consumer.run({
+        eachMessage: async ({ message }) => {
+          if (message.timestamp < fromTimestamp) return
+          if (realTimestamp === 0) realTimestamp = message.timestamp
+          if (realTimestamp > 0) consumer.stop()
+        },
+      })
+      await waitForConsumerToJoinGroup(consumer)
+      await waitFor(() => realTimestamp > 0)
+      const offsetsRealTimestamp = await admin.fetchTopicOffsetsByTimestamp(
+        topicName,
+        realTimestamp
+      )
+      expect(offsetsRealTimestamp).toEqual([{ partition: 0, offset: '10' }])
+    })
+
+    test('returns the offsets from timestamp when no messages', async () => {
+      const fromTimestamp = Date.now()
+      const offsetsFromTimestamp = await admin.fetchTopicOffsetsByTimestamp(
+        topicName,
+        fromTimestamp
+      )
+      expect(offsetsFromTimestamp).toEqual([{ partition: 0, offset: '0' }])
+      const offsets = await admin.fetchTopicOffsets(topicName)
+      expect(offsets).toEqual([{ partition: 0, offset: '0', low: '0', high: '0' }])
+    })
+  })
+})

--- a/src/admin/__tests__/resetOffsets.spec.js
+++ b/src/admin/__tests__/resetOffsets.spec.js
@@ -27,7 +27,7 @@ describe('Admin', () => {
   describe('resetOffsets', () => {
     test('throws an error if the groupId is invalid', async () => {
       admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
-      await expect(admin.setOffsets({ groupId: null })).rejects.toHaveProperty(
+      await expect(admin.resetOffsets({ groupId: null })).rejects.toHaveProperty(
         'message',
         'Invalid groupId null'
       )
@@ -35,7 +35,7 @@ describe('Admin', () => {
 
     test('throws an error if the topic name is not a valid string', async () => {
       admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
-      await expect(admin.setOffsets({ groupId: 'groupId', topic: null })).rejects.toHaveProperty(
+      await expect(admin.resetOffsets({ groupId: 'groupId', topic: null })).rejects.toHaveProperty(
         'message',
         'Invalid topic null'
       )

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -284,6 +284,63 @@ module.exports = ({
   }
 
   /**
+   * @param {string} topic
+   * @param {number=} timestamp
+   */
+
+  const fetchTopicOffsetsByTimestamp = async (topic, timestamp) => {
+    if (!topic || typeof topic !== 'string') {
+      throw new KafkaJSNonRetriableError(`Invalid topic ${topic}`)
+    }
+
+    const retrier = createRetry(retry)
+
+    return retrier(async (bail, retryCount, retryTime) => {
+      try {
+        await cluster.addTargetTopic(topic)
+        await cluster.refreshMetadataIfNecessary()
+
+        const metadata = cluster.findTopicPartitionMetadata(topic)
+        const partitions = metadata.map(p => ({ partition: p.partitionId }))
+
+        const high = await cluster.fetchTopicsOffset([
+          {
+            topic,
+            fromBeginning: false,
+            partitions,
+          },
+        ])
+        const { partitions: highPartitions } = high.pop()
+
+        const offsets = await cluster.fetchTopicsOffset([
+          {
+            topic,
+            fromTimestamp: timestamp,
+            partitions,
+          },
+        ])
+        const { partitions: lowPartitions } = offsets.pop()
+
+        return lowPartitions.map(({ partition, offset }) => ({
+          partition,
+          offset:
+            parseInt(offset, 10) >= 0
+              ? offset
+              : highPartitions.find(({ partition: highPartition }) => highPartition === partition)
+                  .offset,
+        }))
+      } catch (e) {
+        if (e.type === 'UNKNOWN_TOPIC_OR_PARTITION') {
+          await cluster.refreshMetadata()
+          throw e
+        }
+
+        bail(e)
+      }
+    })
+  }
+
+  /**
    * @param {string} groupId
    * @param {string} topic
    * @return {Promise}
@@ -870,6 +927,7 @@ module.exports = ({
     events,
     fetchOffsets,
     fetchTopicOffsets,
+    fetchTopicOffsetsByTimestamp,
     setOffsets,
     resetOffsets,
     describeConfigs,

--- a/src/cluster/__tests__/fetchTopicsOffset.spec.js
+++ b/src/cluster/__tests__/fetchTopicsOffset.spec.js
@@ -11,6 +11,19 @@ const createProducer = require('../../producer')
 describe('Cluster > fetchTopicsOffset', () => {
   let cluster, topic, producer
 
+  const sendSampleMessages = async () => {
+    await producer.send({
+      topic,
+      acks: 1,
+      messages: [
+        { key: 'k1', value: 'v1' },
+        { key: 'k2', value: 'v2' },
+        { key: 'k3', value: 'v3' },
+        { key: 'k4', value: 'v4' },
+      ],
+    })
+  }
+
   beforeEach(async () => {
     topic = `test-topic-${secureRandom()}`
     cluster = createCluster()
@@ -25,16 +38,7 @@ describe('Cluster > fetchTopicsOffset', () => {
       createPartitioner: createModPartitioner,
     })
 
-    await producer.send({
-      topic,
-      acks: 1,
-      messages: [
-        { key: 'k1', value: 'v1' },
-        { key: 'k2', value: 'v2' },
-        { key: 'k3', value: 'v3' },
-        { key: 'k4', value: 'v4' },
-      ],
-    })
+    await sendSampleMessages()
   })
 
   afterEach(async () => {
@@ -67,5 +71,46 @@ describe('Cluster > fetchTopicsOffset', () => {
     ])
 
     expect(result).toEqual([{ topic, partitions: [{ partition: 0, offset: '0' }] }])
+  })
+
+  test('returns correct offsets if fromTimestamp', async () => {
+    const fromTimestamp = Date.now()
+    await sendSampleMessages()
+    const resultTimestamp = await cluster.fetchTopicsOffset([
+      {
+        topic,
+        fromTimestamp,
+        partitions: [{ partition: 0 }, { partition: 1 }, { partition: 2 }],
+      },
+    ])
+
+    expect(resultTimestamp).toEqual([
+      {
+        topic,
+        partitions: expect.arrayContaining([
+          { partition: 0, offset: '1' },
+          { partition: 1, offset: '2' },
+          { partition: 2, offset: '1' },
+        ]),
+      },
+    ])
+
+    const result = await cluster.fetchTopicsOffset([
+      {
+        topic,
+        partitions: [{ partition: 0 }, { partition: 1 }, { partition: 2 }],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        topic,
+        partitions: expect.arrayContaining([
+          { partition: 0, offset: '2' },
+          { partition: 1, offset: '4' },
+          { partition: 2, offset: '2' },
+        ]),
+      },
+    ])
   })
 })

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -409,19 +409,21 @@ module.exports = class Cluster {
     const topicConfigurations = {}
 
     const addDefaultOffset = topic => partition => {
-      const { fromBeginning } = topicConfigurations[topic]
-      return { ...partition, timestamp: this.defaultOffset({ fromBeginning }) }
+      const { timestamp } = topicConfigurations[topic]
+      return { ...partition, timestamp }
     }
 
     // Index all topics and partitions per leader (nodeId)
     for (const topicData of topics) {
-      const { topic, partitions, fromBeginning } = topicData
+      const { topic, partitions, fromBeginning, fromTimestamp } = topicData
       const partitionsPerLeader = this.findLeaderForPartitions(
         topic,
         partitions.map(p => p.partition)
       )
+      const timestamp =
+        fromTimestamp != null ? fromTimestamp : this.defaultOffset({ fromBeginning })
 
-      topicConfigurations[topic] = { fromBeginning }
+      topicConfigurations[topic] = { timestamp }
 
       keys(partitionsPerLeader).map(nodeId => {
         partitionsPerBroker[nodeId] = partitionsPerBroker[nodeId] || {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -136,7 +136,8 @@ export type Cluster = {
     topics: Array<{
       topic: string
       partitions: Array<{ partition: number }>
-      fromBeginning: boolean
+      fromBeginning?: boolean
+      fromTimestamp?: number
     }>
   ): Promise<{ topic: string; partitions: Array<{ partition: number; offset: string }> }>
 }
@@ -314,10 +315,13 @@ export type Admin = {
   fetchOffsets(options: {
     groupId: string
     topic: string
-  }): Promise<Array<{ partition: number; offset: string; metadata: string | null }>>
+  }): Promise<Array<SeekEntry & { metadata: string | null }>>
   fetchTopicOffsets(
     topic: string
-  ): Promise<Array<{ partition: number; offset: string; high: string; low: string }>>
+  ): Promise<Array<SeekEntry & { high: string; low: string }>>
+  fetchTopicOffsetsByTimestamp(
+    topic: string, timestamp?: number
+  ): Promise<Array<SeekEntry>>
   describeCluster(): Promise<{ brokers: Array<{ nodeId: number; host: string; port: number }>; controller: number | null, clusterId: string }>
   setOffsets(options: { groupId: string; topic: string; partitions: SeekEntry[] }): Promise<void>
   resetOffsets(options: { groupId: string; topic: string; earliest: boolean }): Promise<void>


### PR DESCRIPTION
Fixed #329, similar to #525 but with different naming and tests.

~~Supports `consumer.subscribe({ topic: 'test-topic', fromTimestamp: 1576731939876 })`.~~

Edited: reverted `consumer.subscribe` changes and limits the functionality within `admin`.
