### PR TITLE
Move compression to worker threads if available

### DIFF
--- a/examples/compression-test.js
+++ b/examples/compression-test.js
@@ -1,0 +1,170 @@
+const fs = require('fs')
+const ip = require('ip')
+const os = require('os')
+const path = require('path')
+
+const { Kafka, logLevel, CompressionTypes } = require('../index')
+const sleep = require('../src/utils/sleep')
+const { waitFor } = require('../testHelpers')
+const PrettyConsoleLogger = require('./prettyConsoleLogger')
+
+const host = process.env.HOST_IP || ip.address()
+
+const kafka = new Kafka({
+  logLevel: logLevel.INFO,
+  logCreator: PrettyConsoleLogger,
+  brokers: [`${host}:9094`, `${host}:9097`, `${host}:9100`],
+  clientId: 'example-consumer',
+  ssl: {
+    servername: 'localhost',
+    rejectUnauthorized: false,
+    ca: [fs.readFileSync('./testHelpers/certs/cert-signed', 'utf-8')],
+  },
+  sasl: {
+    mechanism: 'plain',
+    username: 'test',
+    password: 'testtest',
+  },
+})
+
+const topicName = `topic-test-${Date.now()}`
+const producer = kafka.producer()
+
+const messagesToProduce = 100
+const bigText =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse eu mi sit amet nisl vulputate sagittis ut at justo. Nullam porta eros sit amet nibh interdum fermentum. Aliquam dignissim felis in magna maximus, ut consectetur lacus malesuada. Ut velit lorem, pulvinar vitae elit vel, efficitur sagittis lorem. Nulla risus ex, mollis ut ante et, iaculis elementum turpis. Vivamus vitae ante nisi. Mauris tristique sit amet sapien vitae fermentum. Cras et luctus lacus. Phasellus sit amet quam et turpis tempor rutrum eu at nulla. Maecenas sit amet viverra purus, in posuere nibh. Pellentesque facilisis sit amet mi non volutpat. In interdum urna sit amet rhoncus gravida. Nulla non imperdiet orci. Vestibulum luctus sollicitudin pellentesque. Aliquam porttitor ut quam nec dapibus. Curabitur at dignissim tellus. Nunc blandit, tortor non aliquet ultrices, odio ligula pretium nibh, id faucibus urna eros eget lacus. Curabitur facilisis rutrum tristique. Vestibulum in tristique nunc. Nunc in lorem id nunc sodales viverra id sit amet massa. Aliquam nec suscipit magna. Nam gravida lectus at urna venenatis posuere. Maecenas pharetra neque sed tincidunt molestie. Fusce facilisis maximus eros id sodales. Quisque venenatis purus vel massa tempor fermentum. Phasellus congue pellentesque massa sit amet egestas. Duis neque metus, rutrum a aliquet et, venenatis sit amet ante. Proin sed felis id nibh consectetur mattis. Quisque tempor fermentum nisi non sollicitudin. Fusce posuere faucibus libero et semper. Aliquam ut nibh quis libero aliquet accumsan. Donec nec justo vel eros consequat volutpat in non dolor. Phasellus congue orci et enim porttitor, quis sagittis enim convallis. Praesent est diam, vestibulum eget mauris eleifend, tristique pharetra dui. Nunc imperdiet est non lectus consequat congue. Donec luctus enim mauris, sit amet consequat lectus malesuada non. Nulla vehicula auctor justo non luctus. Sed quis neque sodales, consectetur urna et, venenatis dui. Mauris magna turpis, ullamcorper nec velit convallis, sagittis tristique metus.'
+
+const time = async operation => {
+  const start = process.hrtime()
+  await operation()
+  return process.hrtime(start)
+}
+
+const createMessage = num => ({
+  key: `key-${num}`,
+  value: `value-${num}-${new Date().toISOString()}-${num % 2 === 0 ? 'short' : bigText}`,
+  headers: {
+    'correlation-id': `${num}-${Date.now()}`,
+  },
+})
+
+const sendMessage = topic => {
+  const messages = Array(10000)
+    .fill()
+    .map((_, i) => createMessage(i))
+
+  return producer
+    .send({
+      topic,
+      compression: CompressionTypes.GZIP,
+      messages,
+    })
+    .catch(e => kafka.logger().error(`[example/producer] ${e.message}`, { stack: e.stack }))
+}
+
+const produceMessages = async (numMessages, topic) => {
+  for (let i = 0; i < numMessages; i++) {
+    await sendMessage(topic)
+  }
+}
+
+const consumeMessages = async (consumer, expectedNumberOfMessages) => {
+  let msgNumber = 0
+  await consumer.run({
+    eachMessage: async () => {
+      msgNumber++
+    },
+  })
+
+  await waitFor(() => msgNumber >= expectedNumberOfMessages, { delay: 50 })
+}
+
+let singleThreadConsumer, multiThreadConsumer, admin
+const run = async () => {
+  admin = kafka.admin()
+  await admin.connect()
+  await admin.createTopics({
+    topics: [
+      { topic: `${topicName}-single-thread`, numPartitions: 6 },
+      { topic: `${topicName}-multi-thread`, numPartitions: 6 },
+    ],
+    waitForLeaders: true,
+  })
+
+  await admin.disconnect()
+  await producer.connect()
+
+  let topic = `${topicName}-single-thread`
+  singleThreadConsumer = kafka.consumer({ groupId: 'test-group-single-thread' })
+  await singleThreadConsumer.connect()
+  await singleThreadConsumer.subscribe({ topic, fromBeginning: true })
+
+  kafka.logger().warn('Starting single thread')
+  const singleThreadDuration = await time(async () => {
+    await produceMessages(messagesToProduce, topic)
+    kafka.logger().info('Messages sent', { topic })
+    await consumeMessages(singleThreadConsumer, messagesToProduce * 100)
+  })
+
+  await singleThreadConsumer.disconnect()
+
+  kafka.logger().info('Finished single-threaded operations', {
+    duration: singleThreadDuration[0] * 1000 + singleThreadDuration[1] / 1000000,
+  })
+
+  kafka.startCompressionWorkerPool({
+    numberOfThreads: os.cpus().length - 1,
+    // logLevel: logLevel.DEBUG,
+    logCreatorPath: path.join(__dirname, './prettyConsoleLogger'),
+  })
+
+  await sleep(100)
+
+  topic = `${topicName}-multi-thread`
+  multiThreadConsumer = kafka.consumer({ groupId: 'test-group-multi-thread' })
+  await multiThreadConsumer.connect()
+  await multiThreadConsumer.subscribe({ topic, fromBeginning: true })
+
+  kafka.logger().warn('Starting multi thread')
+  const multiThreadDuration = await time(async () => {
+    await produceMessages(messagesToProduce, topic)
+    kafka.logger().info('Messages sent', { topic })
+    await consumeMessages(multiThreadConsumer, messagesToProduce * 100)
+  })
+
+  kafka.logger().info('Finished multi-threaded operations', {
+    duration: multiThreadDuration[0] * 1000 + multiThreadDuration[1] / 1000000,
+  })
+}
+
+run().catch(e => kafka.logger().error(`[example/consumer] ${e.message}`, { stack: e.stack }))
+
+const errorTypes = ['unhandledRejection', 'uncaughtException']
+const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2']
+
+errorTypes.map(type => {
+  process.on(type, async e => {
+    try {
+      kafka.logger().info(`process.on ${type}`)
+      kafka.logger().error(e.message, { stack: e.stack })
+      await admin.disconnect()
+      await singleThreadConsumer.disconnect()
+      await multiThreadConsumer.disconnect()
+      await producer.disconnect()
+      process.exit(0)
+    } catch (_) {
+      process.exit(1)
+    }
+  })
+})
+
+signalTraps.map(type => {
+  process.once(type, async () => {
+    console.log('')
+    kafka.logger().info('[example/consumer] disconnecting')
+    await admin.disconnect()
+    await singleThreadConsumer.disconnect()
+    await multiThreadConsumer.disconnect()
+    await producer.disconnect()
+  })
+})

