### PR TITLE
Suppress JoinGroup V4+ response error log when memberId is empty

### DIFF
--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -152,13 +152,10 @@ module.exports = class Broker {
     for (const candidateVersion of availableVersions) {
       try {
         const apiVersions = requests.ApiVersions.protocol({ version: candidateVersion })
-        response = await this.connection.send(
-          {
-            ...apiVersions(),
-            requestTimeout: this.connection.connectionTimeout,
-          },
-          { logResponseError: false }
-        )
+        response = await this.connection.send({
+          ...apiVersions(),
+          requestTimeout: this.connection.connectionTimeout,
+        })
         break
       } catch (e) {
         if (e.type !== 'UNSUPPORTED_VERSION') {
@@ -392,7 +389,7 @@ module.exports = class Broker {
     groupProtocols,
   }) {
     const joinGroup = this.lookupRequest(apiKeys.JoinGroup, requests.JoinGroup)
-    const makeRequest = ({ assignedMemberId = memberId, logResponseError = false } = {}) =>
+    const makeRequest = (assignedMemberId = memberId) =>
       this.connection.send(
         joinGroup({
           groupId,
@@ -401,15 +398,14 @@ module.exports = class Broker {
           memberId: assignedMemberId,
           protocolType,
           groupProtocols,
-        }),
-        { logResponseError }
+        })
       )
 
     try {
       return await makeRequest()
     } catch (error) {
       if (error.name === 'KafkaJSMemberIdRequired') {
-        return makeRequest({ assignedMemberId: error.memberId, logResponseError: true })
+        return makeRequest(error.memberId)
       }
 
       throw error

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -271,11 +271,10 @@ module.exports = class Connection {
    *                          "decode" and "parse"
    *
    * @param {number} [protocol.requestTimeout=null] Override for the default requestTimeout
-   * @param {object} [options={}]
-   * @param {boolean} [options.logResponseError=true] Whether to log response errors
+   * @param {boolean} [protocol.logResponseError=true] Whether to log errors
    * @returns {Promise<data>} where data is the return of "response#parse"
    */
-  async send({ request, response, requestTimeout = null }, { logResponseError = true } = {}) {
+  async send({ request, response, requestTimeout = null, logResponseError = true }) {
     this.failIfNotConnected()
 
     const expectResponse = !request.expectResponse || request.expectResponse()

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -262,17 +262,20 @@ module.exports = class Connection {
 
   /**
    * @public
-   * @param {object} request It is defined by the protocol and consists of an object with "apiKey",
+   * @param {object} protocol
+   * @param {object} protocol.request It is defined by the protocol and consists of an object with "apiKey",
    *                         "apiVersion", "apiName" and an "encode" function. The encode function
    *                         must return an instance of Encoder
    *
-   * @param {object} response It is defined by the protocol and consists of an object with two functions:
+   * @param {object} protocol.response It is defined by the protocol and consists of an object with two functions:
    *                          "decode" and "parse"
    *
-   * @param {number} [requestTimeout=null] Override for the default requestTimeout
+   * @param {number} [protocol.requestTimeout=null] Override for the default requestTimeout
+   * @param {object} [options={}]
+   * @param {boolean} [options.logResponseError=true] Whether to log response errors
    * @returns {Promise<data>} where data is the return of "response#parse"
    */
-  async send({ request, response, requestTimeout = null }) {
+  async send({ request, response, requestTimeout = null }, { logResponseError = true } = {}) {
     this.failIfNotConnected()
 
     const expectResponse = !request.expectResponse || request.expectResponse()
@@ -327,7 +330,7 @@ module.exports = class Connection {
 
       return data
     } catch (e) {
-      if (entry.apiName !== 'ApiVersions') {
+      if (logResponseError) {
         this.logError(`Response ${requestInfo(entry)}`, {
           error: e.message,
           correlationId,

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -89,11 +89,12 @@ describe('Network > Connection', () => {
   })
 
   describe('#send', () => {
-    let apiVersions
+    let apiVersions, metadata
 
     beforeEach(() => {
       connection = new Connection(connectionOpts())
       apiVersions = requests.ApiVersions.protocol({ version: 0 })
+      metadata = requests.Metadata.protocol({ version: 0 })
     })
 
     test('resolves the Promise with the response', async () => {
@@ -266,6 +267,44 @@ describe('Network > Connection', () => {
           type: 'Buffer',
           data: '[filtered]',
         })
+      })
+    })
+
+    describe('Error logging', () => {
+      let connection, errorStub
+
+      beforeEach(() => {
+        connection = new Connection(connectionOpts())
+        errorStub = jest.fn()
+        connection.logger.error = errorStub
+      })
+
+      afterEach(async () => {
+        connection && (await connection.disconnect())
+      })
+
+      it('logs error responses by default', async () => {
+        const protocol = metadata({ topics: [] })
+        protocol.response.parse = () => {
+          throw new Error('non-retriable')
+        }
+        await connection.connect()
+
+        await expect(connection.send(protocol)).rejects.toBeTruthy()
+
+        expect(errorStub).toHaveBeenCalled()
+      })
+
+      it('does not log errors when called with logResponseError=false', async () => {
+        const protocol = metadata({ topics: [] })
+        protocol.response.parse = () => {
+          throw new Error('non-retriable')
+        }
+        await connection.connect()
+
+        await expect(connection.send(protocol, { logResponseError: false })).rejects.toBeTruthy()
+
+        expect(errorStub).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -288,6 +288,9 @@ describe('Network > Connection', () => {
         protocol.response.parse = () => {
           throw new Error('non-retriable')
         }
+
+        expect(protocol.logResponseError).not.toBe(false)
+
         await connection.connect()
 
         await expect(connection.send(protocol)).rejects.toBeTruthy()
@@ -295,14 +298,15 @@ describe('Network > Connection', () => {
         expect(errorStub).toHaveBeenCalled()
       })
 
-      it('does not log errors when called with logResponseError=false', async () => {
+      it('does not log errors when protocol.logResponseError=false', async () => {
         const protocol = metadata({ topics: [] })
         protocol.response.parse = () => {
           throw new Error('non-retriable')
         }
+        protocol.logResponseError = false
         await connection.connect()
 
-        await expect(connection.send(protocol, { logResponseError: false })).rejects.toBeTruthy()
+        await expect(connection.send(protocol)).rejects.toBeTruthy()
 
         expect(errorStub).not.toHaveBeenCalled()
       })

--- a/src/protocol/requests/apiVersions/index.js
+++ b/src/protocol/requests/apiVersions/index.js
@@ -1,18 +1,20 @@
+const logResponseError = false
+
 const versions = {
   0: () => {
     const request = require('./v0/request')
     const response = require('./v0/response')
-    return { request: request(), response }
+    return { request: request(), response, logResponseError }
   },
   1: () => {
     const request = require('./v1/request')
     const response = require('./v1/response')
-    return { request: request(), response }
+    return { request: request(), response, logResponseError }
   },
   2: () => {
     const request = require('./v2/request')
     const response = require('./v2/response')
-    return { request: request(), response }
+    return { request: request(), response, logResponseError }
   },
 }
 

--- a/src/protocol/requests/apiVersions/index.js
+++ b/src/protocol/requests/apiVersions/index.js
@@ -4,7 +4,7 @@ const versions = {
   0: () => {
     const request = require('./v0/request')
     const response = require('./v0/response')
-    return { request: request(), response, logResponseError }
+    return { request: request(), response, logResponseError: true }
   },
   1: () => {
     const request = require('./v1/request')

--- a/src/protocol/requests/apiVersions/index.spec.js
+++ b/src/protocol/requests/apiVersions/index.spec.js
@@ -4,13 +4,20 @@ const ApiVersionsV1 = ApiVersions.protocol({ version: 1 })
 const ApiVersionsV2 = ApiVersions.protocol({ version: 2 })
 
 describe('Protocol > Requests > ApiVersions', () => {
-  it('does not log response errors', () => {
-    const protocolV0 = ApiVersionsV0()
-    const protocolV1 = ApiVersionsV1()
-    const protocolV2 = ApiVersionsV2()
+  describe('V0', () => {
+    it('logs response errors', () => {
+      const protocolV0 = ApiVersionsV0()
+      expect(protocolV0.logResponseError).toBe(true)
+    })
+  })
 
-    expect(protocolV0.logResponseError).toBe(false)
-    expect(protocolV1.logResponseError).toBe(false)
-    expect(protocolV2.logResponseError).toBe(false)
+  describe('V1+', () => {
+    it('does not log response errors', () => {
+      const protocolV1 = ApiVersionsV1()
+      const protocolV2 = ApiVersionsV2()
+
+      expect(protocolV1.logResponseError).toBe(false)
+      expect(protocolV2.logResponseError).toBe(false)
+    })
   })
 })

--- a/src/protocol/requests/apiVersions/index.spec.js
+++ b/src/protocol/requests/apiVersions/index.spec.js
@@ -1,0 +1,16 @@
+const ApiVersions = require('./index')
+const ApiVersionsV0 = ApiVersions.protocol({ version: 0 })
+const ApiVersionsV1 = ApiVersions.protocol({ version: 1 })
+const ApiVersionsV2 = ApiVersions.protocol({ version: 2 })
+
+describe('Protocol > Requests > ApiVersions', () => {
+  it('does not log response errors', () => {
+    const protocolV0 = ApiVersionsV0()
+    const protocolV1 = ApiVersionsV1()
+    const protocolV2 = ApiVersionsV2()
+
+    expect(protocolV0.logResponseError).toBe(false)
+    expect(protocolV1.logResponseError).toBe(false)
+    expect(protocolV2.logResponseError).toBe(false)
+  })
+})

--- a/src/protocol/requests/joinGroup/index.js
+++ b/src/protocol/requests/joinGroup/index.js
@@ -12,6 +12,8 @@ const requestTimeout = ({ rebalanceTimeout, sessionTimeout }) => {
   return Number.isSafeInteger(timeout + NETWORK_DELAY) ? timeout + NETWORK_DELAY : timeout
 }
 
+const logResponseError = memberId => memberId != null && memberId !== ''
+
 const versions = {
   0: ({ groupId, sessionTimeout, memberId, protocolType, groupProtocols }) => {
     const request = require('./v0/request')
@@ -95,6 +97,7 @@ const versions = {
       }),
       response,
       requestTimeout: requestTimeout({ rebalanceTimeout, sessionTimeout }),
+      logResponseError: logResponseError(memberId),
     }
   },
 }

--- a/src/protocol/requests/joinGroup/index.spec.js
+++ b/src/protocol/requests/joinGroup/index.spec.js
@@ -2,6 +2,8 @@ const JoinGroupVersions = require('./index')
 const JoinGroupV0 = JoinGroupVersions.protocol({ version: 0 })
 const JoinGroupV1 = JoinGroupVersions.protocol({ version: 1 })
 const JoinGroupV2 = JoinGroupVersions.protocol({ version: 2 })
+const JoinGroupV3 = JoinGroupVersions.protocol({ version: 3 })
+const JoinGroupV4 = JoinGroupVersions.protocol({ version: 4 })
 
 describe('Protocol > Requests > JoinGroup', () => {
   describe('v0', () => {
@@ -45,9 +47,41 @@ describe('Protocol > Requests > JoinGroup', () => {
       }
       const protocolV1 = JoinGroupV1(parameters)
       const protocolV2 = JoinGroupV2(parameters)
+      const protocolV3 = JoinGroupV3(parameters)
+      const protocolV4 = JoinGroupV4(parameters)
 
       expect(protocolV1.requestTimeout).toBeGreaterThan(rebalanceTimeout)
       expect(protocolV2.requestTimeout).toBeGreaterThan(rebalanceTimeout)
+      expect(protocolV3.requestTimeout).toBeGreaterThan(rebalanceTimeout)
+      expect(protocolV4.requestTimeout).toBeGreaterThan(rebalanceTimeout)
+    })
+  })
+
+  describe('v4+', () => {
+    it('does not log error responses when memberId is empty', () => {
+      const protocol = JoinGroupV4({
+        groupId: 'test-group',
+        sessionTimeout: 1,
+        rebalanceTimeout: 30000,
+        memberId: '',
+        protocolType: 'consumer',
+        groupProtocols: [{ name: 'default' }],
+      })
+
+      expect(protocol.logResponseError).toEqual(false)
+    })
+
+    it('logs error responses when memberId is not empty', () => {
+      const protocol = JoinGroupV4({
+        groupId: 'test-group',
+        sessionTimeout: 1,
+        rebalanceTimeout: 30000,
+        memberId: 'member-id',
+        protocolType: 'consumer',
+        groupProtocols: [{ name: 'default' }],
+      })
+
+      expect(protocol.logResponseError).toEqual(true)
     })
   })
 })


### PR DESCRIPTION
The first time a consumer joins the group, the broker will respond with an error telling us that we need to use a memberId that is returned together with the error. We catch this error and re-issue the request with the new memberId. However, since is is a protocol error, we would log an error that would cause some users to think that something was wrong, even though this is the normal operation when joining the group.

This refactoring moves the decision of whether or not to log the error response into the protocol itself, which allows us to get rid of the special case for `ApiVersions` in `Connection.send`. It also allows us to decide whether or not to log based on the request or response itself, as well as the version of the request. This is relevant in this case, as we don't want to log if there's an error in response to `JoinGroupV4` and the memberId is empty, but we do want to log for older `JoinGroup` versions or when the memberId is in fact set already.

Fixes #856