### PR TITLE
Consistently quote values in the docker-compose configurations

### DIFF
--- a/docker-compose.0_10.yml
+++ b/docker-compose.0_10.yml
@@ -5,11 +5,11 @@ services:
     hostname: zookeeper
     container_name: zookeeper
     ports:
-      - "2181:2181"
+      - '2181:2181'
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+      ZOOKEEPER_CLIENT_PORT: '2181'
+      ZOOKEEPER_TICK_TIME: '2000'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider'
     volumes:
       - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf
 
@@ -18,36 +18,36 @@ services:
     hostname: kafka1
     container_name: kafka1
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka1"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka1'
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
-      - "9092:9092"
-      - "29093:29093"
-      - "9093:9093"
-      - "29094:29094"
-      - "9094:9094"
+      - '29092:29092'
+      - '9092:9092'
+      - '29093:29093'
+      - '9093:9093'
+      - '29094:29094'
+      - '9094:9094'
     environment:
-      KAFKA_BROKER_ID: 0
+      KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092,SSL://kafka1:29093,SSL_HOST://localhost:9093,SASL_SSL://kafka1:29094,SASL_SSL_HOST://localhost:9094
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
@@ -62,36 +62,36 @@ services:
     hostname: kafka2
     container_name: kafka2
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka2"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka2'
     depends_on:
       - zookeeper
     ports:
-      - "29095:29095"
-      - "9095:9095"
-      - "29096:29096"
-      - "9096:9096"
-      - "29097:29097"
-      - "9097:9097"
+      - '29095:29095'
+      - '9095:9095'
+      - '29096:29096'
+      - '9096:9096'
+      - '29097:29097'
+      - '9097:9097'
     environment:
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: '1'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29095,PLAINTEXT_HOST://localhost:9095,SSL://kafka2:29096,SSL_HOST://localhost:9096,SASL_SSL://kafka2:29097,SASL_SSL_HOST://localhost:9097
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
@@ -106,36 +106,36 @@ services:
     hostname: kafka3
     container_name: kafka3
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka3"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka3'
     depends_on:
       - zookeeper
     ports:
-      - "29098:29098"
-      - "9098:9098"
-      - "29099:29099"
-      - "9099:9099"
-      - "29100:29100"
-      - "9100:9100"
+      - '29098:29098'
+      - '9098:9098'
+      - '29099:29099'
+      - '9099:9099'
+      - '29100:29100'
+      - '9100:9100'
     environment:
-      KAFKA_BROKER_ID: 2
+      KAFKA_BROKER_ID: '2'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29098,PLAINTEXT_HOST://localhost:9098,SSL://kafka3:29099,SSL_HOST://localhost:9099,SASL_SSL://kafka3:29100,SASL_SSL_HOST://localhost:9100
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks

--- a/docker-compose.0_11.yml
+++ b/docker-compose.0_11.yml
@@ -5,11 +5,11 @@ services:
     hostname: zookeeper
     container_name: zookeeper
     ports:
-      - "2181:2181"
+      - '2181:2181'
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+      ZOOKEEPER_CLIENT_PORT: '2181'
+      ZOOKEEPER_TICK_TIME: '2000'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider'
     volumes:
       - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf
 
@@ -18,36 +18,36 @@ services:
     hostname: kafka1
     container_name: kafka1
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka1"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka1'
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
-      - "9092:9092"
-      - "29093:29093"
-      - "9093:9093"
-      - "29094:29094"
-      - "9094:9094"
+      - '29092:29092'
+      - '9092:9092'
+      - '29093:29093'
+      - '9093:9093'
+      - '29094:29094'
+      - '9094:9094'
     environment:
-      KAFKA_BROKER_ID: 0
+      KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092,SSL://kafka1:29093,SSL_HOST://localhost:9093,SASL_SSL://kafka1:29094,SASL_SSL_HOST://localhost:9094
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
@@ -62,36 +62,36 @@ services:
     hostname: kafka2
     container_name: kafka2
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka2"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka2'
     depends_on:
       - zookeeper
     ports:
