### PR TITLE
Fix fall-back retry config for producer

### DIFF
--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -62,7 +62,8 @@ module.exports = class Cluster {
   }) {
     this.rootLogger = rootLogger
     this.logger = rootLogger.namespace('Cluster')
-    this.retrier = createRetry({ ...retry })
+    this.retry = { ...retry }
+    this.retrier = createRetry(this.retry)
     this.connectionBuilder = connectionBuilder({
       logger: rootLogger,
       instrumentationEmitter,


### PR DESCRIPTION
See https://github.com/tulios/kafkajs/blob/master/src/producer/index.js#L56
`this.retry` in cluster constructor was not assigned, so referring to `cluster.retry` from producer constructor will always yield undefined.