### PR TITLE
Add `admin.describeGroups`

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -387,14 +387,6 @@ List groups available on the broker.
 await admin.listGroups()
 ```
 
-Example:
-
-```javascript
-const { ResourceTypes } = require('kafkajs')
-
-await admin.listGroups()
-```
-
 Example response:
 
 ```javascript
@@ -403,6 +395,33 @@ Example response:
         {groupId: 'testgroup', protocolType: 'consumer'}
     ]
 }
+```
+
+## <a name="describe-groups"></a> Describe groups
+
+Describe consumer groups by `groupId`s. This is similar to [consumer.describeGroup()](Consuming.md#describe-group), except
+it allows you to describe multiple groups and does not require you to have a consumer be part of any of those groups.
+
+```js
+await admin.describeGroups([ 'testgroup' ])
+// {
+//   groups: [{
+//     errorCode: 0,
+//     groupId: 'testgroup',
+//     members: [
+//       {
+//         clientHost: '/172.19.0.1',
+//         clientId: 'test-3e93246fe1f4efa7380a',
+//         memberAssignment: Buffer,
+//         memberId: 'test-3e93246fe1f4efa7380a-ff87d06d-5c87-49b8-a1f1-c4f8e3ffe7eb',
+//         memberMetadata: Buffer,
+//       },
+//     ],
+//     protocol: 'RoundRobinAssigner',
+//     protocolType: 'consumer',
+//     state: 'Stable',
+//   }]
+// }
 ```
 
 ## <a name="delete-groups"></a> Delete groups
@@ -418,8 +437,6 @@ await admin.deleteGroups([groupId])
 Example:
 
 ```javascript
-const { ResourceTypes } = require('kafkajs')
-
 await admin.deleteGroups(['group-test'])
 ```
 

--- a/src/admin/__tests__/describeGroups.spec.js
+++ b/src/admin/__tests__/describeGroups.spec.js
@@ -1,0 +1,119 @@
+const createAdmin = require('../index')
+const createConsumer = require('../../consumer')
+const createProducer = require('../../producer')
+
+const {
+  createCluster,
+  newLogger,
+  createTopic,
+  secureRandom,
+  createModPartitioner,
+  waitForConsumerToJoinGroup,
+  waitForMessages,
+} = require('testHelpers')
+
+describe('Admin', () => {
+  let admin, topicName, groupIds, cluster, consumers, producer
+
+  beforeAll(async () => {
+    topicName = `test-topic-${secureRandom()}`
+    groupIds = [
+      `consumer-group-id-${secureRandom()}`,
+      `consumer-group-id-${secureRandom()}`,
+      `consumer-group-id-${secureRandom()}`,
+    ]
+
+    cluster = createCluster()
+    admin = createAdmin({ cluster: cluster, logger: newLogger() })
+    consumers = groupIds.map(groupId =>
+      createConsumer({
+        cluster,
+        groupId,
+        maxWaitTimeInMs: 100,
+        logger: newLogger(),
+      })
+    )
+
+    producer = createProducer({
+      cluster,
+      createPartitioner: createModPartitioner,
+      logger: newLogger(),
+    })
+
+    await Promise.all([
+      admin.connect(),
+      producer.connect(),
+      ...[consumers.map(consumer => consumer.connect())],
+    ])
+
+    await createTopic({ topic: topicName })
+
+    const messagesConsumed = []
+    await Promise.all(
+      consumers.map(async consumer => {
+        await consumer.subscribe({ topic: topicName, fromBeginning: true })
+        consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+        await waitForConsumerToJoinGroup(consumer)
+      })
+    )
+
+    const messages = Array(1)
+      .fill()
+      .map(() => {
+        const value = secureRandom()
+        return { key: `key-${value}`, value: `value-${value}` }
+      })
+
+    await producer.send({ acks: 1, topic: topicName, messages })
+    await waitForMessages(messagesConsumed, { number: messages.length * consumers.length })
+  })
+
+  afterAll(async () => {
+    admin && (await admin.disconnect())
+    consumers && (await Promise.all(consumers.map(consumer => consumer.disconnect())))
+    producer && (await producer.disconnect())
+  })
+
+  describe('describeGroups', () => {
+    test('returns describe group response for multiple groups', async () => {
+      const describeGroupsResponse = await admin.describeGroups(groupIds)
+
+      expect(describeGroupsResponse.groups).toIncludeSameMembers(
+        groupIds.map(groupId => ({
+          errorCode: 0,
+          groupId,
+          members: [
+            {
+              clientHost: expect.any(String),
+              clientId: expect.any(String),
+              memberId: expect.any(String),
+              memberAssignment: expect.anything(),
+              memberMetadata: expect.anything(),
+            },
+          ],
+          protocol: 'RoundRobinAssigner',
+          protocolType: 'consumer',
+          state: 'Stable',
+        }))
+      )
+    })
+
+    test('returns a response for groups that do not exist', async () => {
+      const groupId = `non-existent-consumer-group-id-${secureRandom()}`
+      const response = await admin.describeGroups([groupId])
+
+      expect(response).toEqual({
+        groups: [
+          {
+            errorCode: 0,
+            groupId,
+            members: [],
+            protocol: '',
+            protocolType: '',
+            state: 'Dead',
+          },
+        ],
+      })
+    })
+  })
+})


### PR DESCRIPTION
Implements a new method on the Admin client, `describeGroups`. It works the same as the equivalent method on the Consumer, except it allows you to query by multiple groupIds.

Fixes #731