### PR TITLE
Change sponsor anchor tag

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,2 +1,1 @@
 github: [Nevon, tulios]
-custom: ['https://github.com/tulios/kafkajs#sponsors']

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [Contributing](#contributing)
   - [Help Wanted](#help-wanted)
   - [Contact](#contact)
-- [Sponsors](#sponsors)
+- [Sponsors](#sponsorship)
 - [License](#license)
   - [Acknowledgements](#acknowledgements)
 
@@ -134,9 +134,9 @@ Here are some projects that we would like to build, but haven't yet been able to
 
 [Join our Slack community](https://kafkajs-slackin.herokuapp.com/)
 
-## <a name="sponsors"></a> Sponsors ❤️
+## <a name="sponsorship"></a> Sponsors ❤️
 
-*To become a sponsor, [reach out in our Slack community](https://kafkajs-slackin.herokuapp.com/) to get in touch with one of the maintainers. Also consider becoming a Github Sponsor by following any of the links under "Sponsor this project" in the sidebar.*
+*To become a sponsor, [reach out in our Slack community](https://kafkajs-slackin.herokuapp.com/) to get in touch with one of the maintainers. Also consider becoming a Github Sponsor by following any of the links under "[Sponsor this project](https://github.com/tulios/kafkajs#sponsors)" in the sidebar.*
 
 <a href="https://www.confluent.io/confluent-cloud/?utm_source=kafkajs&utm_medium=opensource&utm_campaign=referral">
   <img src="https://raw.githubusercontent.com/tulios/kafkajs/master/logo/confluent/logo.png" width="830px">


### PR DESCRIPTION
Github has a popup when you press the "Sponsor" button. Normally you can link directly to that popup by adding the "#sponsor" anchor to the repo link, but because we already use that anchor in our readme, it's broken, so I'm changing our anchor to "#sponsorship" instead.