--- a/examples/consumer.js
+++ b/examples/consumer.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const ip = require('ip')
+const path = require('path')
 
 const { Kafka, logLevel } = require('../index')
 const PrettyConsoleLogger = require('./prettyConsoleLogger')
@@ -21,6 +22,12 @@ const kafka = new Kafka({
     username: 'test',
     password: 'testtest',
   },
+})
+
+kafka.startCompressionWorkerPool({
+  numberOfThreads: 1,
+  logLevel: logLevel.DEBUG,
+  logCreatorPath: path.join(__dirname, './prettyConsoleLogger'),
 })
 
 const topic = 'topic-test'

--- a/examples/producer.js
+++ b/examples/producer.js
@@ -71,8 +71,6 @@ let intervalId
 const run = async () => {
   await producer.connect()
   intervalId = setInterval(sendMessage, 3000)
-  // await sendMessage()
-  // await producer.disconnect()
 }
 
 run().catch(e => kafka.logger().error(`[example/producer] ${e.message}`, { stack: e.stack }))

--- a/examples/producer.js
+++ b/examples/producer.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const ip = require('ip')
+const path = require('path')
 
 const { Kafka, CompressionTypes, logLevel } = require('../index')
 const PrettyConsoleLogger = require('./prettyConsoleLogger')
