### PR TITLE
Fix a typo in a type name

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -522,7 +522,7 @@ export type GroupDescription = {
 }
 
 export type TopicPartitions = { topic: string; partitions: number[] }
-export type TopicPartitionOffsetAndMedata = {
+export type TopicPartitionOffsetAndMetadata = {
   topic: string
   partition: number
   offset: string
@@ -669,7 +669,7 @@ export type Consumer = {
   subscribe(topic: ConsumerSubscribeTopic): Promise<void>
   stop(): Promise<void>
   run(config?: ConsumerRunConfig): Promise<void>
-  commitOffsets(topicPartitions: Array<TopicPartitionOffsetAndMedata>): Promise<void>
+  commitOffsets(topicPartitions: Array<TopicPartitionOffsetAndMetadata>): Promise<void>
   seek(topicPartition: { topic: string; partition: number; offset: string }): void
   describeGroup(): Promise<GroupDescription>
   pause(topics: Array<{ topic: string; partitions?: number[] }>): void

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -529,6 +529,9 @@ export type TopicPartitionOffsetAndMetadata = {
   metadata?: string | null
 }
 
+// TODO: Remove with 2.x
+export type TopicPartitionOffsetAndMedata = TopicPartitionOffsetAndMetadata
+
 export type Batch = {
   topic: string
   partition: number


### PR DESCRIPTION
Note that this technically is a backwards-incompatible change (the type `TopicPartitionOffsetAndMedata` is no longer exported), which feels ok to me. If it isn't this could be "fixed" by exporting the old type name as well as

```typescript
export type TopicPartitionOffsetAndMedata = TopicPartitionOffsetAndMetadata
```