### PR TITLE
Add commercial support contact section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@
   </p>
 </p>
 
+<hr />
+<p align="center">
+<b>Commercial support available!</b><br /><a href="https://kafka.js.org/#support">Resolve issues faster by getting help directly from a <b>KafkaJS developer</b></a>
+</p>
+
 ## Table of Contents
 
 - [About the project](#about)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -259,6 +259,7 @@ jobs:
         env:
           VERSION: $(Build.SourceBranch)
           GH_TOKEN: $(GH_TOKEN)
+          CONTACT_FORM_URL: $(CONTACT_FORM_URL)
       - bash: |
           git add .
           DOC_VERSION=$(echo "$VERSION" | sed -e "s/^refs\/tags\/v//")
@@ -379,3 +380,4 @@ jobs:
         displayName: publish to gh-pages
         env:
           GH_NAME: $(GH_NAME)
+          CONTACT_FORM_URL: $(CONTACT_FORM_URL)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -270,6 +270,9 @@
       },
       "version-1.13.0/version-1.13.0-producing": {
         "title": "Producing Messages"
+      },
+      "version-1.14.0/version-1.14.0-configuration": {
+        "title": "Client Configuration"
       }
     },
     "links": {

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -29,6 +29,10 @@ function Help(props) {
       title: 'Join the community',
     },
     {
+      content: `Commercial support is [available directly from the KafkaJS developers](${baseUrl}#support).`,
+      title: 'Get dedicated support',
+    },
+    {
       content: `Believe you have found a bug? Please [open an issue](https://github.com/tulios/kafkajs/issues) describing the issue as clearly as you can.`,
       title: 'Open an issue',
     },
@@ -51,7 +55,7 @@ function Help(props) {
             If you're still unable to find a solution to your problem, feel free to check out the
             links below.
           </p>
-          <GridBlock contents={supportLinks} layout="threeColumn" />
+          <GridBlock contents={supportLinks} layout="fourColumn" />
         </div>
       </Container>
     </div>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -110,11 +110,53 @@ class Index extends React.Component {
       </div>
     )
 
+    const SupportSection = props => (
+      <Container className="support" id="support" padding={['top', 'bottom']} background="light">
+        <h2>Commercial support available!</h2>
+        <p>
+          Resolve issues faster with support directly from a <b>KafkaJS expert</b>. We can help you
+          with architectural consultations, issue triage &amp; bug fixing, developer training and
+          custom development.
+        </p>
+
+        <form
+          action={props.siteConfig.contactFormUrl}
+          method="POST"
+          acceptCharset="UTF-8"
+          className="contact-form"
+        >
+          <label htmlFor="email" className="email-label">
+            Email
+          </label>
+          <input type="email" name="email" placeholder="foo@example.com" />
+
+          <label htmlFor="message">What can we help you with?</label>
+          <textarea name="message" placeholder="I would like help with ..." rows={3}></textarea>
+
+          <input type="hidden" name="_gotcha" />
+          <button type="submit" className="button">
+            Submit
+          </button>
+        </form>
+
+        <small>
+          No up-front payment required, but a minimum charge at an agreed upon hourly rate may
+          apply. Commercial support is subject to availability. For community support, direct your
+          questions at the{' '}
+          <a href="https://stackoverflow.com/questions/tagged/kafkajs">
+            #kafkajs tag on StackOverflow
+          </a>{' '}
+          or our <a href={props.siteConfig.slackUrl}>Slack community</a>.
+        </small>
+      </Container>
+    )
+
     return (
       <div>
         <HomeSplash siteConfig={siteConfig} language={language} />
         <div className="mainContainer">
           <Features />
+          {siteConfig.contactFormUrl && <SupportSection siteConfig={siteConfig} />}
         </div>
       </div>
     )

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -10,6 +10,7 @@
 
 const repoUrl = 'https://github.com/tulios/kafkajs'
 const slackUrl = 'https://kafkajs-slackin.herokuapp.com/'
+const contactFormUrl = process.env.CONTACT_FORM_URL
 
 const siteConfig = {
   title: 'KafkaJS',
@@ -78,6 +79,7 @@ const siteConfig = {
   repoUrl,
   slackUrl,
   siteConfigUrl: repoUrl + '/edit/master/website/siteConfig.js',
+  contactFormUrl,
 }
 
 module.exports = siteConfig

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -15,6 +15,8 @@
 @media only screen and (min-width: 1500px) {
 }
 
+textarea, input, button, select { font-family: inherit; font-size: inherit; }
+
 body .hljs {
   display: block;
   overflow-x: auto;
@@ -98,4 +100,66 @@ input#search_input_react {
 
 .headerTitleWithLogo {
   font-weight: normal;
+}
+
+.support .wrapper {
+  text-align: center;
+  max-width: 700px;
+}
+
+.contact-form button {
+  cursor: pointer;
+  margin-top: 1rem;
+  text-align: left;
+}
+
+.contact-form img {
+  width: 24px;
+  height: 24px;
+}
+
+.contact-form {
+  position: relative;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+}
+
+.contact-form label {
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}
+
+.contact-form input, .contact-form textarea {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 300;
+  color: #000;
+  background: transparent;
+  outline: none;
+  border: 0;
+  border-bottom: 1px solid #4d6894;
+  line-height: 35px;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.support small {
+  font-size: .75rem;
+}
+
+.mainContainer {
+  padding-bottom: 0;
+}
+
+input::placeholder, textarea::placeholder {
+  color: #a0a0a0;
 }


### PR DESCRIPTION
Since I've done a couple of hands-on debugging sessions together with some users, and there's no shortage of developers asking for support, I figured I'd give this a shot and see if people are willing to pay for dedicated support.

This updates the website to have a contact form to get in touch regarding commercial support. This is a plain old form that is set up to go to me. This is what it looks like:

![screenshot of KafkaJS website showing a commercial support section with a contact form](https://user-images.githubusercontent.com/83586/94831428-02068600-040d-11eb-8bdd-0da99a658079.png)

Additionally, it adds a small section to the readme that links to that same form.

---

The hardest part of this was figuring out how the hell you set secret environment variables in Azure Pipelines. That UI...