### PR TITLE
Only commit offsets on eachMessage failures if autoCommit is enabled

### DIFF
--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -196,8 +196,8 @@ module.exports = class Runner extends EventEmitter {
           })
         }
 
-        // In case of errors, commit the previously consumed offsets
-        await this.consumerGroup.commitOffsets()
+        // In case of errors, commit the previously consumed offsets unless autoCommit is disabled
+        await this.autoCommitOffsets()
         throw e
       }
 


### PR DESCRIPTION
Currently, `eachMessage` is not respecting the `autoCommit` property and always committing offsets on failures. This is a simplified PR for #782