### PR TITLE
Merge TopicMessages by topic in sendBatch

### DIFF
--- a/src/producer/messageProducer.js
+++ b/src/producer/messageProducer.js
@@ -57,12 +57,12 @@ module.exports = ({ logger, cluster, partitioner, eosManager, idempotent, retrie
     }
 
     const mergedTopicMessages = topicMessages.reduce((merged, { topic, messages }) => {
-      const topicBatch = merged.find(({ topic: mergedTopic }) => topic === mergedTopic)
+      const index = merged.findIndex(({ topic: mergedTopic }) => topic === mergedTopic)
 
-      if (!topicBatch) {
+      if (index === -1) {
         merged.push({ topic, messages })
       } else {
-        topicBatch.messages.concat(messages)
+        merged[index].messages = [...merged[index].messages, ...messages]
       }
 
       return merged


### PR DESCRIPTION
Fixes #622

I'm not entirely satisfied with the testing here. Basically what I'm asserting is that the expected number of messages are produced, but I'm not asserting message ordering.

Unfortunately I can't really validate that without consuming the topic, which means that the producer test depends on the consumer. Maybe that's okay? On the other hand, the logic is pretty trivial, but still.