### PR TITLE
Update readme and funding

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,1 @@
+github: [Nevon]

--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,1 +1,2 @@
 github: [Nevon]
+custom: ['https://github.com/tulios/kafkajs#sponsors']

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Here are some projects that we would like to build, but haven't yet been able to
 
 ## <a name="sponsors"></a> Sponsors ❤️
 
-*To become a sponsor, [reach out in our Slack community](https://kafkajs-slackin.herokuapp.com/) to get in touch with one of the maintainers.*
+*To become a sponsor, [reach out in our Slack community](https://kafkajs-slackin.herokuapp.com/) to get in touch with one of the maintainers. Also consider becoming a Github Sponsor by following any of the links under "Sponsor this project" in the sidebar.*
 
 <a href="https://www.confluent.io/confluent-cloud/?utm_source=kafkajs&utm_medium=opensource&utm_campaign=referral">
   <img src="https://raw.githubusercontent.com/tulios/kafkajs/master/logo/confluent/logo.png" width="830px">

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## <a name="about"></a> About the Project
 
-KafkaJS is a modern [Apache Kafka](https://kafka.apache.org/) client for Node.js. It is compatible with Kafka 0.10+ and offers native support for 0.11 features. 
+KafkaJS is a modern [Apache Kafka](https://kafka.apache.org/) client for Node.js. It is compatible with Kafka 0.10+ and offers native support for 0.11 features.
 
 ### <a name="features"></a> Features
 
@@ -145,3 +145,5 @@ See [LICENSE](https://github.com/tulios/kafkajs/blob/master/LICENSE) for more de
 
 * Thanks to [Sebastian Norde](https://github.com/sebastiannorde) for the V1 logo ❤️
 * Thanks to [Tracy (Tan Yun)](https://medium.com/@tanyuntracy) for the V2 logo ❤️
+
+<small>Apache Kafka and Kafka are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries. KafkaJS has no affiliation with the Apache Software Foundation.</small>

--- a/README.md
+++ b/README.md
@@ -1,37 +1,64 @@
-# <a href='https://kafka.js.org'><img src='https://raw.githubusercontent.com/tulios/kafkajs/master/logoV2.png' height='60' alt='KafkaJS' aria-label='kafka.js.org' /></a>
+[![Build Status](https://dev.azure.com/tulios/kafkajs/_apis/build/status/tulios.kafkajs?branchName=master)](https://dev.azure.com/tulios/kafkajs/_build/latest?definitionId=2&branchName=master) [![npm version](https://badge.fury.io/js/kafkajs.svg)](https://badge.fury.io/js/kafkajs) [![Slack Channel](https://kafkajs-slackin.herokuapp.com/badge.svg)](https://kafkajs-slackin.herokuapp.com/)
+<br />
+<p align="center">
+  <a href="https://kafka.js.org">
+      <img src="https://raw.githubusercontent.com/tulios/kafkajs/master/logo/v2/kafkajs_circle.svg" alt="Logo" width="125" height="125">
+  </a>
 
-A modern Apache Kafka client for node.js. This library is compatible with Kafka `0.10+`.  
-Native support for Kafka `0.11` features.
+  <h3 align="center">KafkaJS</h3>
 
-KafkaJS is battle-tested and ready for production.
+  <p align="center">
+    A modern Apache Kafka® client for Node.js
+    <br />
+    <a href="https://kafka.js.org/"><strong>Get Started »</strong></a>
+    <br />
+    <br />
+    <a href="https://kafka.js.org/docs/getting-started" target="_blank">Read the Docs</a>
+    ·
+    <a href="https://github.com/tulios/kafkajs/issues/new?assignees=&labels=&template=bug_report.md&title=">Report Bug</a>
+    ·
+    <a href="https://github.com/tulios/kafkajs/issues/new?assignees=&labels=&template=feature_request.md&title=">Request Feature</a>
+  </p>
+</p>
 
-[![Build Status](https://dev.azure.com/tulios/kafkajs/_apis/build/status/tulios.kafkajs?branchName=master)](https://dev.azure.com/tulios/kafkajs/_build/latest?definitionId=2&branchName=master)
-[![npm version](https://badge.fury.io/js/kafkajs.svg)](https://badge.fury.io/js/kafkajs)
-[![Slack Channel](https://kafkajs-slackin.herokuapp.com/badge.svg)](https://kafkajs-slackin.herokuapp.com/)
+## Table of Contents
 
-## Features
+- [About the project](#about)
+  - [Features](#features)
+  - [Getting Started](#getting-started)
+    - [Usage](#usage)
+- [Contributing](#contributing)
+  - [Help Wanted](#help-wanted)
+  - [Contact](#contact)
+- [Sponsors](#sponsors)
+- [License](#license)
+  - [Acknowledgements](#acknowledgements)
 
-- Producer
-- Consumer groups with pause, resume, and seek
-- Transactional support for producers and consumers
-- Message headers
-- GZIP compression
-- Snappy and LZ4 compression through plugins
-- Plain, SSL and SASL_SSL implementations
-- Support for SCRAM-SHA-256 and SCRAM-SHA-512
-- Support for AWS IAM authentication
-- Admin client
+## <a name="about"></a> About the Project
 
-_Read something on the website that didn't work with the latest stable version?_  
-[Check the pre-release versions](https://kafka.js.org/docs/pre-releases) - the website is updated on every merge to master.
+KafkaJS is a modern [Apache Kafka](https://kafka.apache.org/) client for Node.js. It is compatible with Kafka 0.10+ and offers native support for 0.11 features. 
 
-## <a name="getting-started"></a> Getting Started
+### <a name="features"></a> Features
+
+* Producer
+* Consumer groups with pause, resume, and seek
+* Transactional support for producers and consumers
+* Message headers
+* GZIP compression
+  * Snappy and LZ4 compression through pluggable codecs
+* Plain, SSL and SASL_SSL implementations
+* Support for SCRAM-SHA-256 and SCRAM-SHA-512
+* Support for AWS IAM authentication
+* Admin client
+
+### <a name="getting-started"></a> Getting Started
 
 ```sh
 npm install kafkajs
 # yarn add kafkajs
 ```
 
+#### <a name="usage"></a> Usage
 ```javascript
 const { Kafka } = require('kafkajs')
 
@@ -71,8 +98,6 @@ const run = async () => {
 run().catch(console.error)
 ```
 
-## Documentation
-
 Learn more about using [KafkaJS on the official site!](https://kafka.js.org)
 
 - [Getting Started](https://kafka.js.org/docs/getting-started)
@@ -80,6 +105,9 @@ Learn more about using [KafkaJS on the official site!](https://kafka.js.org)
 - [Configuring KafkaJS](https://kafka.js.org/docs/configuration)
 - [Example Producer](https://kafka.js.org/docs/producer-example)
 - [Example Consumer](https://kafka.js.org/docs/consumer-example)
+
+> _Read something on the website that didn't work with the latest stable version?_  
+[Check the pre-release versions](https://kafka.js.org/docs/pre-releases) - the website is updated on every merge to master.
 
 ## <a name="contributing"></a> Contributing
 
@@ -94,21 +122,26 @@ We welcome contributions to KafkaJS, but we also want to see a thriving third-pa
 Here are some projects that we would like to build, but haven't yet been able to prioritize:
 
 * [Dead Letter Queue](https://eng.uber.com/reliable-reprocessing/) - Automatically reprocess messages
-* [Schema Registry](https://www.confluent.io/confluent-schema-registry/) - ~~Seamless integration with the schema registry to encode and decode AVRO~~ **[Now available!](https://www.npmjs.com/package/@kafkajs/confluent-schema-registry)** thanks to [@erikengervall](https://github.com/erikengervall)
+* ✅ [Schema Registry](https://www.confluent.io/confluent-schema-registry/) - **[Now available!](https://www.npmjs.com/package/@kafkajs/confluent-schema-registry)** thanks to [@erikengervall](https://github.com/erikengervall)
 * [Metrics](https://prometheus.io/) - Integrate with the [instrumentation events](https://kafka.js.org/docs/instrumentation-events) to expose commonly used metrics
 
-## Acknowledgements
+### <a name="contact"></a> Contact 💬
 
-Thanks to [Sebastian Norde](https://github.com/sebastiannorde) for the V1 logo ❤️
+[Join our Slack community](https://kafkajs-slackin.herokuapp.com/)
 
-Thanks to [Tracy (Tan Yun)](https://medium.com/@tanyuntracy) for the V2 logo ❤️
+## <a name="sponsors"></a> Sponsors ❤️
 
-### Sponsored by:
+*To become a sponsor, [reach out in our Slack community](https://kafkajs-slackin.herokuapp.com/) to get in touch with one of the maintainers.*
 
 <a href="https://www.confluent.io/confluent-cloud/?utm_source=kafkajs&utm_medium=opensource&utm_campaign=referral">
-  <img src="./logo/confluent/logo.png" width="830px">
+  <img src="https://raw.githubusercontent.com/tulios/kafkajs/master/logo/confluent/logo.png" width="830px">
 </a>
 
-## License
+## <a name="license"></a> License
 
 See [LICENSE](https://github.com/tulios/kafkajs/blob/master/LICENSE) for more details.
+
+### <a name="acknowledgements"></a> Acknowledgements
+
+* Thanks to [Sebastian Norde](https://github.com/sebastiannorde) for the V1 logo ❤️
+* Thanks to [Tracy (Tan Yun)](https://medium.com/@tanyuntracy) for the V2 logo ❤️


### PR DESCRIPTION
This PR does 3 things:

1. Pretties up the README a bit. See below for a screenshot, since the PR preview is not great.
2. Adds a funding.yml file [to integrate with Github's Sponsorship section](https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository). Currently this file contains my own Github Sponsors profile as well as a custom link linking to the "Sponsors" section of the readme with general instructions for sponsoring the project. [See the "Sponsor this project" section in the eslint repo sidebar for an example](https://github.com/eslint/eslint). To actually enable this, @tulios would also need to go to Settings -> Features and tick the "Sponsorship" button.
3. Add a trademark notice regarding the Apache Kafka trademark, and a note saying that KafkaJS is not affiliated with the Apache Software Foundation.

![kafkajsreadme](https://user-images.githubusercontent.com/83586/88061394-bb242680-cb67-11ea-982b-4bdf47535953.png)
