### PR TITLE
Remove the 'autoCommit' option from the `createConsumerGroup` call parameter

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -232,7 +232,6 @@ module.exports = ({
 
     const restart = onCrash => {
       consumerGroup = createConsumerGroup({
-        autoCommit,
         autoCommitInterval,
         autoCommitThreshold,
       })


### PR DESCRIPTION
Closes #689 .

@ankon: Your PR didn't have latest master, and I didn't have permission to push to your fork, so the easiest and fastest thing was to just create another PR and cherry-pick your change.