### PR TITLE
Add new protocol errors

### DIFF
--- a/src/protocol/error.js
+++ b/src/protocol/error.js
@@ -520,6 +520,50 @@ const errorCodes = [
     message:
       'The consumer group has reached its max size. It already has the configured maximum number of members',
   },
+  {
+    type: 'FENCED_INSTANCE_ID',
+    code: 82,
+    retriable: false,
+    message:
+      'The broker rejected this static consumer since another consumer with the same group instance id has registered with a different member id',
+  },
+  {
+    type: 'ELIGIBLE_LEADERS_NOT_AVAILABLE',
+    code: 83,
+    retriable: true,
+    message: 'Eligible topic partition leaders are not available',
+  },
+  {
+    type: 'ELECTION_NOT_NEEDED',
+    code: 84,
+    retriable: true,
+    message: 'Leader election not needed for topic partition',
+  },
+  {
+    type: 'NO_REASSIGNMENT_IN_PROGRESS',
+    code: 85,
+    retriable: false,
+    message: 'No partition reassignment is in progress',
+  },
+  {
+    type: 'GROUP_SUBSCRIBED_TO_TOPIC',
+    code: 86,
+    retriable: false,
+    message:
+      'Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it',
+  },
+  {
+    type: 'INVALID_RECORD',
+    code: 87,
+    retriable: false,
+    message: 'This record has failed the validation on broker and hence be rejected',
+  },
+  {
+    type: 'UNSTABLE_OFFSET_COMMIT',
+    code: 88,
+    retriable: true,
+    message: 'There are unstable offsets that need to be cleared',
+  },
 ]
 
 const unknownErrorCode = errorCode => ({


### PR DESCRIPTION
None of these new errors have any impact that would currently require code changes, as they are all in relation to functionality that KafkaJS doesn't currently have.

The one exception being INVALID_RECORD, which we currently could get when producing, in which case we would just log that it's an unknown protocol error. When Produce v8 is implemented, this error could be improved by including more information about the invalid record. https://cwiki.apache.org/confluence/display/KAFKA/KIP-467%3A+Augment+ProduceResponse+error+messaging+for+specific+culprit+records