### PR TITLE
Ensure fair fetch response allocation across topic-partitions

### DIFF
--- a/src/broker/__tests__/fetchPartitionAllocation.spec.js
+++ b/src/broker/__tests__/fetchPartitionAllocation.spec.js
@@ -49,18 +49,27 @@ describe('Broker > Fetch', () => {
    */
   test('it should randomize the order of the requested topic-partitions', async () => {
     const topics = [createFetchTopic('topic-a', 3), createFetchTopic('topic-b', 2)]
+    const flattened = [
+      { topic: topics[0].topic, partition: topics[0].partitions[0] },
+      { topic: topics[0].topic, partition: topics[0].partitions[1] },
+      { topic: topics[0].topic, partition: topics[0].partitions[2] },
+      { topic: topics[1].topic, partition: topics[1].partitions[0] },
+      { topic: topics[1].topic, partition: topics[1].partitions[1] },
+    ]
 
     mockShuffle.mockImplementationOnce(() => [
-      { topic: topics[0].topic, partitions: [topics[0].partitions[0]] },
-      { topic: topics[1].topic, partitions: [topics[1].partitions[0]] },
+      flattened[0],
+      flattened[3],
       // test that consecutive partitions for same topic are merged
-      { topic: topics[0].topic, partitions: [topics[0].partitions[1]] },
-      { topic: topics[0].topic, partitions: [topics[0].partitions[2]] },
-      { topic: topics[1].topic, partitions: [topics[1].partitions[1]] },
+      flattened[1],
+      flattened[2],
+      flattened[4],
     ])
     fetchRequestMock = jest.fn()
 
     await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
+
+    expect(mockShuffle).toHaveBeenCalledWith(flattened)
 
     expect(fetchRequestMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/broker/__tests__/fetchPartitionAllocation.spec.js
+++ b/src/broker/__tests__/fetchPartitionAllocation.spec.js
@@ -36,7 +36,6 @@ describe('Broker > Fetch', () => {
       logger: newLogger(),
     })
 
-    broker.isConnected = () => true
     broker.lookupRequest = () => fetchRequestMock
   })
 

--- a/src/broker/__tests__/fetchPartitionAllocation.spec.js
+++ b/src/broker/__tests__/fetchPartitionAllocation.spec.js
@@ -2,7 +2,6 @@ jest.mock('../../utils/shuffle', () => jest.fn())
 
 const Broker = require('../index')
 const mockShuffle = require('../../utils/shuffle')
-const shuffle = jest.requireActual('../../utils/shuffle')
 
 const { createConnection, newLogger } = require('testHelpers')
 
@@ -30,8 +29,6 @@ describe('Broker > Fetch', () => {
   }
 
   beforeEach(async () => {
-    mockShuffle.mockImplementation(shuffle)
-
     connection = createConnection()
     connection.send = jest.fn()
     broker = new Broker({

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -307,7 +307,7 @@ module.exports = class Broker {
     // Shuffle topic-partitions to ensure fair response allocation across partitions (KIP-74)
     const flattenedTopicPartitions = topics.reduce((topicPartitions, { topic, partitions }) => {
       partitions.forEach(partition => {
-        topicPartitions.push({ topic, partitions: [partition] })
+        topicPartitions.push({ topic, partition })
       })
       return topicPartitions
     }, [])
@@ -316,13 +316,13 @@ module.exports = class Broker {
 
     // Consecutive partitions for the same topic can be combined into a single `topic` entry
     const consolidatedTopicPartitions = shuffledTopicPartitions.reduce(
-      (topicPartitions, { topic, partitions }) => {
+      (topicPartitions, { topic, partition }) => {
         const last = topicPartitions[topicPartitions.length - 1]
 
         if (last != null && last.topic === topic) {
-          topicPartitions[topicPartitions.length - 1].partitions.push(partitions[0])
+          topicPartitions[topicPartitions.length - 1].partitions.push(partition)
         } else {
-          topicPartitions.push({ topic, partitions })
+          topicPartitions.push({ topic, partitions: [partition] })
         }
 
         return topicPartitions


### PR DESCRIPTION
See #849 for details, but this fixes a big issue with uneven consumption when the consumer has fallen behind on several partitions and `maxBytesPerPartition * numPartitions > maxBytes`.