-      - "29095:29095"
-      - "9095:9095"
-      - "29096:29096"
-      - "9096:9096"
-      - "29097:29097"
-      - "9097:9097"
+      - '29095:29095'
+      - '9095:9095'
+      - '29096:29096'
+      - '9096:9096'
+      - '29097:29097'
+      - '9097:9097'
     environment:
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: '1'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29095,PLAINTEXT_HOST://localhost:9095,SSL://kafka2:29096,SSL_HOST://localhost:9096,SASL_SSL://kafka2:29097,SASL_SSL_HOST://localhost:9097
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
@@ -106,36 +106,36 @@ services:
     hostname: kafka3
     container_name: kafka3
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka3"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka3'
     depends_on:
       - zookeeper
     ports:
-      - "29098:29098"
-      - "9098:9098"
-      - "29099:29099"
-      - "9099:9099"
-      - "29100:29100"
-      - "9100:9100"
+      - '29098:29098'
+      - '9098:9098'
+      - '29099:29099'
+      - '9099:9099'
+      - '29100:29100'
+      - '9100:9100'
     environment:
-      KAFKA_BROKER_ID: 2
+      KAFKA_BROKER_ID: '2'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29098,PLAINTEXT_HOST://localhost:9098,SSL://kafka3:29099,SSL_HOST://localhost:9099,SASL_SSL://kafka3:29100,SASL_SSL_HOST://localhost:9100
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks

--- a/docker-compose.1_1.yml
+++ b/docker-compose.1_1.yml
@@ -5,11 +5,11 @@ services:
     hostname: zookeeper
     container_name: zookeeper
     ports:
-      - "2181:2181"
+      - '2181:2181'
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+      ZOOKEEPER_CLIENT_PORT: '2181'
+      ZOOKEEPER_TICK_TIME: '2000'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider'
     volumes:
       - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf
 
@@ -18,36 +18,36 @@ services:
     hostname: kafka1
     container_name: kafka1
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka1"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka1'
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
-      - "9092:9092"
-      - "29093:29093"
-      - "9093:9093"
-      - "29094:29094"
-      - "9094:9094"
+      - '29092:29092'
+      - '9092:9092'
+      - '29093:29093'
+      - '9093:9093'
+      - '29094:29094'
+      - '9094:9094'
     environment:
-      KAFKA_BROKER_ID: 0
+      KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092,SSL://kafka1:29093,SSL_HOST://localhost:9093,SASL_SSL://kafka1:29094,SASL_SSL_HOST://localhost:9094
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
@@ -62,36 +62,36 @@ services:
     hostname: kafka2
     container_name: kafka2
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka2"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka2'
     depends_on:
       - zookeeper
     ports:
-      - "29095:29095"
-      - "9095:9095"
-      - "29096:29096"
-      - "9096:9096"
-      - "29097:29097"
-      - "9097:9097"
+      - '29095:29095'
+      - '9095:9095'
+      - '29096:29096'
+      - '9096:9096'
+      - '29097:29097'
+      - '9097:9097'
     environment:
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: '1'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29095,PLAINTEXT_HOST://localhost:9095,SSL://kafka2:29096,SSL_HOST://localhost:9096,SASL_SSL://kafka2:29097,SASL_SSL_HOST://localhost:9097
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks
@@ -106,36 +106,36 @@ services:
     hostname: kafka3
     container_name: kafka3
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka3"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka3'
     depends_on:
       - zookeeper
     ports:
-      - "29098:29098"
-      - "9098:9098"
-      - "29099:29099"
-      - "9099:9099"
-      - "29100:29100"
-      - "9100:9100"
+      - '29098:29098'
+      - '9098:9098'
+      - '29099:29099'
+      - '9099:9099'
+      - '29100:29100'
+      - '9100:9100'
     environment:
-      KAFKA_BROKER_ID: 2
+      KAFKA_BROKER_ID: '2'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29098,PLAINTEXT_HOST://localhost:9098,SSL://kafka3:29099,SSL_HOST://localhost:9099,SASL_SSL://kafka3:29100,SASL_SSL_HOST://localhost:9100
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks

--- a/docker-compose.2_2.yml
+++ b/docker-compose.2_2.yml
@@ -5,11 +5,11 @@ services:
     hostname: zookeeper
     container_name: zookeeper
     ports:
-      - "2181:2181"
+      - '2181:2181'
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+      ZOOKEEPER_CLIENT_PORT: '2181'
+      ZOOKEEPER_TICK_TIME: '2000'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider'
     volumes:
       - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf:ro,z
 