@@ -21,6 +22,12 @@ const kafka = new Kafka({
     username: 'test',
     password: 'testtest',
   },
+})
+
+kafka.startCompressionWorkerPool({
+  numberOfThreads: 1,
+  logLevel: logLevel.DEBUG,
+  logCreatorPath: path.join(__dirname, './prettyConsoleLogger'),
 })
 
 const topic = 'topic-test'
@@ -64,6 +71,8 @@ let intervalId
 const run = async () => {
   await producer.connect()
   intervalId = setInterval(sendMessage, 3000)
+  // await sendMessage()
+  // await producer.disconnect()
 }
 
 run().catch(e => kafka.logger().error(`[example/producer] ${e.message}`, { stack: e.stack }))

--- a/examples/report.md
+++ b/examples/report.md
@@ -1,0 +1,94 @@
+Parameters:
+1000 * 100 messages
+16 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:44:13.727Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 6317.6354
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:44:20.596Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 6720.9607
+info:  ┗ [4] }
+```
+
+Parameters
+10000 * 100 messages
+16 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:45:46.570Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 55895.5945
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:46:46.005Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 59291.9369
+info:  ┗ [4] }
+```
+
+Parameters
+1000 * 1000 messages
+16 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:47:58.822Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 19991.0183
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:48:19.289Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 20329.0268
+info:  ┗ [4] }
+```
+
+Parameters
+1000 * 1000 messages
+15 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:49:03.638Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 20032.0227
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:49:24.117Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 20339.3427
+info:  ┗ [4] }
+```
+
+Parameters
+100 * 10000 messages
+15 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:51:14.113Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 25329.8898
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-22T13:51:38.982Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 24725.4134
+info:  ┗ [4] }
+```

--- a/examples/report.md
+++ b/examples/report.md
@@ -1,3 +1,5 @@
+## GZIP
+
 Parameters:
 1000 * 100 messages
 16 workers
@@ -90,5 +92,64 @@ info:  ┃ [0] {
 info:  ┃ [1]   "timestamp": "2020-09-22T13:51:38.982Z",
 info:  ┃ [2]   "logger": "kafkajs",
 info:  ┃ [3]   "duration": 24725.4134
+info:  ┗ [4] }
+```
+
+## Snappy
+
+Parameters:
+1000 * 100 messages
+15 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-24T14:14:04.833Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 5597.4399
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-24T14:14:10.995Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 6026.1829
+info:  ┗ [4] }
+```
+
+Parameters
+10000 * 100 messages
+15 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-24T14:14:04.833Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 50358.5431
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-24T14:14:10.995Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 53925.259
+info:  ┗ [4] }
+```
+
+Parameters
+1000 * 1000 messages
+15 workers
+
+```
+info:  ┏ Finished single-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-24T14:14:04.833Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 50358.5431
+info:  ┗ [4] }
+info:  ┏ Finished multi-threaded operations
+info:  ┃ [0] {
+info:  ┃ [1]   "timestamp": "2020-09-24T14:14:10.995Z",
+info:  ┃ [2]   "logger": "kafkajs",
+info:  ┃ [3]   "duration": 53925.259
 info:  ┗ [4] }
 ```

