### PR TITLE
Only wait for the lock when there was actually batches enqueued

### DIFF
--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -362,7 +362,9 @@ module.exports = class Runner {
     }
 
     await Promise.all(enqueuedTasks.map(fn => fn()))
-    await lock
+    if (expectedNumberOfExecutions > 0) {
+      await lock
+    }
     await this.autoCommitOffsets()
     await this.consumerGroup.heartbeat({ interval: this.heartbeatInterval })
   }


### PR DESCRIPTION
It is possible for fetch to have requests with no batches: If a seek happens
between `fetch` processing the known seek offsets and the actual request checking
the partitions and skipping any that have a seek offset _at that point_ the protection
against empty requests isn't enough.

In this case we must not wait for the lock here, because there won't be any task
that can unlock it, and in result we end up with never fetching again for this specific
group.

This fixes the issue seen with https://kafkajs.slack.com/archives/CF6RFPF6K/p1584530032102400