### PR TITLE
Make header value possibly undefined

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -96,7 +96,7 @@ export type PartitionMetadata = {
 }
 
 export interface IHeaders {
-  [key: string]: Buffer | string
+  [key: string]: Buffer | string | undefined
 }
 
 export interface ConsumerConfig {


### PR DESCRIPTION
Previously this would cause a runtime crash if accessing a header that doesn't exist.

Fixes #924.