### PR TITLE
Fix the return value of Cluster.findTopicPartitionMetadata

### DIFF
--- a/src/cluster/__tests__/findTopicPartitionMetadata.spec.js
+++ b/src/cluster/__tests__/findTopicPartitionMetadata.spec.js
@@ -9,13 +9,15 @@ describe('Cluster > findTopicPartitionMetadata', () => {
   })
 
   test('returns the partition metadata of a topic', () => {
-    const partitionMetadata = {
-      isr: [2],
-      leader: 2,
-      partitionErrorCode: 0,
-      partitionId: 0,
-      replicas: [2],
-    }
+    const partitionMetadata = [
+      {
+        isr: [2],
+        leader: 2,
+        partitionErrorCode: 0,
+        partitionId: 0,
+        replicas: [2],
+      },
+    ]
     cluster.brokerPool.metadata = { topicMetadata: [{ topic, partitionMetadata }] }
     expect(cluster.findTopicPartitionMetadata(topic)).toEqual(partitionMetadata)
   })
@@ -33,13 +35,15 @@ describe('Cluster > findTopicPartitionMetadata', () => {
   })
 
   it('returns an empty array if there is no metadata for a given topic', () => {
-    const partitionMetadata = {
-      isr: [2],
-      leader: 2,
-      partitionErrorCode: 0,
-      partitionId: 0,
-      replicas: [2],
-    }
+    const partitionMetadata = [
+      {
+        isr: [2],
+        leader: 2,
+        partitionErrorCode: 0,
+        partitionId: 0,
+        replicas: [2],
+      },
+    ]
     cluster.brokerPool.metadata = { topicMetadata: [{ topic, partitionMetadata }] }
     const anotherTopic = `test-topic-${secureRandom()}`
     expect(cluster.findTopicPartitionMetadata(anotherTopic)).toEqual([])

--- a/src/producer/sendMessages.js
+++ b/src/producer/sendMessages.js
@@ -29,7 +29,7 @@ module.exports = ({ logger, cluster, partitioner, eosManager }) => {
       for (const { topic, messages } of topicMessages) {
         const partitionMetadata = cluster.findTopicPartitionMetadata(topic)
 
-        if (keys(partitionMetadata).length === 0) {
+        if (partitionMetadata.length === 0) {
           logger.debug('Producing to topic without metadata', {
             topic,
             targetTopics: Array.from(cluster.targetTopics),

--- a/src/producer/sendMessages.spec.js
+++ b/src/producer/sendMessages.spec.js
@@ -197,8 +197,8 @@ describe('Producer > sendMessages', () => {
     })
 
     cluster.findTopicPartitionMetadata
-      .mockImplementationOnce(() => ({}))
-      .mockImplementationOnce(() => partitionsPerLeader)
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => topicPartitionMetadata)
 
     await sendMessages({ topicMessages: [{ topic, messages }] })
 
@@ -216,8 +216,8 @@ describe('Producer > sendMessages', () => {
     eosManager.getSequence.mockReturnValue(5)
 
     cluster.findTopicPartitionMetadata
-      .mockImplementationOnce(() => ({}))
-      .mockImplementationOnce(() => partitionsPerLeader)
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => topicPartitionMetadata)
 
     await sendMessages({
       topicMessages: [{ topic, messages }],
@@ -262,8 +262,8 @@ describe('Producer > sendMessages', () => {
     })
 
     cluster.findTopicPartitionMetadata
-      .mockImplementationOnce(() => ({}))
-      .mockImplementationOnce(() => partitionsPerLeader)
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => topicPartitionMetadata)
 
     eosManager.isTransactional.mockReturnValue(true)
 
@@ -302,8 +302,8 @@ describe('Producer > sendMessages', () => {
     })
 
     cluster.findTopicPartitionMetadata
-      .mockImplementationOnce(() => ({}))
-      .mockImplementationOnce(() => partitionsPerLeader)
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => topicPartitionMetadata)
 
     eosManager.isTransactional.mockReturnValue(true)
 
@@ -347,8 +347,8 @@ describe('Producer > sendMessages', () => {
     })
 
     cluster.findTopicPartitionMetadata
-      .mockImplementationOnce(() => ({}))
-      .mockImplementationOnce(() => partitionsPerLeader)
+      .mockImplementationOnce(() => [])
+      .mockImplementationOnce(() => topicPartitionMetadata)
 
     eosManager.isTransactional.mockReturnValue(false)
 


### PR DESCRIPTION
The return value is not an Object, but an Array (of PartitionMetadata objects). This also means we can
simply check the number of entries and don't need to calculate the keys when sending messages.

Note that this exposed a bunch of problems in the tests as well: the mocked calls not just returned the
wrong type, but in fact returned a completely unrelated value.