### PR TITLE
Use the length from the message to pre-allocate the result array

### DIFF
--- a/src/protocol/decoder.js
+++ b/src/protocol/decoder.js
@@ -133,9 +133,9 @@ module.exports = class Decoder {
       return []
     }
 
-    const array = []
+    const array = new Array(length)
     for (let i = 0; i < length; i++) {
-      array.push(reader(this))
+      array[i] = reader(this)
     }
 
     return array
@@ -148,9 +148,9 @@ module.exports = class Decoder {
       return []
     }
 
-    const array = []
+    const array = new Array(length)
     for (let i = 0; i < length; i++) {
-      array.push(reader(this))
+      array[i] = reader(this)
     }
 
     return array
@@ -163,9 +163,9 @@ module.exports = class Decoder {
       return []
     }
 
-    const array = []
+    const array = new Array(length)
     for (let i = 0; i < length; i++) {
-      array.push(await reader(this))
+      array[i] = await reader(this)
     }
 
     return array

--- a/src/protocol/recordBatch/v0/decoder.js
+++ b/src/protocol/recordBatch/v0/decoder.js
@@ -95,10 +95,10 @@ const decodeRecords = async (codec, recordsDecoder, recordContext) => {
   const compressedRecordsBuffer = recordsDecoder.readAll()
   const decompressedRecordBuffer = await codec.decompress(compressedRecordsBuffer)
   const decompressedRecordDecoder = new Decoder(decompressedRecordBuffer)
-  const records = []
+  const records = new Array(length)
 
   for (let i = 0; i < length; i++) {
-    records.push(decodeRecord(decompressedRecordDecoder, recordContext))
+    records[i] = decodeRecord(decompressedRecordDecoder, recordContext)
   }
 
   return records


### PR DESCRIPTION
This can help to improve performance ever so slightly -- but then again this is called in a tight loopy environment, so everything counts.

See https://jsperf.com/best-init-array/3 for a performance indication.