### PR TITLE
Fix the type of the PartitionAssigner

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,9 +105,7 @@ export interface ConsumerConfig {
   readUncommitted?: boolean
 }
 
-export interface PartitionAssigner {
-  new(config: { cluster: Cluster }): Assigner
-}
+export type PartitionAssigner = (config: { cluster: Cluster }) => Assigner
 
 export interface CoordinatorMetadata {
   errorCode: number


### PR DESCRIPTION
This is not supposed to be a constructor (something to be called with `new`), but rather it is
just a simple callable thing.

---
See https://github.com/tulios/kafkajs/blob/3601d7a7ba32137179df1e44e2a5fab4ffd40f6b/src/consumer/index.js#L48-L51