### PR TITLE
Remove unused require('fs')

### DIFF
--- a/docs/ConsumerExample.md
+++ b/docs/ConsumerExample.md
@@ -6,7 +6,6 @@ title: Consumer
 The following example assumes that you are using the local Kafka configuration described in [Running Kafka in Development](DockerLocal.md).
 
 ```javascript
-const fs = require('fs')
 const ip = require('ip')
 
 const { Kafka, logLevel } = require('../index')
@@ -70,7 +69,6 @@ signalTraps.map(type => {
 The following example assumes a valid SSL certificate and SASL authentication using the `scram-sha-256` mechanism. Other mechanisms are also available (see [Client Configuration](Configuration.md#sasl)).
 
 ```javascript
-const fs = require('fs')
 const ip = require('ip')
 
 const { Kafka, logLevel } = require('../index')

--- a/docs/ProducerExample.md
+++ b/docs/ProducerExample.md
@@ -6,7 +6,6 @@ title: Producer
 The following example assumes that you are using the local Kafka configuration described in [Running Kafka in Development](DockerLocal.md).
 
 ```javascript
-const fs = require('fs')
 const ip = require('ip')
 
 const { Kafka, CompressionTypes, logLevel } = require('../index')


### PR DESCRIPTION
In the consumer and producer examples there are `require('fs')`s but `fs` is never used.