### PR TITLE
Fix application lock in case of errors before actual connection established 

### DIFF
--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -200,10 +200,15 @@ module.exports = class Connection {
    */
   async disconnect() {
     this.logDebug('disconnecting...')
-    this.requestQueue.destroy()
     this.connected = false
-    this.socket.end()
-    this.socket.unref()
+
+    this.requestQueue.destroy()
+
+    if (this.socket) {
+      this.socket.end()
+      this.socket.unref()
+    }
+
     this.logDebug('disconnected')
     return true
   }

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -199,10 +199,6 @@ module.exports = class Connection {
    * @returns {Promise}
    */
   async disconnect() {
-    if (!this.connected) {
-      return true
-    }
-
     this.logDebug('disconnecting...')
     this.requestQueue.destroy()
     this.connected = false

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -74,6 +74,17 @@ describe('Network > Connection', () => {
       await expect(connection.disconnect()).resolves.toEqual(true)
       expect(connection.connected).toEqual(false)
     })
+
+    test('trigger "end" and "unref" function on not active connection', async () => {
+      expect(connection.connected).toEqual(false)
+      connection.socket = {
+        end: jest.fn(),
+        unref: jest.fn(),
+      }
+      await expect(connection.disconnect()).resolves.toEqual(true)
+      expect(connection.socket.end).toHaveBeenCalled()
+      expect(connection.socket.unref).toHaveBeenCalled()
+    })
   })
 
   describe('#send', () => {


### PR DESCRIPTION
This is basically fix for #767,  after running some debugging looks like we do not close socket connections properly. One of the examples when timeout hit before connection is established in this case `this.connected` will be `false` and we won't `end` and `unref` socket correctly you can see those handlers with

```js
 console.log(process._getActiveHandles());
```

There is no particular point on having 
```js
 if (!this.connected) {	
      return true	
  }
```
as calling the same `unref` and `end` function multiple times won't affect socket