### PR TITLE
Explicitly require mockdate ^2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jest-extended": "^0.11.2",
     "jest-junit": "^10.0.0",
     "lint-staged": "^9.2.0",
-    "mockdate": "^2.0.3",
+    "mockdate": "^2.0.5",
     "prettier": "^1.18.2",
     "semver": "^6.2.0",
     "typescript": "^3.5.3",


### PR DESCRIPTION
2.0.3 and 2.0.4 contain problems in the TypeScript definitions, which are fixed
with 2.0.5.

Note that this is a no-op for pretty much any meaning of the word, but it documents that trying to compile/type-check the code with 2.0.3 will fail due to errors outside of KafkaJS.