### PR TITLE
Document the parameters of `writeArray` and `writeNullableArray`

### DIFF
--- a/src/protocol/encoder.js
+++ b/src/protocol/encoder.js
@@ -202,6 +202,10 @@ module.exports = class Encoder {
     return this
   }
 
+  /**
+   * @param {any[]} array
+   * @param {'int32'|'number'|'string'|'object'} [type]
+   */
   writeNullableArray(array, type) {
     // A null value is encoded with length of -1 and there are no following bytes
     // On the context of this library, empty array and null are the same thing
@@ -209,6 +213,11 @@ module.exports = class Encoder {
     return this.writeArray(array, type, length)
   }
 
+  /**
+   * @param {any[]} array
+   * @param {'int32'|'number'|'string'|'object'} [type]
+   * @param {number} [length]
+   */
   writeArray(array, type, length) {
     const arrayLength = length == null ? array.length : length
     this.writeInt32(arrayLength)
@@ -228,7 +237,6 @@ module.exports = class Encoder {
     } else {
       array.forEach(value => {
         switch (typeof value) {
-          case 'int32':
           case 'number':
             this.writeInt32(value)
             break


### PR DESCRIPTION
This fixes a bunch of warnings in smart IDEs when looking at code (for example in fetch/v7/request.js) that doesn't
provide the type and length parameters.

While there: Drop the case of 'typeof value' returning 'int32': That just cannot happen.