### PR TITLE
Improve the docker-compose environment for better compatibility

### DIFF
--- a/docker-compose.2_2.yml
+++ b/docker-compose.2_2.yml
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
       KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
     volumes:
-      - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf
+      - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf:ro,z
 
   kafka1:
     image: confluentinc/cp-kafka:5.2.3-1
@@ -49,13 +49,12 @@ services:
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
-      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks
-      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds
-      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds
-      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds
-      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf
+      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
+      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
+      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds:ro,z
+      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds:ro,z
+      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds:ro,z
+      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf:ro,z
   
   kafka2:
     image: confluentinc/cp-kafka:5.2.3-1
@@ -93,13 +92,12 @@ services:
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
-      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks
-      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds
-      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds
-      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds
-      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf
+      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
+      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
+      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds:ro,z
+      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds:ro,z
+      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds:ro,z
+      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf:ro,z
 
   kafka3:
     image: confluentinc/cp-kafka:5.2.3-1
@@ -137,10 +135,9 @@ services:
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
-      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks
-      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds
-      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds
-      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds
-      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf
+      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
+      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
+      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds:ro,z
+      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds:ro,z
+      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds:ro,z
+      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf:ro,z

--- a/docker-compose.2_3.yml
+++ b/docker-compose.2_3.yml
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
       KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
     volumes:
-      - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf
+      - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf:ro,z
 
   kafka1:
     image: confluentinc/cp-kafka:5.3.1
@@ -49,13 +49,12 @@ services:
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
-      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks
-      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds
-      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds
-      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds
-      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf
+      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
+      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
+      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds:ro,z
+      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds:ro,z
+      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds:ro,z
+      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf:ro,z
   
   kafka2:
     image: confluentinc/cp-kafka:5.3.1
@@ -93,13 +92,12 @@ services:
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
-      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks
-      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds
-      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds
-      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds
-      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf
+      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
+      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
+      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds:ro,z
+      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds:ro,z
+      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds:ro,z
+      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf:ro,z
 
   kafka3:
     image: confluentinc/cp-kafka:5.3.1
@@ -137,10 +135,9 @@ services:
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
       KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
-      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks
-      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds
-      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds
-      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds
-      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf
+      - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
+      - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
+      - ./testHelpers/certs/keystore_creds:/etc/kafka/secrets/keystore_creds:ro,z
+      - ./testHelpers/certs/sslkey_creds:/etc/kafka/secrets/sslkey_creds:ro,z
+      - ./testHelpers/certs/truststore_creds:/etc/kafka/secrets/truststore_creds:ro,z
+      - ./testHelpers/kafka/server-jaas.conf:/opt/kafka/config/server-jaas.conf:ro,z


### PR DESCRIPTION
* Remove the volume reference to /var/run/docker.sock
  This isn't needed (there's no docker calls from inside the containers, basically), and won't work
  with other container runtimes such as podman on Fedora.
* Mark the other volumes as mounted "read-only": The containers are merely consuming from these,
  and shouldn't ever have to touch the content there
* Explicitly label the remaining volumes for SELinux sharing between containers
  This fixes additional problems on SELinux-enabled environments, and is a no-op for other
  environments.