### PR TITLE
improved docs - fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Learn more about using [KafkaJS on the official site!](https://kafka.js.org)
 
 ## <a name="contributing"></a> Contributing
 
-KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bugfixes, feature development and other contributions.
+KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bug fixes, feature development and other contributions.
 
 See [Developing KafkaJS](https://kafka.js.org/docs/contribution-guide) for information on how to run and develop KafkaJS.
 

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -94,10 +94,10 @@ await consumer.run({
 * `eachBatchAutoResolve` configures auto-resolve of batch processing. If set to true, KafkaJS will automatically commit the last offset of the batch if `eachBatch` doesn't throw an error. Default: true.
 * `batch.highWatermark` is the last committed offset within the topic partition. It can be useful for calculating lag.
 * `resolveOffset()` is used to mark a message in the batch as processed. In case of errors, the consumer will automatically commit the resolved offsets.
-* `async heartbeat()` can be used to send heartbeat to the broker according to the set `heartbeatInterval` value in consumer [configuration](#options).
-* `async commitOffsetsIfNecessary(offsets?)` is used to commit offsets based on the autoCommit configurations (`autoCommitInterval` and `autoCommitThreshold`). Note that auto commit won't happen in `eachBatch` if `commitOffsetsIfNecessary` is not invoked. Take a look at [autoCommit](#auto-commit) for more information.
+* `heartbeat(): Promise<void>` can be used to send heartbeat to the broker according to the set `heartbeatInterval` value in consumer [configuration](#options).
+* `commitOffsetsIfNecessary(offsets?): Promise<void>` is used to commit offsets based on the autoCommit configurations (`autoCommitInterval` and `autoCommitThreshold`). Note that auto commit won't happen in `eachBatch` if `commitOffsetsIfNecessary` is not invoked. Take a look at [autoCommit](#auto-commit) for more information.
 * `uncommittedOffsets()` returns all offsets by topic-partition which have not yet been committed.
-* `isRunning()` returns true is consumer is in running state, else it returns false.
+* `isRunning()` returns true if consumer is in running state, else it returns false.
 * `isStale()` returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling [`consumer.seek`](#seek) the messages in the batch should be discarded, as they are not at the offset we seeked to.
 
 ### Example

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -55,13 +55,22 @@ await consumer.run({
 
 ## <a name="each-batch"></a> eachBatch
 
-Some use cases require dealing with batches directly. This handler will feed your function batches and provide some utility functions to give your code more flexibility: `resolveOffset`, `heartbeat`, `isRunning`, and `commitOffsetsIfNecessary`. All resolved offsets will be automatically committed after the function is executed.
+Some use cases require dealing with batches directly. This handler will feed your function batches and provide some utility functions to give your code more flexibility: `resolveOffset`, `heartbeat`, `commitOffsetsIfNecessary`, `uncommittedOffsets`, `isRunning`, and `isStale`. All resolved offsets will be automatically committed after the function is executed.
 
 > Note: Be aware that using `eachBatch` directly is considered a more advanced use case as compared to using `eachMessage`, since you will have to understand how session timeouts and heartbeats are connected.
 
 ```javascript
 await consumer.run({
-    eachBatch: async ({ batch, resolveOffset, heartbeat, isRunning, isStale }) => {
+    eachBatchAutoResolve: true,
+    eachBatch: async ({
+        batch,
+        resolveOffset,
+        heartbeat,
+        commitOffsetsIfNecessary,
+        uncommittedOffsets,
+        isRunning,
+        isStale,
+    }) => {
         for (let message of batch.messages) {
             console.log({
                 topic: batch.topic,
@@ -82,11 +91,13 @@ await consumer.run({
 })
 ```
 
-* `batch.highWatermark` is the last committed offset within the topic partition. It can be useful for calculating lag.
 * `eachBatchAutoResolve` configures auto-resolve of batch processing. If set to true, KafkaJS will automatically commit the last offset of the batch if `eachBatch` doesn't throw an error. Default: true.
+* `batch.highWatermark` is the last committed offset within the topic partition. It can be useful for calculating lag.
 * `resolveOffset()` is used to mark a message in the batch as processed. In case of errors, the consumer will automatically commit the resolved offsets.
-* `commitOffsetsIfNecessary(offsets?)` is used to commit offsets based on the autoCommit configurations (`autoCommitInterval` and `autoCommitThreshold`). Note that auto commit won't happen in `eachBatch` if `commitOffsetsIfNecessary` is not invoked. Take a look at [autoCommit](#auto-commit) for more information.
+* `async heartbeat()` can be used to send heartbeat to the broker according to the set `heartbeatInterval` value in consumer [configuration](#options).
+* `async commitOffsetsIfNecessary(offsets?)` is used to commit offsets based on the autoCommit configurations (`autoCommitInterval` and `autoCommitThreshold`). Note that auto commit won't happen in `eachBatch` if `commitOffsetsIfNecessary` is not invoked. Take a look at [autoCommit](#auto-commit) for more information.
 * `uncommittedOffsets()` returns all offsets by topic-partition which have not yet been committed.
+* `isRunning()` returns true is consumer is in running state, else it returns false.
 * `isStale()` returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling [`consumer.seek`](#seek) the messages in the batch should be discarded, as they are not at the offset we seeked to.
 
 ### Example
@@ -130,7 +141,7 @@ A guideline for setting `partitionsConsumedConcurrently` would be that it should
 
 The messages are always fetched in batches from Kafka, even when using the `eachMessage` handler. All resolved offsets will be committed to Kafka after processing the whole batch.
 
-Committing offsets periodically during a batch allows the consumer to recover from group rebalances, stale metadata and other issues before it has completed the entire batch. However, committing more often increases network traffic and slows down processing. Auto-commit offers more flexibility when committing offsets; there are two flavors available:
+Committing offsets periodically during a batch allows the consumer to recover from group rebalancing, stale metadata and other issues before it has completed the entire batch. However, committing more often increases network traffic and slows down processing. Auto-commit offers more flexibility when committing offsets; there are two flavors available:
 
 `autoCommitInterval`: The consumer will commit offsets after a given period, for example, five seconds. Value in milliseconds. Default: `null`
 

--- a/docs/ContributionGuide.md
+++ b/docs/ContributionGuide.md
@@ -3,7 +3,7 @@ id: contribution-guide
 title: Contributing
 ---
 
-KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bugfixes, feature development and other contributions.
+KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bug fixes, feature development and other contributions.
 
 Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://kafkajs-slackin.herokuapp.com/) is also a good place if you want to discuss your plans before starting your implementation.
 

--- a/src/admin/__tests__/alterConfigs.spec.js
+++ b/src/admin/__tests__/alterConfigs.spec.js
@@ -89,7 +89,7 @@ describe('Admin', () => {
       )
     })
 
-    test('throws an error if there are invalid resource configEntriy values', async () => {
+    test('throws an error if there are invalid resource configEntry values', async () => {
       admin = createAdmin({ cluster: createCluster(), logger: newLogger() })
       const resources = [
         {

--- a/src/admin/__tests__/deleteGroups.spec.js
+++ b/src/admin/__tests__/deleteGroups.spec.js
@@ -77,7 +77,7 @@ describe('Admin', () => {
     })
 
     test('delete groups that is still connected', async () => {
-      // let's try to delete group that has consumer conected, it should throw error
+      // let's try to delete group that has consumer connected, it should throw error
       try {
         await admin.deleteGroups([groupId])
       } catch (error) {

--- a/src/admin/__tests__/resetOffsets.spec.js
+++ b/src/admin/__tests__/resetOffsets.spec.js
@@ -84,7 +84,7 @@ describe('Admin', () => {
       expect(offsets).toEqual([{ partition: 0, offset: '-2', metadata: null }])
     })
 
-    test('throws an error if the consumer group is runnig', async () => {
+    test('throws an error if the consumer group is running', async () => {
       consumer = createConsumer({ groupId, cluster: createCluster(), logger: newLogger() })
       await consumer.connect()
       await consumer.subscribe({ topic: topicName })

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -217,7 +217,7 @@ module.exports = class ConsumerGroup {
           assignedPartitions,
         })
 
-        // If the consumer is not aware of all assigned partions, refresh metadata
+        // If the consumer is not aware of all assigned partitions, refresh metadata
         // and update the list of partitions per subscribed topic. It's enough to perform
         // this operation once since refresh metadata will update metadata for all topics
         await this.cluster.refreshMetadata()

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -336,7 +336,7 @@ module.exports = ({
 
         if (metadata !== null && typeof metadata !== 'string') {
           throw new KafkaJSNonRetriableError(
-            `Invalid offset metatadta, expected string or null, received ${metadata}`
+            `Invalid offset metadata, expected string or null, received ${metadata}`
           )
         }
 

--- a/src/producer/index.js
+++ b/src/producer/index.js
@@ -83,7 +83,7 @@ module.exports = ({
 
   /**
    * Begin a transaction. The returned object contains methods to send messages
-   * to the transaction and end the transaction by comitting or aborting.
+   * to the transaction and end the transaction by committing or aborting.
    *
    * Only messages sent on the transaction object will participate in the transaction.
    *


### PR DESCRIPTION
Consumer docs are missing some params in the example. I have also added ~async~ `: Promise<void>` with methods that return Promise. Let me know if that is okay.
Also fixed some typos.