### PR TITLE
Feat: add option for admin.fetchOffsets to resolve the offsets

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -183,7 +183,29 @@ await admin.fetchTopicOffsetsByTimestamp(topic, timestamp)
 `fetchOffsets` returns the consumer group offset for a topic.
 
 ```javascript
-await admin.fetchOffsets({ groupId, topic })
+await admin.fetchOffsets({ groupId, topic, })
+// [
+//   { partition: 0, offset: '31004' },
+//   { partition: 1, offset: '54312' },
+//   { partition: 2, offset: '32103' },
+//   { partition: 3, offset: '28' },
+// ]
+```
+
+Include the optional `resolveOffsets` flag to resolve the offsets without having to start a consumer, useful when fetching directly after calling [resetOffets](#a-name-reset-offsets-a-reset-consumer-group-offsets):
+
+```javascript
+await admin.resetOffsets({ groupId, topic })
+await admin.fetchOffsets({ groupId, topic, resolveOffsets: false })
+// [
+//   { partition: 0, offset: '-1' },
+//   { partition: 1, offset: '-1' },
+//   { partition: 2, offset: '-1' },
+//   { partition: 3, offset: '-1' },
+// ]
+
+await admin.resetOffsets({ groupId, topic })
+await admin.fetchOffsets({ groupId, topic, resolveOffsets: true })
 // [
 //   { partition: 0, offset: '31004' },
 //   { partition: 1, offset: '54312' },

--- a/src/admin/__tests__/fetchOffsets.spec.js
+++ b/src/admin/__tests__/fetchOffsets.spec.js
@@ -10,7 +10,10 @@ const {
   waitForConsumerToJoinGroup,
   generateMessages,
   waitForMessages,
+  testIfKafkaAtLeast_0_11,
 } = require('testHelpers')
+const Encoder = require('../../protocol/encoder')
+const Decoder = require('../../protocol/decoder')
 
 describe('Admin', () => {
   let admin, cluster, groupId, logger, topicName
@@ -153,6 +156,109 @@ describe('Admin', () => {
         expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '0', metadata: null }])
         expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '0', metadata: null }])
       })
+
+      testIfKafkaAtLeast_0_11(
+        'will return the correct offset when earliest offset is greater than 0',
+        async () => {
+          // simulate earliest offset = 7, by deleting first 7 messages from the topic
+          const messagesToDelete = [
+            {
+              topic: topicName,
+              partitions: [
+                {
+                  partition: 0,
+                  offset: '7',
+                },
+              ],
+            },
+          ]
+
+          await deleteRecords({ cluster, topicName, topicDetails: messagesToDelete })
+          await admin.resetOffsets({ groupId, topic: topicName, earliest: true })
+
+          const offsetsBeforeResolving = await admin.fetchOffsets({
+            groupId,
+            topic: topicName,
+          })
+          const offsetsUponResolving = await admin.fetchOffsets({
+            groupId,
+            topic: topicName,
+            resolveOffsets: true,
+          })
+          const offsetsAfterResolving = await admin.fetchOffsets({
+            groupId,
+            topic: topicName,
+          })
+
+          expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '-2', metadata: null }])
+          expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '7', metadata: null }])
+          expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '7', metadata: null }])
+        }
+      )
     })
   })
 })
+
+/**
+ * Manually delete records up to the selected offset
+ * http://kafka.apache.org/protocol.html#The_Messages_DeleteRecords
+ * Only available from Kafka 0.11 upwards
+ */
+const deleteRecords = async ({ cluster, topicName, topicDetails }) => {
+  const partitionLeader = await cluster.findLeaderForPartitions(topicName, [0])
+  const [nodeId] = Object.keys(partitionLeader)
+
+  const connection = (await cluster.findBroker({ nodeId })).connection
+  const requestTimeout = 5000
+  const request = {
+    apiKey: 21,
+    apiVersion: 0,
+    encode: async () => {
+      return new Encoder()
+        .writeArray(
+          topicDetails.map(({ topic, partitions }) => {
+            return new Encoder().writeString(topic).writeArray(
+              partitions.map(({ partition, offset }) => {
+                return new Encoder().writeInt32(partition).writeInt64(offset)
+              })
+            )
+          })
+        )
+        .writeInt32(requestTimeout)
+    },
+    expectResponse: () => true,
+  }
+
+  const response = {
+    decode: async rawData => {
+      const decoder = new Decoder(rawData)
+      return {
+        throttleTime: decoder.readInt32(),
+        topics: decoder
+          .readArray(decoder => ({
+            topic: decoder.readString(),
+            partitions: decoder.readArray(decoder => ({
+              partitionIndex: decoder.readInt32(),
+              lowWatermark: decoder.readInt64(),
+              errorCode: decoder.readInt16(),
+            })),
+          }))
+          .sort((a, b) => a.topic.localeCompare(b.topic)),
+      }
+    },
+    parse: data => {
+      let responseCode
+      if (
+        data.topics.some(({ partitions }) =>
+          partitions.some(({ errorCode }) => {
+            responseCode = errorCode
+            return errorCode !== 0
+          })
+        )
+      )
+        throw new Error(`Unable to delete Kafka record. Returned code ${responseCode}`)
+    },
+  }
+
+  await connection.send({ request, response })
+}

--- a/src/admin/__tests__/fetchOffsets.spec.js
+++ b/src/admin/__tests__/fetchOffsets.spec.js
@@ -1,8 +1,19 @@
 const createAdmin = require('../index')
-const { secureRandom, createCluster, newLogger, createTopic } = require('testHelpers')
+const createProducer = require('../../producer')
+const createConsumer = require('../../consumer')
+const {
+  secureRandom,
+  createCluster,
+  newLogger,
+  createTopic,
+  createModPartitioner,
+  waitForConsumerToJoinGroup,
+  generateMessages,
+  waitForMessages,
+} = require('testHelpers')
 
 describe('Admin', () => {
-  let admin, cluster, consumer, groupId, logger, topicName
+  let admin, cluster, groupId, logger, topicName
 
   beforeEach(async () => {
     topicName = `test-topic-${secureRandom()}`
@@ -19,7 +30,6 @@ describe('Admin', () => {
 
   afterEach(async () => {
     admin && (await admin.disconnect())
-    consumer && (await consumer.disconnect())
   })
 
   describe('fetchOffsets', () => {
@@ -59,6 +69,90 @@ describe('Admin', () => {
       })
 
       expect(offsets).toEqual([{ partition: 0, offset: '13', metadata: null }])
+    })
+
+    describe('when resolveOffsets option is enabled', () => {
+      let producer, consumer, messagesConsumed
+
+      beforeEach(async () => {
+        producer = createProducer({
+          cluster,
+          createPartitioner: createModPartitioner,
+          logger,
+        })
+        await producer.connect()
+
+        consumer = createConsumer({
+          cluster,
+          groupId,
+          maxWaitTimeInMs: 100,
+          logger,
+        })
+        await consumer.connect()
+        await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+        messagesConsumed = []
+        consumer.run({ eachMessage: async event => messagesConsumed.push(event) })
+        await waitForConsumerToJoinGroup(consumer)
+
+        const messages = generateMessages({ number: 10 })
+        await producer.send({
+          acks: 1,
+          topic: topicName,
+          messages,
+        })
+        await waitForMessages(messagesConsumed, { number: messages.length })
+        await consumer.stop()
+      })
+
+      afterEach(async () => {
+        producer && (await producer.disconnect())
+        consumer && (await consumer.disconnect())
+      })
+
+      test('returns latest topic offsets after resolving, and persists them', async () => {
+        await admin.resetOffsets({ groupId, topic: topicName })
+
+        const offsetsBeforeResolving = await admin.fetchOffsets({
+          groupId,
+          topic: topicName,
+        })
+        const offsetsUponResolving = await admin.fetchOffsets({
+          groupId,
+          topic: topicName,
+          resolveOffsets: true,
+        })
+        const offsetsAfterResolving = await admin.fetchOffsets({
+          groupId,
+          topic: topicName,
+        })
+
+        expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '-1', metadata: null }])
+        expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '10', metadata: null }])
+        expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '10', metadata: null }])
+      })
+
+      test('returns earliest topic offsets after resolving, and persists them', async () => {
+        await admin.resetOffsets({ groupId, topic: topicName, earliest: true })
+
+        const offsetsBeforeResolving = await admin.fetchOffsets({
+          groupId,
+          topic: topicName,
+        })
+        const offsetsUponResolving = await admin.fetchOffsets({
+          groupId,
+          topic: topicName,
+          resolveOffsets: true,
+        })
+        const offsetsAfterResolving = await admin.fetchOffsets({
+          groupId,
+          topic: topicName,
+        })
+
+        expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '-2', metadata: null }])
+        expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '0', metadata: null }])
+        expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '0', metadata: null }])
+      })
     })
   })
 })

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -384,16 +384,20 @@ module.exports = ({
       const indexedOffsets = indexByPartition(await fetchTopicOffsets(topic))
       consumerOffsets = consumerOffsets.map(({ topic, partitions }) => ({
         topic,
-        partitions: partitions.map(({ offset, partition, ...props }) => ({
-          partition,
-          offset:
-            Number(offset) === EARLIEST_OFFSET
-              ? indexedOffsets[partition].low
-              : Number(offset) === LATEST_OFFSET
-              ? indexedOffsets[partition].high
-              : offset,
-          ...props,
-        })),
+        partitions: partitions.map(({ offset, partition, ...props }) => {
+          let resolvedOffset = offset
+          if (Number(offset) === EARLIEST_OFFSET) {
+            resolvedOffset = indexedOffsets[partition].low
+          }
+          if (Number(offset) === LATEST_OFFSET) {
+            resolvedOffset = indexedOffsets[partition].high
+          }
+          return {
+            partition,
+            offset: resolvedOffset,
+            ...props,
+          }
+        }),
       }))
       const [{ partitions }] = consumerOffsets
       await setOffsets({ groupId, topic, partitions })

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -381,8 +381,6 @@ module.exports = ({
 
     if (resolveOffsets) {
       const indexedOffsets = indexByPartition(await fetchTopicOffsets(topic))
-      console.log('fetched offsets')
-      console.log(indexedOffsets[0])
       consumerOffsets = consumerOffsets.map(({ topic, partitions }) => ({
         topic,
         partitions: partitions.map(({ offset, partition, ...props }) => ({

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -359,6 +359,7 @@ module.exports = ({
   /**
    * @param {string} groupId
    * @param {string} topic
+   * @param {boolean} [resolveOffsets=false]
    * @return {Promise}
    */
   const fetchOffsets = async ({ groupId, topic, resolveOffsets = false }) => {

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -7,7 +7,7 @@ const { events, wrap: wrapEvent, unwrap: unwrapEvent } = require('./instrumentat
 const { LEVELS } = require('../loggers')
 const { KafkaJSNonRetriableError, KafkaJSDeleteGroupsError } = require('../errors')
 const RESOURCE_TYPES = require('../protocol/resourceTypes')
-const { EARLIEST_OFFSET } = require('../constants')
+const { EARLIEST_OFFSET, LATEST_OFFSET } = require('../constants')
 
 const { CONNECT, DISCONNECT } = events
 
@@ -381,6 +381,8 @@ module.exports = ({
 
     if (resolveOffsets) {
       const indexedOffsets = indexByPartition(await fetchTopicOffsets(topic))
+      console.log('fetched offsets')
+      console.log(indexedOffsets[0])
       consumerOffsets = consumerOffsets.map(({ topic, partitions }) => ({
         topic,
         partitions: partitions.map(({ offset, partition, ...props }) => ({
@@ -388,7 +390,9 @@ module.exports = ({
           offset:
             Number(offset) === EARLIEST_OFFSET
               ? indexedOffsets[partition].low
-              : indexedOffsets[partition].high,
+              : Number(offset) === LATEST_OFFSET
+              ? indexedOffsets[partition].high
+              : offset,
           ...props,
         })),
       }))

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -322,6 +322,7 @@ export type Admin = {
   fetchOffsets(options: {
     groupId: string
     topic: string
+    resolveOffsets?: boolean
   }): Promise<Array<SeekEntry & { metadata: string | null }>>
   fetchTopicOffsets(topic: string): Promise<Array<SeekEntry & { high: string; low: string }>>
   fetchTopicOffsetsByTimestamp(topic: string, timestamp?: number): Promise<Array<SeekEntry>>


### PR DESCRIPTION
Closes #205

Had a stab at issue #205 as I don't think anyone was working on it any more.

Tweaking the admin to resolve the offsets I think was fairly quick, but let me know if you had other ideas for the implementation.

I might have gone a little OTT with some of the tests 🙈. Wanted to include test cases for:

(a) what happens when you fetch/resolve without having reset the consumer group offsets: it should return the consumer's latest offsets rather than the topic's highwatermark. That's where I'm sending two separate message batches and fetching the offsets before the second batch, and

(b) what happens when low watermark is greater than 0. Am simulating this by deleting some messages from the topic. I couldn't find that the kafkajs client implemented `deleteRecords` yet? (not sure if it's on the roadmap for the future, or a decision to leave it out, or I might have missed it), so I wrote a helper for the test to do it.

Let me know if you want me to simplify any of these.. (also, if you don't have deleteRecords but do want to implement it in the main client I'm happy to look into that as well)