--- a/examples/workerSetup.js
+++ b/examples/workerSetup.js
@@ -1,0 +1,13 @@
+const SnappyCodec = require('kafkajs-snappy')
+const { CompressionTypes, CompressionCodecs } = require('../index')
+const PrettyConsoleLogger = require('./prettyConsoleLogger')
+
+module.exports = () => {
+  // configure Snappy codec
+  CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec
+
+  // Return extra configs for the worker (format/shape pending)
+  return {
+    logCreator: PrettyConsoleLogger,
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -72,12 +72,17 @@ module.exports = class Client {
     }
   }
 
+  /**
+   * @public
+   * @param {number} numberOfThreads
+   * @param {logLevels} logLevel
+   * @param {string} setupScriptPath
+   */
   startCompressionWorkerPool(args = {}) {
     createCompressionWorkerPool({
-      enabled: false,
       numberOfThreads: 1,
       logLevel: INFO,
-      logLevelCreatorPath: null,
+      setupScriptPath: null,
       ...args,
     })
   }

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ const {
   LEVELS: { INFO },
 } = require('./loggers')
 
+const { createCompressionWorkerPool } = require('./protocol/message/compression/workerPool')
+
 const InstrumentationEventEmitter = require('./instrumentation/emitter')
 const LoggerConsole = require('./loggers/console')
 const Cluster = require('./cluster')
@@ -46,8 +48,8 @@ module.exports = class Client {
       maxInFlightRequests = null,
       instrumentationEmitter = null,
       isolationLevel,
-    }) =>
-      new Cluster({
+    }) => {
+      return new Cluster({
         logger: this[PRIVATE.LOGGER],
         retry: this[PRIVATE.CLUSTER_RETRY],
         offsets: this[PRIVATE.OFFSETS],
@@ -67,6 +69,17 @@ module.exports = class Client {
         maxInFlightRequests,
         isolationLevel,
       })
+    }
+  }
+
+  startCompressionWorkerPool(args = {}) {
+    createCompressionWorkerPool({
+      enabled: false,
+      numberOfThreads: 1,
+      logLevel: INFO,
+      logLevelCreatorPath: null,
+      ...args,
+    })
   }
 
   /**

--- a/src/protocol/message/compression/worker.js
+++ b/src/protocol/message/compression/worker.js
@@ -19,9 +19,15 @@ if (isMainThread) {
   )
 }
 
-const { logLevel, logCreatorPath } = workerData
-const logCreator = logCreatorPath ? require(logCreatorPath) : LoggerConsole
-const rootLogger = createLogger({ level: logLevel || INFO, logCreator })
+const { logLevel, setupScriptPath } = workerData
+const setupWorker = require(setupScriptPath)
+const { logCreator } = setupWorker()
+
+const rootLogger = createLogger({
+  level: logLevel || INFO,
+  logCreator: logCreator || LoggerConsole,
+})
+
 const threadLogger = rootLogger.namespace(`CompressionWorkerThread#${threadId}`)
 
 const decompressTask = async ({ attributes, compressedRecordsBuffer }) => {

--- a/src/protocol/message/compression/worker.js
+++ b/src/protocol/message/compression/worker.js
@@ -1,0 +1,99 @@
+const Encoder = require('../../encoder')
+const { KafkaJSNonRetriableError } = require('../../../errors')
+const {
+  createLogger,
+  LEVELS: { INFO },
+} = require('../../../loggers')
+const LoggerConsole = require('../../../loggers/console')
+
+const { workerThreads, failIfWorkerThreadsNotAvailable } = require('./workerThreads')
+const { lookupCodecByRecordBatchAttributes, lookupCodec } = require('./index')
+const { workerTaskType, workerResultType } = require('./workerPoolTaskType')
+
+failIfWorkerThreadsNotAvailable()
+const { isMainThread, workerData, threadId, parentPort } = workerThreads
+
+if (isMainThread) {
+  throw new KafkaJSNonRetriableError(
+    'The compression worker cannot be initialized on the main thread'
+  )
+}
+
+const { logLevel, logCreatorPath } = workerData
+const logCreator = logCreatorPath ? require(logCreatorPath) : LoggerConsole
+const rootLogger = createLogger({ level: logLevel || INFO, logCreator })
+const threadLogger = rootLogger.namespace(`CompressionWorkerThread#${threadId}`)
+
+const decompressTask = async ({ attributes, compressedRecordsBuffer }) => {
+  const codec = lookupCodecByRecordBatchAttributes(attributes)
+  const decompressedRecordBuffer = await codec.decompress(compressedRecordsBuffer)
+  const sharedBuffer = new SharedArrayBuffer(decompressedRecordBuffer.length + 1)
+  const sharedArray = new Uint8Array(sharedBuffer)
+
+  sharedArray[0] = workerResultType.SUCCESS
+  sharedArray.set(decompressedRecordBuffer, 1)
+
+  parentPort.postMessage(sharedArray)
+}
+
+const compressTask = async ({ compressionType, records }) => {
+  const codec = lookupCodec(compressionType)
+  const compressedRecords = await codec.compress(new Encoder().writeBuffer(Buffer.from(records)))
+  const sharedBuffer = new SharedArrayBuffer(compressedRecords.length + 1)
+  const sharedArray = new Uint8Array(sharedBuffer)
+
+  sharedArray[0] = workerResultType.SUCCESS
+  sharedArray.set(compressedRecords, 1)
+
+  parentPort.postMessage(sharedArray)
+}
+
+const handleError = e => {
+  const errorMessage = Buffer.from(e.message)
+  const sharedBuffer = new SharedArrayBuffer(errorMessage.length + 1)
+  const sharedArray = new Uint8Array(sharedBuffer)
+
+  sharedArray[0] = workerResultType.FAILURE
+  sharedArray.set(errorMessage, 1)
+
+  parentPort.postMessage(sharedArray)
+}
+
+parentPort.on('message', sharedBuffer => {
+  const sharedArray = new Uint8Array(sharedBuffer)
+  const taskType = sharedArray[0]
+
+  switch (taskType) {
+    case workerTaskType.COMPRESS: {
+      const compressionType = sharedArray[1]
+      const records = Buffer.from(sharedArray.slice(2, sharedArray.length))
+
+      compressTask({ compressionType, records }).catch(e => {
+        threadLogger.error('Failed to compress data', {
+          error: e.message,
+          stack: e.stack,
+        })
+
+        handleError(e)
+      })
+      break
+    }
+
+    case workerTaskType.DECOMPRESS: {
+      const attributes = sharedArray[1]
+      const compressedRecordsBuffer = Buffer.from(sharedArray.slice(2, sharedArray.length))
+
+      decompressTask({ attributes, compressedRecordsBuffer }).catch(e => {
+        threadLogger.error('Failed to decompress data', {
+          error: e.message,
+          stack: e.stack,
+        })
+
+        handleError(e)
+      })
+      break
+    }
+  }
+})
+
+threadLogger.debug('Worker initialized', { threadId })

--- a/src/protocol/message/compression/workerPool.js
+++ b/src/protocol/message/compression/workerPool.js
@@ -1,0 +1,183 @@
+const path = require('path')
+const { EventEmitter } = require('events')
+const { KafkaJSNonRetriableError } = require('../../../errors')
+
+const {
+  workerThreads,
+  isWorkerThreadsAvailable,
+  failIfWorkerThreadsNotAvailable,
+} = require('./workerThreads')
+
+const { workerTaskType, workerResultType } = require('./workerPoolTaskType')
+
+const WORKER_PATH = path.join(__dirname, './worker.js')
+const PRIVATE = {
+  WORKER_ID: Symbol('private:CompressionWorkerPool:workerId'),
+  WORKER_STATUS: Symbol('private:CompressionWorkerPool:workerStatus'),
+  WORKERS: Symbol('private:CompressionWorkerPool:workers'),
+  CREATE_WORKER: Symbol('private:CompressionWorkerPool:createWorker'),
+  POST_MESSAGE: Symbol('private:CompressionWorkerPool:postMessage'),
+}
+
+const WORKER_STATUS = {
+  AVAILABLE: 'available',
+  BUSY: 'busy',
+}
+
+const INTERNAL_EVENTS = {
+  WORKER_AVAILABLE: 'worker-available',
+}
+
+let globalWorkersId = 0
+const nextWorkerId = () => {
+  return ++globalWorkersId
+}
+
+class CompressionWorkerPool extends EventEmitter {
+  /**
+   * @param {number} numberOfThreads. Default 1
+   * @param {logLevels} logLevel
+   * @param {string} logCreatorPath
+   */
+  constructor({ numberOfThreads, logLevel, logCreatorPath } = {}) {
+    super()
+    this.numberOfThreads = numberOfThreads || 1
+    this[PRIVATE.WORKERS] = []
+
+    for (let i = 0; i < numberOfThreads; i++) {
+      this[PRIVATE.CREATE_WORKER]({ logLevel, logCreatorPath })
+    }
+  }
+
+  close() {
+    for (const worker of this[PRIVATE.WORKERS]) {
+      worker.terminate()
+    }
+  }
+
+  /**
+   * @async
+   * @public
+   * @param {CompressionTypes} compression
+   * @param {Buffer} records
+   */
+  compress(compressionType, records) {
+    // TODO: throw if no workers
+    const sharedBuffer = new SharedArrayBuffer(records.length + 2)
+    const sharedArray = new Uint8Array(sharedBuffer)
+    sharedArray[0] = workerTaskType.COMPRESS
+    sharedArray[1] = compressionType
+    sharedArray.set(records, 2)
+
+    return new Promise((resolve, reject) => {
+      this[PRIVATE.POST_MESSAGE](sharedBuffer, resolve, reject)
+    })
+  }
+
+  /**
+   * @async
+   * @public
+   * @param {Uint8} attributes
+   * @param {Buffer} compressedRecordsBuffer
+   */
+  decompress(attributes, compressedRecordsBuffer) {
+    // TODO: throw if no workers
+    const sharedBuffer = new SharedArrayBuffer(compressedRecordsBuffer.length + 2)
+    const sharedArray = new Uint8Array(sharedBuffer)
+    sharedArray[0] = workerTaskType.DECOMPRESS
+    sharedArray[1] = attributes
+    sharedArray.set(compressedRecordsBuffer, 2)
+
+    return new Promise((resolve, reject) => {
+      this[PRIVATE.POST_MESSAGE](sharedBuffer, resolve, reject)
+    })
+  }
+
+  [PRIVATE.POST_MESSAGE](payload, success, failure) {
+    // TODO: if exiting, block new messages
+    const findAvailableWorker = () =>
+      this[PRIVATE.WORKERS].find(
+        worker => worker[PRIVATE.WORKER_STATUS] === WORKER_STATUS.AVAILABLE
+      )
+
+    const sendPayload = worker => {
+      worker[PRIVATE.WORKER_STATUS] = WORKER_STATUS.BUSY
+
+      worker.once('message', sharedBuffer => {
+        try {
+          const sharedArray = new Uint8Array(sharedBuffer)
+
+          if (sharedArray[0] === workerResultType.FAILURE) {
+            const errorMessage = Buffer.from(sharedArray.slice(1)).toString()
+            return failure(new KafkaJSNonRetriableError(errorMessage))
+          }
+
+          success(Buffer.from(sharedArray.slice(1)))
+        } finally {
+          worker[PRIVATE.WORKER_STATUS] = WORKER_STATUS.AVAILABLE
+          this.emit(INTERNAL_EVENTS.WORKER_AVAILABLE)
+        }
+      })
+
+      worker.once('error', e => {
+        failure(e)
+        worker[PRIVATE.WORKER_STATUS] = WORKER_STATUS.AVAILABLE
+        this.emit(INTERNAL_EVENTS.WORKER_AVAILABLE)
+      })
+
+      worker.postMessage(payload)
+    }
+
+    const execute = () => {
+      const worker = findAvailableWorker()
+      worker ? sendPayload(worker) : this.once(INTERNAL_EVENTS.WORKER_AVAILABLE, execute)
+    }
+
+    execute()
+  }
+
+  [PRIVATE.CREATE_WORKER]({ logLevel, logCreatorPath }) {
+    const worker = new workerThreads.Worker(WORKER_PATH, {
+      workerData: { logLevel, logCreatorPath },
+    })
+
+    worker.unref()
+    worker[PRIVATE.WORKER_ID] = nextWorkerId()
+    worker[PRIVATE.WORKER_STATUS] = WORKER_STATUS.AVAILABLE
+    worker.on('exit', code => {
+      const index = this[PRIVATE.WORKERS].indexOf(worker)
+      this[PRIVATE.WORKERS].splice(index, 1)
+    })
+
+    this[PRIVATE.WORKERS].push(worker)
+  }
+}
+
+let compressionWorkerPool
+
+/**
+ * @param {number} numberOfThreads
+ * @param {logLevels} logLevel
+ * @param {string} logCreatorPath
+ */
+const createCompressionWorkerPool = args => {
+  failIfWorkerThreadsNotAvailable()
+
+  if (!compressionWorkerPool) {
+    compressionWorkerPool = new CompressionWorkerPool(args)
+    return true
+  }
+
+  return false
+}
+
+const getCompressionWorkerPool = () => compressionWorkerPool
+const isCompressionWorkerPoolAvailable = () =>
+  isWorkerThreadsAvailable() && getCompressionWorkerPool() != null
+
+module.exports = {
+  createCompressionWorkerPool,
+  getCompressionWorkerPool,
+  isCompressionWorkerPoolAvailable,
+  isWorkerThreadsAvailable,
+}