@@ -18,36 +18,36 @@ services:
     hostname: kafka1
     container_name: kafka1
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka1"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka1'
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
-      - "9092:9092"
-      - "29093:29093"
-      - "9093:9093"
-      - "29094:29094"
-      - "9094:9094"
+      - '29092:29092'
+      - '9092:9092'
+      - '29093:29093'
+      - '9093:9093'
+      - '29094:29094'
+      - '9094:9094'
     environment:
-      KAFKA_BROKER_ID: 0
+      KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092,SSL://kafka1:29093,SSL_HOST://localhost:9093,SASL_SSL://kafka1:29094,SASL_SSL_HOST://localhost:9094
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
       - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
@@ -61,36 +61,36 @@ services:
     hostname: kafka2
     container_name: kafka2
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka2"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka2'
     depends_on:
       - zookeeper
     ports:
-      - "29095:29095"
-      - "9095:9095"
-      - "29096:29096"
-      - "9096:9096"
-      - "29097:29097"
-      - "9097:9097"
+      - '29095:29095'
+      - '9095:9095'
+      - '29096:29096'
+      - '9096:9096'
+      - '29097:29097'
+      - '9097:9097'
     environment:
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: '1'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29095,PLAINTEXT_HOST://localhost:9095,SSL://kafka2:29096,SSL_HOST://localhost:9096,SASL_SSL://kafka2:29097,SASL_SSL_HOST://localhost:9097
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
       - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
@@ -104,36 +104,36 @@ services:
     hostname: kafka3
     container_name: kafka3
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka3"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka3'
     depends_on:
       - zookeeper
     ports:
-      - "29098:29098"
-      - "9098:9098"
-      - "29099:29099"
-      - "9099:9099"
-      - "29100:29100"
-      - "9100:9100"
+      - '29098:29098'
+      - '9098:9098'
+      - '29099:29099'
+      - '9099:9099'
+      - '29100:29100'
+      - '9100:9100'
     environment:
-      KAFKA_BROKER_ID: 2
+      KAFKA_BROKER_ID: '2'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29098,PLAINTEXT_HOST://localhost:9098,SSL://kafka3:29099,SSL_HOST://localhost:9099,SASL_SSL://kafka3:29100,SASL_SSL_HOST://localhost:9100
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
       - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z

--- a/docker-compose.2_3.yml
+++ b/docker-compose.2_3.yml
@@ -5,11 +5,11 @@ services:
     hostname: zookeeper
     container_name: zookeeper
     ports:
-      - "2181:2181"
+      - '2181:2181'
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+      ZOOKEEPER_CLIENT_PORT: '2181'
+      ZOOKEEPER_TICK_TIME: '2000'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/etc/kafka/server-jaas.conf -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider'
     volumes:
       - ./testHelpers/kafka/server-jaas.conf:/etc/kafka/server-jaas.conf:ro,z
 
@@ -18,36 +18,36 @@ services:
     hostname: kafka1
     container_name: kafka1
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka1"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka1'
     depends_on:
       - zookeeper
     ports:
-      - "29092:29092"
-      - "9092:9092"
-      - "29093:29093"
-      - "9093:9093"
-      - "29094:29094"
-      - "9094:9094"
+      - '29092:29092'
+      - '9092:9092'
+      - '29093:29093'
+      - '9093:9093'
+      - '29094:29094'
+      - '9094:9094'
     environment:
-      KAFKA_BROKER_ID: 0
+      KAFKA_BROKER_ID: '0'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092,SSL://kafka1:29093,SSL_HOST://localhost:9093,SASL_SSL://kafka1:29094,SASL_SSL_HOST://localhost:9094
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
       - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
@@ -61,36 +61,36 @@ services:
     hostname: kafka2
     container_name: kafka2
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka2"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka2'
     depends_on:
       - zookeeper
     ports:
-      - "29095:29095"
-      - "9095:9095"
-      - "29096:29096"
-      - "9096:9096"
-      - "29097:29097"
-      - "9097:9097"
+      - '29095:29095'
+      - '9095:9095'
+      - '29096:29096'
+      - '9096:9096'
+      - '29097:29097'
+      - '9097:9097'
     environment:
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: '1'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29095,PLAINTEXT_HOST://localhost:9095,SSL://kafka2:29096,SSL_HOST://localhost:9096,SASL_SSL://kafka2:29097,SASL_SSL_HOST://localhost:9097
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
       - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z
