### PR TITLE
Use addMultipleTargetTopics instead of looping over multiple calls to addTargetTopic

### DIFF
--- a/src/producer/sendMessages.js
+++ b/src/producer/sendMessages.js
@@ -18,9 +18,8 @@ module.exports = ({ logger, cluster, partitioner, eosManager }) => {
   return async ({ acks, timeout, compression, topicMessages }) => {
     const responsePerBroker = new Map()
 
-    for (const { topic } of topicMessages) {
-      await cluster.addTargetTopic(topic)
-    }
+    const topics = topicMessages.map(({ topic }) => topic)
+    await cluster.addMultipleTargetTopics(topics)
 
     const createProducerRequests = async responsePerBroker => {
       const topicMetadata = new Map()

--- a/src/producer/sendMessages.spec.js
+++ b/src/producer/sendMessages.spec.js
@@ -54,7 +54,7 @@ describe('Producer > sendMessages', () => {
       },
     ]
     cluster = {
-      addTargetTopic: jest.fn(),
+      addMultipleTargetTopics: jest.fn(),
       refreshMetadata: jest.fn(),
       refreshMetadataIfNecessary: jest.fn(),
       findTopicPartitionMetadata: jest.fn(() => topicPartitionMetadata),


### PR DESCRIPTION
`addTargetTopic` internally calls `addMultipleTargetTopics` by building a singular array anyways, and
`addMultipleTargetTopics` itself is fairly expensive and requires locking: Simply calling
it directly should make things faster when sending out batches for multiple topics.

---
This should help when batch-producing messages to multiple topics at the same time. Looking at the produce path it seems there could be quite some additional potential for "improvements", but it is difficult to quantify how much all of that would help.