### PR TITLE
Improve error handling during broker discovery

### DIFF
--- a/src/cluster/__tests__/connectionBuilder.spec.js
+++ b/src/cluster/__tests__/connectionBuilder.spec.js
@@ -108,7 +108,7 @@ describe('Cluster > ConnectionBuilder', () => {
         logger,
       }).build()
     ).rejects.toEqual(
-      new KafkaJSConnectionError('Failed to connect: brokers function returned nothing')
+      new KafkaJSConnectionError('Failed to connect: "config.brokers" returned void or empty array')
     )
   })
 
@@ -127,7 +127,7 @@ describe('Cluster > ConnectionBuilder', () => {
         logger,
       }).build()
     ).rejects.toEqual(
-      new KafkaJSConnectionError('Failed to connect: brokers function returned exception')
+      new KafkaJSConnectionError('Failed to connect: "config.brokers" threw: oh a crash!')
     )
   })
 

--- a/src/cluster/connectionBuilder.js
+++ b/src/cluster/connectionBuilder.js
@@ -35,12 +35,17 @@ module.exports = ({
     try {
       list = await brokers()
     } catch (e) {
-      logger.error(e)
-      throw new KafkaJSConnectionError(`Failed to connect: brokers function returned exception`)
+      const wrappedError = new KafkaJSConnectionError(
+        `Failed to connect: "config.brokers" threw: ${e.message}`
+      )
+      wrappedError.stack = `${wrappedError.name}\n  Caused by: ${e.stack}`
+      throw wrappedError
     }
 
     if (!list || list.length === 0) {
-      throw new KafkaJSConnectionError(`Failed to connect: brokers function returned nothing`)
+      throw new KafkaJSConnectionError(
+        `Failed to connect: "config.brokers" returned void or empty array`
+      )
     }
     return list
   }


### PR DESCRIPTION
Error stack now points to user-provided "config.brokers" function
instead of ConnectionBuilder to make it more clear where the error
came from.