--- a/src/protocol/message/compression/workerPool.js
+++ b/src/protocol/message/compression/workerPool.js
@@ -37,15 +37,15 @@ class CompressionWorkerPool extends EventEmitter {
   /**
    * @param {number} numberOfThreads. Default 1
    * @param {logLevels} logLevel
-   * @param {string} logCreatorPath
+   * @param {string} setupScriptPath
    */
-  constructor({ numberOfThreads, logLevel, logCreatorPath } = {}) {
+  constructor({ numberOfThreads, logLevel, setupScriptPath } = {}) {
     super()
     this.numberOfThreads = numberOfThreads || 1
     this[PRIVATE.WORKERS] = []
 
     for (let i = 0; i < numberOfThreads; i++) {
-      this[PRIVATE.CREATE_WORKER]({ logLevel, logCreatorPath })
+      this[PRIVATE.CREATE_WORKER]({ logLevel, setupScriptPath })
     }
   }
 
@@ -140,9 +140,9 @@ class CompressionWorkerPool extends EventEmitter {
     execute()
   }
 
-  [PRIVATE.CREATE_WORKER]({ logLevel, logCreatorPath }) {
+  [PRIVATE.CREATE_WORKER]({ logLevel, setupScriptPath }) {
     const worker = new workerThreads.Worker(WORKER_PATH, {
-      workerData: { logLevel, logCreatorPath },
+      workerData: { logLevel, setupScriptPath },
     })
 
     worker.unref()
@@ -162,7 +162,7 @@ let compressionWorkerPool
 /**
  * @param {number} numberOfThreads
  * @param {logLevels} logLevel
- * @param {string} logCreatorPath
+ * @param {string} setupScriptPath
  */
 const createCompressionWorkerPool = args => {
   failIfWorkerThreadsNotAvailable()

--- a/src/protocol/message/compression/workerPoolTaskType.js
+++ b/src/protocol/message/compression/workerPoolTaskType.js
@@ -1,0 +1,14 @@
+const workerTaskType = {
+  COMPRESS: 1,
+  DECOMPRESS: 2,
+}
+
+const workerResultType = {
+  SUCCESS: 0,
+  FAILURE: 1,
+}
+
+module.exports = {
+  workerTaskType,
+  workerResultType,
+}

--- a/src/protocol/message/compression/workerThreads.js
+++ b/src/protocol/message/compression/workerThreads.js
@@ -1,0 +1,21 @@
+const { KafkaJSNotImplemented } = require('../../../errors')
+
+let workerThreads = null
+try {
+  workerThreads = require('worker_threads') // eslint-disable-line node/no-unsupported-features/node-builtins
+} catch (e) {}
+
+const isWorkerThreadsAvailable = () => !!workerThreads
+const failIfWorkerThreadsNotAvailable = () => {
+  if (!isWorkerThreadsAvailable()) {
+    throw new KafkaJSNotImplemented(
+      `The module "worker_threads" is not supported until Node.js 12.11.0, current version ${process.env}`
+    )
+  }
+}
+
+module.exports = {
+  workerThreads,
+  isWorkerThreadsAvailable,
+  failIfWorkerThreadsNotAvailable,
+}


### PR DESCRIPTION
This is experimental work ⚠

The idea is to move the compression and decompression work to worker threads. This change could potentially improve performance as the operations would not block the event loop. This is still pending a proper benchmark, which will happen during the course of this draft.

* Note 1: worker threads require Node.js >= 12.11
* Note 2: If this is successful we could potentially move the encoding and decoding bits to worker threads.