### PR TITLE
Add missing TypeScript typing for Admin.listTopics

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -295,6 +295,7 @@ export interface SeekEntry {
 export type Admin = {
   connect(): Promise<void>
   disconnect(): Promise<void>
+  listTopics(): Promise<string[]>
   createTopics(options: {
     validateOnly?: boolean
     waitForLeaders?: boolean

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -173,6 +173,8 @@ const runAdmin = async () => {
     })
   })
 
+  await admin.listTopics()
+
   await admin.createTopics({
     topics: [{ topic, numPartitions: 10, replicationFactor: 1 }],
     timeout: 30000,


### PR DESCRIPTION
#718 added the ability to list topics, but the typing for the `Admin` was not updated.