### PR TITLE
Resolve socket requests without response immediately when they have been queued

### DIFF
--- a/src/network/requestQueue/index.js
+++ b/src/network/requestQueue/index.js
@@ -122,16 +122,23 @@ module.exports = class RequestQueue {
       return
     }
 
+    this.sendSocketRequest(socketRequest)
+  }
+
+  /**
+   * @param {SocketRequest} socketRequest
+   */
+  sendSocketRequest(socketRequest) {
     socketRequest.send()
 
     if (!socketRequest.expectResponse) {
       this.logger.debug(`Request does not expect a response, resolving immediately`, {
         clientId: this.clientId,
         broker: this.broker,
-        correlationId,
+        correlationId: socketRequest.correlationId,
       })
 
-      this.inflight.delete(correlationId)
+      this.inflight.delete(socketRequest.correlationId)
       socketRequest.completed({ size: 0, payload: null })
     }
   }
@@ -147,7 +154,7 @@ module.exports = class RequestQueue {
 
     if (this.pending.length > 0) {
       const pendingRequest = this.pending.pop()
-      pendingRequest.send()
+      this.sendSocketRequest(pendingRequest)
 
       this.logger.debug(`Consumed pending request`, {
         clientId: this.clientId,


### PR DESCRIPTION
Found while working on #776 and reading the code in the request queue: When we push a request that doesn't need a reply and we can execute it immediately we will do so, and then properly complete the request. But: When the request would have to be enqueued we will not check the "does it need a response", and so likely this request will just get stuck somehow.
