### PR TITLE
Sort the partitions before checking with `toEqual`

### DIFF
--- a/src/broker/__tests__/txnOffsetCommit.spec.js
+++ b/src/broker/__tests__/txnOffsetCommit.spec.js
@@ -100,6 +100,7 @@ describe('Broker > TxnOffsetCommit', () => {
       ],
     })
 
+    result.topics.forEach(topic => topic.partitions.sort((p1, p2) => p1.partition - p2.partition))
     expect(result).toEqual({
       throttleTime: 0,
       topics: [


### PR DESCRIPTION
While `toEqual` does a deep equality, it won't be able to see that the partition arrays are "equal enough" when
they are reordered.

---
Output from a failing run:

~~~~
FAIL  src/broker/__tests__/txnOffsetCommit.spec.js
● Broker > TxnOffsetCommit › request

  expect(received).toEqual(expected) // deep equality

  - Expected  - 2
  + Received  + 2

  @@ -3,15 +3,15 @@
      "topics": Array [
        Object {
          "partitions": Array [
            Object {
              "errorCode": 0,
  -           "partition": 0,
  +           "partition": 1,
            },
            Object {
              "errorCode": 0,
  -           "partition": 1,
  +           "partition": 0,
            },
          ],
          "topic": "test-topic-e9910243da64e6938ba1-30855-77acdeb3-2eb9-4659-ae00-d0bb5c5e0b2b",
        },
      ],

    101 |     })
    102 | 
  > 103 |     expect(result).toEqual({
        |                    ^
    104 |       throttleTime: 0,
    105 |       topics: [
    106 |         {

    at Object.<anonymous> (src/broker/__tests__/txnOffsetCommit.spec.js:103:20)
        at runMicrotasks (<anonymous>)
~~~~