@@ -104,36 +104,36 @@ services:
     hostname: kafka3
     container_name: kafka3
     labels:
-      - "custom.project=kafkajs"
-      - "custom.service=kafka3"
+      - 'custom.project=kafkajs'
+      - 'custom.service=kafka3'
     depends_on:
       - zookeeper
     ports:
-      - "29098:29098"
-      - "9098:9098"
-      - "29099:29099"
-      - "9099:9099"
-      - "29100:29100"
-      - "9100:9100"
+      - '29098:29098'
+      - '9098:9098'
+      - '29099:29099'
+      - '9099:9099'
+      - '29100:29100'
+      - '9100:9100'
     environment:
-      KAFKA_BROKER_ID: 2
+      KAFKA_BROKER_ID: '2'
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,SSL:SSL,SSL_HOST:SSL,SASL_SSL:SASL_SSL,SASL_SSL_HOST:SASL_SSL
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29098,PLAINTEXT_HOST://localhost:9098,SSL://kafka3:29099,SSL_HOST://localhost:9099,SASL_SSL://kafka3:29100,SASL_SSL_HOST://localhost:9100
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_SSL_KEYSTORE_FILENAME: "kafka.server.keystore.jks"
-      KAFKA_SSL_KEYSTORE_CREDENTIALS: "keystore_creds"
-      KAFKA_SSL_KEY_CREDENTIALS: "sslkey_creds"
-      KAFKA_SSL_TRUSTSTORE_FILENAME: "kafka.server.truststore.jks"
-      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: "truststore_creds"
-      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: "PLAIN"
-      KAFKA_SASL_ENABLED_MECHANISMS: "PLAIN,SCRAM-SHA-256,SCRAM-SHA-512"
-      KAFKA_OPTS: "-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf"
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+      KAFKA_SSL_KEYSTORE_FILENAME: 'kafka.server.keystore.jks'
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: 'keystore_creds'
+      KAFKA_SSL_KEY_CREDENTIALS: 'sslkey_creds'
+      KAFKA_SSL_TRUSTSTORE_FILENAME: 'kafka.server.truststore.jks'
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: 'truststore_creds'
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: 'PLAIN'
+      KAFKA_SASL_ENABLED_MECHANISMS: 'PLAIN,SCRAM-SHA-256,SCRAM-SHA-512'
+      KAFKA_OPTS: '-Djava.security.auth.login.config=/opt/kafka/config/server-jaas.conf'
       # suppress verbosity
       # https://github.com/confluentinc/cp-docker-images/blob/master/debian/kafka/include/etc/confluent/docker/log4j.properties.template
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
     volumes:
       - ./testHelpers/certs/kafka.server.keystore.jks:/etc/kafka/secrets/kafka.server.keystore.jks:ro,z
       - ./testHelpers/certs/kafka.server.truststore.jks:/etc/kafka/secrets/kafka.server.truststore.jks:ro,z


### PR DESCRIPTION
This commit aligns the quoting style to always use single quotes rather than an mix
of double quotes, single quotes, and no quotes.

The "no quotes" also introduced a rather ugly other problem: at least podman-compose locally
gets confused by environment variables like `KAFKA_BROKER_ID: 0`, and basically drops these
out, probably because '0' is a falsy value in YAML. This leads to Kafka starting up without
a broker id, and thereby it generates one for itself -- which the tests then are very unhappy about:

~~~~
 FAIL  src/cluster/__tests__/brokerPool.spec.js
  ● Cluster > BrokerPool › #refreshMetadata › updates the list of brokers

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Array [
    -   "0",
        "1",
    +   "1001",
        "2",
      ]

      178 |       expect(brokerPool.brokers).toEqual({})
      179 |       await brokerPool.refreshMetadata([topicName])
    > 180 |       expect(Object.keys(brokerPool.brokers).sort()).toEqual(['0', '1', '2'])
          |                                                      ^
      181 |       expect(Object.values(brokerPool.brokers)).toEqual(
      182 |         expect.arrayContaining([expect.any(Broker), expect.any(Broker), expect.any(Broker)])
      183 |       )

      at Object.<anonymous> (src/cluster/__tests__/brokerPool.spec.js:180:54)
~~~~

As environment variables should always be strings anyways: Fix that by just always quoting all environment
variables, to reduce the mental load of having all of YAMLs arcane rules in ones head.