### PR TITLE
Fix the requestQueue.fulfillRequest test for when there are pending requests

### DIFF
--- a/src/network/requestQueue/index.spec.js
+++ b/src/network/requestQueue/index.spec.js
@@ -294,8 +294,11 @@ describe('Network > RequestQueue', () => {
       }
 
       requestQueue.push(request)
+
+      // Pick one of the inflight requests to fulfill
+      const correlationId = requestQueue.inflight.keys().next().value
       requestQueue.fulfillRequest({
-        correlationId: request.entry.correlationId,
+        correlationId,
         payload,
         size,
       })

--- a/src/network/requestQueue/index.spec.js
+++ b/src/network/requestQueue/index.spec.js
@@ -133,11 +133,10 @@ describe('Network > RequestQueue', () => {
         entry: createEntry(),
         expectResponse: true,
       }
-
-      requestQueue.push(request)
     })
 
     it('deletes the inflight request and calls completed on the request', () => {
+      requestQueue.push(request)
       expect(requestQueue.inflight.size).toEqual(1)
 
       requestQueue.fulfillRequest({
@@ -163,21 +162,23 @@ describe('Network > RequestQueue', () => {
         }
       })
 
-      it('calls send on the latest pending request', () => {
+      it('calls send on the earliest pending request', () => {
         requestQueue.push(request)
         expect(requestQueue.pending.length).toEqual(1)
 
         const currentInflightSize = requestQueue.inflight.size
 
+        // Pick one of the inflight requests to fulfill
+        const correlationId = requestQueue.inflight.keys().next().value
         requestQueue.fulfillRequest({
-          correlationId: request.entry.correlationId,
+          correlationId: correlationId,
           payload,
           size,
         })
 
         expect(send).toHaveBeenCalled()
         expect(requestQueue.pending.length).toEqual(0)
-        expect(requestQueue.inflight.size).toEqual(currentInflightSize - 1)
+        expect(requestQueue.inflight.size).toEqual(currentInflightSize)
       })
     })
   })


### PR DESCRIPTION
The test was essentially testing its own setup: The outer `beforeEach` would put the `request`
into the queue, which means the `send` method would get called (no pending/inflight requests
at that point). Then the inner `beforeEach` would saturate the queue, and then the test would
add the same request again (this time queued as pending).

When fulfilling the request with this correlation id then we would complete the first request, and
then pop the request added by the test into "in-flight" mode: At this point this.inflight[correlationId]
actually points to the second request, because `send` will have overwritten the entry.

fulfillRequest then does `this.inflight.delete(correlationId)` (assuming to delete the just-fulfilled
entry), but effectively clears out the inflight-ness of the second request.

This commit fixes the problem in the test:
1. Explicitly push the request into the queue in the tests, not in the `beforeEach` call, and
2. Pick one of the dummies created by the inner `beforeEach` to fulfill, and
3. Fix the inflight size check: We had N, and this test removes one and then checks that another
   takes its place -- so the expected size is the same size as before.

Note that this also points to another (theoretical) problem here: If a request is arriving with
the same correlation id as another request, and both of these end up being "in-flight" at the same
time, we would notice the conflict.