### PR TITLE
Make Array shuffle test pass in Node >= 11.0.0

### DIFF
--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -1,1 +1,19 @@
-module.exports = array => [...array].sort(() => Math.random() - 0.5)
+const shuffle = array => array.sort(() => Math.random() - 0.5)
+
+module.exports = array => {
+  if (!Array.isArray(array)) {
+    throw new TypeError("'array' is not an array")
+  }
+
+  if (array.length < 2) {
+    return array
+  }
+
+  let shuffled = [...array]
+
+  while (shuffled.every((value, index) => value === array[index])) {
+    shuffled = shuffle(shuffled)
+  }
+
+  return shuffled
+}

--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -1,5 +1,3 @@
-const shuffle = array => array.sort(() => Math.random() - 0.5)
-
 module.exports = array => {
   if (!Array.isArray(array)) {
     throw new TypeError("'array' is not an array")
@@ -9,11 +7,14 @@ module.exports = array => {
     return array
   }
 
-  let shuffled = [...array]
+  const copy = array.slice()
 
-  while (!shuffled.some((value, index) => value !== array[index])) {
-    shuffled = shuffle(shuffled)
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    const temp = copy[i]
+    copy[i] = copy[j]
+    copy[j] = temp
   }
 
-  return shuffled
+  return copy
 }

--- a/src/utils/shuffle.js
+++ b/src/utils/shuffle.js
@@ -11,7 +11,7 @@ module.exports = array => {
 
   let shuffled = [...array]
 
-  while (shuffled.every((value, index) => value === array[index])) {
+  while (!shuffled.some((value, index) => value !== array[index])) {
     shuffled = shuffle(shuffled)
   }
 

--- a/src/utils/shuffle.spec.js
+++ b/src/utils/shuffle.spec.js
@@ -3,17 +3,19 @@ const shuffle = require('./shuffle')
 describe('Utils > shuffle', () => {
   it('shuffles', () => {
     const array = [1, 2, 3]
-    jest
-      .spyOn(Math, 'random')
-      .mockImplementationOnce(() => 0.4)
-      .mockImplementationOnce(() => 0.7)
-      .mockImplementationOnce(() => 0.4)
-      .mockImplementationOnce(() => 0.6)
-      .mockImplementationOnce(() => 0.6)
-      .mockImplementationOnce(() => 0.6)
+    const shuffled = shuffle(array)
 
-    expect(shuffle(array)).toEqual([1, 3, 2])
-    expect(shuffle(array)).toEqual([3, 2, 1])
-    expect(Math.random).toHaveBeenCalledTimes(6)
+    expect(shuffled).not.toEqual(array)
+    expect(shuffled).toIncludeSameMembers(array)
+  })
+
+  it('returns the same order for single element arrays', () => {
+    expect(shuffle([1])).toEqual([1])
+  })
+
+  it('throws if it receives a non-array', () => {
+    expect(() => shuffle()).toThrowError(TypeError)
+    expect(() => shuffle('foo')).toThrowError(TypeError)
+    expect(() => shuffle({})).toThrowError(TypeError)
   })
 })

--- a/src/utils/shuffle.spec.js
+++ b/src/utils/shuffle.spec.js
@@ -2,7 +2,9 @@ const shuffle = require('./shuffle')
 
 describe('Utils > shuffle', () => {
   it('shuffles', () => {
-    const array = [1, 2, 3]
+    const array = Array(500)
+      .fill()
+      .map((_, i) => i)
     const shuffled = shuffle(array)
 
     expect(shuffled).not.toEqual(array)


### PR DESCRIPTION
Due to a change in how array sorting works, the shuffle test would fail in Node >= 11.0.0.

```
 FAIL  src/utils/shuffle.spec.js
  ● Utils > shuffle › shuffles

    expect(received).toEqual(expected) // deep equality

    - Expected  - 2
    + Received  + 2

      Array [
    -   1,
    -   3,
        2,
    +   3,
    +   1,
      ]

      13 |       .mockImplementationOnce(() => 0.6)
      14 |
    > 15 |     expect(shuffle(array)).toEqual([1, 3, 2])
         |                            ^
      16 |     expect(shuffle(array)).toEqual([3, 2, 1])
      17 |     expect(Math.random).toHaveBeenCalledTimes(6)
      18 |   })

      at Object.<anonymous> (src/utils/shuffle.spec.js:15:28)
```

Instead of relying on implementation details of how the engine implements sorting, we'll add a requirement on the shuffle implementation to always return a different order than the input array. That way we can simply assert that the returned array is different from the input, rather than asserting on the exact order, which may differ between engine versions since it's explicitly undefined in the spec.

The updated test will pass in both Node 10 and 11+.