### PR TITLE
Remove the 'autoCommit' option from the `createConsumerGroup` call parameter

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -232,7 +232,6 @@ module.exports = ({
 
     const restart = onCrash => {
       consumerGroup = createConsumerGroup({
-        autoCommit,
         autoCommitInterval,
         autoCommitThreshold,
       })


### PR DESCRIPTION
`createConsumerGroup` doesn't take an `autoCommit` option (anymore?), this is only needed
for the actual runner.