### PR TITLE
Remove brokers with closed connections from the brokers list

### DIFF
--- a/src/cluster/__tests__/brokerPool.spec.js
+++ b/src/cluster/__tests__/brokerPool.spec.js
@@ -1,5 +1,6 @@
 const {
   createConnectionBuilder,
+  plainTextBrokers,
   createConnection,
   newLogger,
   secureRandom,
@@ -131,6 +132,48 @@ describe('Cluster > BrokerPool', () => {
       expect(brokerPool.metadata).toEqual(null)
       expect(brokerPool.versions).toEqual(null)
       expect(brokerPool.brokers).toEqual({})
+    })
+  })
+
+  describe('#removeBroker', () => {
+    let host, port
+
+    beforeEach(async () => {
+      await brokerPool.connect()
+      await brokerPool.refreshMetadata([topicName])
+      expect(Object.values(brokerPool.brokers).length).toBeGreaterThan(1)
+
+      const brokerUri = plainTextBrokers().shift()
+      const [hostToRemove, portToRemove] = brokerUri.split(':')
+      host = hostToRemove
+      port = Number(portToRemove)
+    })
+
+    it('removes the broker by host and port', () => {
+      const numberOfBrokers = Object.values(brokerPool.brokers).length
+
+      brokerPool.removeBroker({ host, port })
+
+      const brokers = Object.values(brokerPool.brokers)
+      expect(brokers.length).toEqual(numberOfBrokers - 1)
+      expect(
+        brokers.find(broker => broker.connection.host === host && broker.connection.port === port)
+      ).toEqual(undefined)
+    })
+
+    it('replaces the seed broker if it is the target broker', () => {
+      const seedBrokerHost = brokerPool.seedBroker.connection.host
+      const seedBrokerPort = brokerPool.seedBroker.connection.port
+      brokerPool.removeBroker({ host: seedBrokerHost, port: seedBrokerPort })
+
+      // check only port since the host will be "localhost" on most tests
+      expect(brokerPool.seedBroker.connection.port).not.toEqual(seedBrokerPort)
+    })
+
+    it('erases metadataExpireAt to force a metadata refresh', () => {
+      brokerPool.metadataExpireAt = Date.now() + 25
+      brokerPool.removeBroker({ host, port })
+      expect(brokerPool.metadataExpireAt).toEqual(null)
     })
   })
 

--- a/src/cluster/brokerPool.js
+++ b/src/cluster/brokerPool.js
@@ -113,6 +113,26 @@ module.exports = class BrokerPool {
 
   /**
    * @public
+   * @param {String} host
+   * @param {Number} port
+   */
+  removeBroker({ host, port }) {
+    const removedBroker = values(this.brokers).find(
+      broker => broker.connection.host === host && broker.connection.port === port
+    )
+
+    if (removedBroker) {
+      delete this.brokers[removedBroker.nodeId]
+      this.metadataExpireAt = null
+
+      if (this.seedBroker.nodeId === removedBroker.nodeId) {
+        this.seedBroker = shuffle(values(this.brokers))[0]
+      }
+    }
+  }
+
+  /**
+   * @public
    * @param {Array<String>} topics
    * @returns {Promise<null>}
    */

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -118,6 +118,15 @@ module.exports = class Cluster {
 
   /**
    * @public
+   * @param {String} host
+   * @param {Number} port
+   */
+  removeBroker({ host, port }) {
+    this.brokerPool.removeBroker({ host, port })
+  }
+
+  /**
+   * @public
    * @returns {Promise<null>}
    */
   async refreshMetadata() {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -543,7 +543,11 @@ module.exports = class ConsumerGroup {
       await this.recoverFromOffsetOutOfRange(e)
     }
 
-    if (e.name === 'KafkaJSBrokerNotFound') {
+    if (e.name === 'KafkaJSConnectionClosedError') {
+      this.cluster.removeBroker({ host: e.host, port: e.port })
+    }
+
+    if (e.name === 'KafkaJSBrokerNotFound' || e.name === 'KafkaJSConnectionClosedError') {
       this.logger.debug(`${e.message}, refreshing metadata and retrying...`)
       await this.cluster.refreshMetadata()
     }

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -251,6 +251,10 @@ module.exports = ({
         stack: e.stack,
       })
 
+      if (e.name === 'KafkaJSConnectionClosedError') {
+        cluster.removeBroker({ host: e.host, port: e.port })
+      }
+
       await disconnect()
 
       instrumentationEmitter.emit(CRASH, {

--- a/src/errors.js
+++ b/src/errors.js
@@ -62,6 +62,15 @@ class KafkaJSConnectionError extends KafkaJSError {
   }
 }
 
+class KafkaJSConnectionClosedError extends KafkaJSConnectionError {
+  constructor(e, { host, port } = {}) {
+    super(e, { broker: `${host}:${port}` })
+    this.host = host
+    this.port = port
+    this.name = 'KafkaJSConnectionClosedError'
+  }
+}
+
 class KafkaJSRequestTimeoutError extends KafkaJSError {
   constructor(e, { broker, correlationId, createdAt, sentAt, pendingDuration } = {}) {
     super(e)
@@ -176,6 +185,7 @@ module.exports = {
   KafkaJSBrokerNotFound,
   KafkaJSProtocolError,
   KafkaJSConnectionError,
+  KafkaJSConnectionClosedError,
   KafkaJSRequestTimeoutError,
   KafkaJSSASLAuthenticationError,
   KafkaJSNumberOfRetriesExceeded,

--- a/src/producer/messageProducer.js
+++ b/src/producer/messageProducer.js
@@ -100,6 +100,10 @@ module.exports = ({
           topicMessages: mergedTopicMessages,
         })
       } catch (error) {
+        if (error.name === 'KafkaJSConnectionClosedError') {
+          cluster.removeBroker({ host: error.host, port: error.port })
+        }
+
         if (!cluster.isConnected()) {
           logger.debug(`Cluster has disconnected, reconnecting: ${error.message}`, {
             retryCount,
@@ -114,6 +118,7 @@ module.exports = ({
         // for this topic has increased in the meantime
         if (
           error.name === 'KafkaJSConnectionError' ||
+          error.name === 'KafkaJSConnectionClosedError' ||
           (error.name === 'KafkaJSProtocolError' && error.retriable)
         ) {
           logger.error(`Failed to send messages: ${error.message}`, { retryCount, retryTime })


### PR DESCRIPTION
When the broker closes the connection abruptly, KafkaJS is doing two things:
1) it tries to disconnect the broker before rejecting the ongoing requests, this causes a deadlock
2) it throws a retriable error, which forces the client to retry the same broker

This PR addresses both issues. It guarantees that any ongoing requests will be rejected before we properly disconnect the broker (the requests will never resolve). It removes the problematic broker from the list and forces a metadata refresh.

It possibly improves the issue described on #660, but it doesn't address the ultimate root cause: the lack of proper keep alive configs in node.js. With proper configs, the socket will be monitored, and any problems with the connection can be detected. I want to try a custom socket factory using [node-net-keepalive](https://github.com/hertzg/node-net-keepalive) to monitor the socket.