### PR TITLE
Only disconnect() the consumer & producers when they were created

### DIFF
--- a/src/consumer/__tests__/assignerProtocolIntegration.spec.js
+++ b/src/consumer/__tests__/assignerProtocolIntegration.spec.js
@@ -24,8 +24,8 @@ describe('Consumer > assignerProtocol > integration', () => {
   })
 
   afterEach(async () => {
-    await consumer1.disconnect()
-    await consumer2.disconnect()
+    consumer1 && (await consumer1.disconnect())
+    consumer2 && (await consumer2.disconnect())
   })
 
   test('provides member user data', async () => {

--- a/src/consumer/__tests__/connection.spec.js
+++ b/src/consumer/__tests__/connection.spec.js
@@ -29,7 +29,7 @@ describe('Consumer', () => {
   })
 
   afterEach(async () => {
-    await consumer.disconnect()
+    consumer && (await consumer.disconnect())
   })
 
   test('support SSL connections', async () => {

--- a/src/consumer/__tests__/consume010MessagesOn011API.spec.js
+++ b/src/consumer/__tests__/consume010MessagesOn011API.spec.js
@@ -57,8 +57,8 @@ describe('Consumer', () => {
   })
 
   afterEach(async () => {
-    await consumer.disconnect()
-    await producer.disconnect()
+    consumer && (await consumer.disconnect())
+    producer && (await producer.disconnect())
   })
 
   testIfKafka_0_11('consume 0.10 messages with 0.11 API', async () => {

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -45,8 +45,8 @@ describe('Consumer', () => {
   })
 
   afterEach(async () => {
-    await consumer.disconnect()
-    await producer.disconnect()
+    consumer && (await consumer.disconnect())
+    producer && (await producer.disconnect())
   })
 
   it('consume messages', async () => {

--- a/src/consumer/__tests__/controlBatches.spec.js
+++ b/src/consumer/__tests__/controlBatches.spec.js
@@ -47,8 +47,8 @@ describe('Consumer', () => {
   })
 
   afterEach(async () => {
-    await consumer.disconnect()
-    await producer.disconnect()
+    consumer && (await consumer.disconnect())
+    producer && (await producer.disconnect())
   })
 
   testIfKafka_0_11('forwards empty control batches to eachBatch', async () => {

--- a/src/consumer/__tests__/emptyAssignment.spec.js
+++ b/src/consumer/__tests__/emptyAssignment.spec.js
@@ -21,8 +21,8 @@ describe('Consumer', () => {
   })
 
   afterEach(async () => {
-    await consumer1.disconnect()
-    await consumer2.disconnect()
+    consumer1 && (await consumer1.disconnect())
+    consumer2 && (await consumer2.disconnect())
   })
 
   test('can join the group without receiving any assignment', async () => {

--- a/src/consumer/__tests__/subscribe.spec.js
+++ b/src/consumer/__tests__/subscribe.spec.js
@@ -34,8 +34,8 @@ describe('Consumer', () => {
   })
 
   afterEach(async () => {
-    await consumer.disconnect()
-    await producer.disconnect()
+    consumer && (await consumer.disconnect())
+    producer && (await producer.disconnect())
   })
 
   describe('when subscribe', () => {


### PR DESCRIPTION
This test sometimes fails without creating the consumers, and then we get an additional misleading
error in `afterEach` as well. Avoid these.

Related-to: #654