### PR TITLE
Improve offset commit handling

### DIFF
--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -60,7 +60,7 @@ module.exports = class OffsetManager {
     }
 
     let offset = this.resolvedOffsets[topic][partition]
-    if (Long.fromValue(offset).equals(-1)) {
+    if (isInvalidOffset(offset)) {
       offset = '0'
     }
 

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -105,7 +105,7 @@ module.exports = class OffsetManager {
 
     const subtractOffsets = (resolvedOffset, committedOffset) => {
       const resolvedOffsetLong = Long.fromValue(resolvedOffset)
-      return committedOffset === '-1'
+      return isInvalidOffset(committedOffset)
         ? resolvedOffsetLong
         : resolvedOffsetLong.subtract(Long.fromValue(committedOffset))
     }

--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -101,6 +101,7 @@ module.exports = class OffsetManager {
    * @returns {Long}
    */
   countResolvedOffsets() {
+    const committedOffsets = this.committedOffsets()
     const toPartitions = topic => keys(this.resolvedOffsets[topic])
 
     const subtractOffsets = (resolvedOffset, committedOffset) => {
@@ -111,10 +112,7 @@ module.exports = class OffsetManager {
     }
 
     const subtractPartitionOffsets = (topic, partition) =>
-      subtractOffsets(
-        this.resolvedOffsets[topic][partition],
-        this.committedOffsets()[topic][partition]
-      )
+      subtractOffsets(this.resolvedOffsets[topic][partition], committedOffsets[topic][partition])
 
     const subtractTopicOffsets = topic =>
       toPartitions(topic).map(partition => subtractPartitionOffsets(topic, partition))

--- a/src/consumer/offsetManager/isInvalidOffset.js
+++ b/src/consumer/offsetManager/isInvalidOffset.js
@@ -1,3 +1,3 @@
 const Long = require('long')
 
-module.exports = offset => !offset || Long.fromValue(offset).isNegative()
+module.exports = offset => (!offset && offset !== 0) || Long.fromValue(offset).isNegative()

--- a/src/consumer/offsetManager/isInvalidOffset.js
+++ b/src/consumer/offsetManager/isInvalidOffset.js
@@ -1,3 +1,3 @@
 const Long = require('long')
 
-module.exports = offset => !offset || Long.fromValue(offset).compare(0) === -1
+module.exports = offset => !offset || Long.fromValue(offset).isNegative()

--- a/src/consumer/offsetManager/isInvalidOffset.js
+++ b/src/consumer/offsetManager/isInvalidOffset.js
@@ -1,4 +1,3 @@
 const Long = require('long')
-const isNumber = number => /^-?\d+$/.test(number)
 
-module.exports = offset => !isNumber(offset) || Long.fromValue(offset).compare(0) === -1
+module.exports = offset => !offset || Long.fromValue(offset).compare(0) === -1


### PR DESCRIPTION
The main part of this PR is fixing the problem that batch processing sometimes will fail with this or a similar stack trace:
~~~~
TypeError: Cannot read property 'low' of undefined
        at Function.fromValue (/app/node_modules/long/src/long.js:286:25)
        at subtractOffsets (/app/node_modules/@collaborne/kafkajs/src/consumer/offsetManager/index.js:110:44)
        at subtractPartitionOffsets (/app/node_modules/@collaborne/kafkajs/src/consumer/offsetManager/index.js:114:7)
        at /app/node_modules/@collaborne/kafkajs/src/consumer/offsetManager/index.js:120:44
        at Array.map (<anonymous>)
        at subtractTopicOffsets (/app/node_modules/@collaborne/kafkajs/src/consumer/offsetManager/index.js:120:27)
        at Array.map (<anonymous>)
        at OffsetManager.countResolvedOffsets (/app/node_modules/@collaborne/kafkajs/src/consumer/offsetManager/index.js:122:37)
        at OffsetManager.commitOffsetsIfNecessary (/app/node_modules/@collaborne/kafkajs/src/consumer/offsetManager/index.js:189:12)
        at ConsumerGroup.commitOffsetsIfNecessary (/app/node_modules/@collaborne/kafkajs/src/consumer/consumerGroup.js:295:30)
        at commitOffsetsIfNecessary (/app/node_modules/@collaborne/kafkajs/src/consumer/runner.js:235:34)
~~~~

Note that this is using [@collaborne/kafkajs](https://github.com/Collaborne/kafkajs/tree/collaborne), our own fork of KafkaJS containing a bunch of the PRs that are still under review but that we found work well in practice. We have seen the same errors also with stock KafkaJS versions.

Basically after reviewing this error and the code in the mentioned areas the conclusion is pretty simple: This is a race between seeking and committing/resolving. The race is hard to reproduce in a controlled way, but the fix looks pretty trivial:

```diff
3faa4ff Tue, 23 Jun 2020 12:29:15 +0200 Use `isInvalidOffset` to check whether the committed offset is known [Andreas Kohn]

diff --git a/src/consumer/offsetManager/index.js b/src/consumer/offsetManager/index.js
index 577b092..80a1a32 100644
--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -105,7 +105,7 @@ module.exports = class OffsetManager {
 
     const subtractOffsets = (resolvedOffset, committedOffset) => {
       const resolvedOffsetLong = Long.fromValue(resolvedOffset)
-      return committedOffset === '-1'
+      return isInvalidOffset(committedOffset)
         ? resolvedOffsetLong
         : resolvedOffsetLong.subtract(Long.fromValue(committedOffset))
     }
```

There might be other ways to _prevent_ the race, for example by carefully going over the state changes of the committed and resolved offsets, but given that the code already checked for the "-1" special value switching this out with `isInvalidOffset` (which checks undefined/null-ness as well) looks simple enough.

The other commits here are just "fall-out" from reading the code:
1. Avoid some potentially expensive operations (regular expressions, mainly)
2. Be more consistent