### PR TITLE
Fix encoder instanceof issue with Encoder

### DIFF
--- a/src/protocol/encoder.js
+++ b/src/protocol/encoder.js
@@ -56,6 +56,7 @@ module.exports = class Encoder {
 
   constructor() {
     this.buffer = Buffer.alloc(0)
+    this.name = 'Encoder'
   }
 
   writeInt8(value) {
@@ -173,7 +174,7 @@ module.exports = class Encoder {
   }
 
   writeEncoder(value) {
-    if (value instanceof Encoder !== true) {
+    if (value == null || value.name !== 'Encoder') {
       throw new Error('value should be an instance of Encoder')
     }
     this.buffer = Buffer.concat([this.buffer, value.buffer])

--- a/src/protocol/encoder.js
+++ b/src/protocol/encoder.js
@@ -56,7 +56,6 @@ module.exports = class Encoder {
 
   constructor() {
     this.buffer = Buffer.alloc(0)
-    this.name = 'Encoder'
   }
 
   writeInt8(value) {
@@ -174,15 +173,15 @@ module.exports = class Encoder {
   }
 
   writeEncoder(value) {
-    if (value == null || value.name !== 'Encoder') {
+    if (value == null || value.buffer == null) {
       throw new Error('value should be an instance of Encoder')
     }
-    this.buffer = Buffer.concat([this.buffer, value.buffer])
-    return this
+
+    return this.writeBuffer(value.buffer)
   }
 
   writeEncoderArray(value) {
-    if (!Array.isArray(value) || value.some(v => !(v instanceof Encoder))) {
+    if (!Array.isArray(value) || value.some(v => v == null || !Buffer.isBuffer(v.buffer))) {
       throw new Error('all values should be an instance of Encoder[]')
     }
 
@@ -195,7 +194,7 @@ module.exports = class Encoder {
   }
 
   writeBuffer(value) {
-    if (value instanceof Buffer !== true) {
+    if (!Buffer.isBuffer(value)) {
       throw new Error('value should be an instance of Buffer')
     }
 

--- a/src/protocol/encoder.spec.js
+++ b/src/protocol/encoder.spec.js
@@ -16,6 +16,18 @@ describe('Protocol > Encoder', () => {
   const B = (...args) => Buffer.from(args)
   const L = value => Long.fromString(`${value}`)
 
+  describe('writeEncoder', () => {
+    it('should throw if the value is not an Encoder', () => {
+      const encoder = new Encoder()
+      expect(() => encoder.writeEncoder()).toThrow('value should be an instance of Encoder')
+    })
+
+    it('should append the value buffer to the existing encoder', () => {
+      const encoder = new Encoder().writeBuffer(B(1)).writeEncoder(new Encoder().writeBuffer(B(2)))
+      expect(encoder.buffer).toEqual(B(1, 2))
+    })
+  })
+
   describe('varint', () => {
     test('encode signed int32 numbers', () => {
       expect(signed32(0)).toEqual(B(0x00))

--- a/src/protocol/encoder.spec.js
+++ b/src/protocol/encoder.spec.js
@@ -28,6 +28,25 @@ describe('Protocol > Encoder', () => {
     })
   })
 
+  describe('writeEncoderArray', () => {
+    it('should throw if any of the elements in the array are not encoders', () => {
+      const values = [new Encoder(), 'not an encoder']
+      expect(() => new Encoder().writeEncoderArray(values)).toThrow(
+        'all values should be an instance of Encoder[]'
+      )
+    })
+
+    it('should append all encoder values to the existing encoder', () => {
+      const values = [
+        new Encoder().writeBuffer(B(1)),
+        new Encoder().writeBuffer(B(2)),
+        new Encoder().writeBuffer(B(3)),
+      ]
+
+      expect(new Encoder().writeEncoderArray(values).buffer).toEqual(B(1, 2, 3))
+    })
+  })
+
   describe('varint', () => {
     test('encode signed int32 numbers', () => {
       expect(signed32(0)).toEqual(B(0x00))


### PR DESCRIPTION
@bfdill was having this issue where KafkaJS was failing to encode requests because `Encoder.writeEncoder` was throwing, because the value was not an instanceof `Encoder`, even though we could clearly see that it was in fact an encoder. I don't have an explanation for this, but we have seen issues with instanceof before. I'm guessing that his project was doing something strange at build time, since it was a Typescript project (maybe he's accidentally transpiling `node_modules`).

```
Error: value should be an instance of Encoder
        at Encoder.writeEncoder (/Users/user/projects/project/node_modules/kafkajs/src/protocol/encoder.js:177:13)
        at Object.<anonymous>.module.exports (/Users/user/projects/project/node_modules/kafkajs/src/protocol/request.js:10:6)
        at sendRequest (/Users/user/projects/project/node_modules/kafkajs/src/network/connection.js:276:30)
        at Connection.send (/Users/user/projects/project/node_modules/kafkajs/src/network/connection.js:303:53)
        at Broker.apiVersions (/Users/user/projects/project/node_modules/kafkajs/src/broker/index.js:153:20)
        at Broker.connect (/Users/user/projects/project/node_modules/kafkajs/src/broker/index.js:93:25)
        at /Users/user/projects/project/node_modules/kafkajs/src/cluster/brokerPool.js:79:9
        at Cluster.connect (/Users/user/projects/project/node_modules/kafkajs/src/cluster/index.js:104:5)
        at Object.connect (/Users/user/projects/project/node_modules/kafkajs/src/producer/index.js:205:7) {
      [stack]: 'Error: value should be an instance of Encoder\n' +
        '    at Encoder.writeEncoder (/Users/user/projects/project/node_modules/kafkajs/src/protocol/encoder.js:177:13)\n' +
        '    at Object.<anonymous>.module.exports (/Users/user/projects/project/node_modules/kafkajs/src/protocol/request.js:10:6)\n' +
        '    at sendRequest (/Users/user/projects/project/node_modules/kafkajs/src/network/connection.js:276:30)\n' +
        '    at Connection.send (/Users/user/projects/project/node_modules/kafkajs/src/network/connection.js:303:53)\n' +
        '    at Broker.apiVersions (/Users/user/projects/project/node_modules/kafkajs/src/broker/index.js:153:20)\n' +
        '    at Broker.connect (/Users/user/projects/project/node_modules/kafkajs/src/broker/index.js:93:25)\n' +
        '    at /Users/user/projects/project/node_modules/kafkajs/src/cluster/brokerPool.js:79:9\n' +
        '    at Cluster.connect (/Users/user/projects/project/node_modules/kafkajs/src/cluster/index.js:104:5)\n' +
        '    at Object.connect (/Users/user/projects/project/node_modules/kafkajs/src/producer/index.js:205:7)',
      [message]: 'value should be an instance of Encoder'
    }
```
I thought about adding a `name` property to every instance of Encoder, but it feels a bit ugly, so I decided to go for an approach where we instead just check that the value is "Encoder-like", i.e. has a `buffer` property with a Buffer inside it, since that's what we actually care about. Anyway the encoder is only an internal class, so it's mostly there to prevent us from shooting ourselves in the foot.