### PR TITLE
Bump API versions for client-side throttling

### DIFF
--- a/src/broker/__tests__/addOffsetsToTxn.spec.js
+++ b/src/broker/__tests__/addOffsetsToTxn.spec.js
@@ -57,6 +57,7 @@ describe('Broker > AddOffsetsToTxn', () => {
     })
 
     expect(result).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       errorCode: 0,
     })

--- a/src/broker/__tests__/addPartitionsToTxn.spec.js
+++ b/src/broker/__tests__/addPartitionsToTxn.spec.js
@@ -69,6 +69,7 @@ describe('Broker > AddPartitionsToTxn', () => {
     })
 
     expect(result).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       errors: [
         {

--- a/src/broker/__tests__/alterConfigs.spec.js
+++ b/src/broker/__tests__/alterConfigs.spec.js
@@ -80,6 +80,7 @@ describe('Broker > alterConfigs', () => {
           resourceType: RESOURCE_TYPES.TOPIC,
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
     })
 

--- a/src/broker/__tests__/createAcls.spec.js
+++ b/src/broker/__tests__/createAcls.spec.js
@@ -48,7 +48,8 @@ describe('Broker > createAcls', () => {
     const response = await broker.createAcls({ acl: [acl] })
 
     expect(response).toEqual({
-      clientSideThrottleTime: 0,
+      clientSideThrottleTime: expect.optional(0),
+      throttleTime: 0,
       creationResponses: [{ errorCode: 0, errorMessage: null }],
     })
   })

--- a/src/broker/__tests__/createTopics.spec.js
+++ b/src/broker/__tests__/createTopics.spec.js
@@ -36,6 +36,7 @@ describe('Broker > createTopics', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       topicErrors: [
         {
@@ -61,6 +62,7 @@ describe('Broker > createTopics', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       topicErrors: [
         {

--- a/src/broker/__tests__/deleteAcls.spec.js
+++ b/src/broker/__tests__/deleteAcls.spec.js
@@ -61,7 +61,8 @@ describe('Broker > deleteAcls', () => {
     })
 
     expect(response).toEqual({
-      clientSideThrottleTime: 0,
+      clientSideThrottleTime: expect.optional(0),
+      throttleTime: 0,
       filterResponses: [
         {
           errorCode: 0,

--- a/src/broker/__tests__/deleteRecords.spec.js
+++ b/src/broker/__tests__/deleteRecords.spec.js
@@ -114,7 +114,7 @@ describe('Broker > deleteRecords', () => {
     const response = await broker.deleteRecords({ topics: recordsToDelete })
 
     expect(response).toEqual({
-      clientSideThrottleTime: 0,
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       topics: [
         {

--- a/src/broker/__tests__/deleteTopics.spec.js
+++ b/src/broker/__tests__/deleteTopics.spec.js
@@ -41,6 +41,7 @@ describe('Broker > deleteTopics', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       topicErrors: [
         { topic: topicName1, errorCode: 0 },

--- a/src/broker/__tests__/describeAcls.spec.js
+++ b/src/broker/__tests__/describeAcls.spec.js
@@ -57,7 +57,8 @@ describe('Broker > describeAcls', () => {
     })
 
     expect(response).toEqual({
-      clientSideThrottleTime: 0,
+      clientSideThrottleTime: expect.optional(0),
+      throttleTime: 0,
       errorCode: 0,
       errorMessage: null,
       resources: [

--- a/src/broker/__tests__/describeConfigs.spec.js
+++ b/src/broker/__tests__/describeConfigs.spec.js
@@ -81,6 +81,7 @@ describe('Broker > describeConfigs', () => {
           resourceType: RESOURCE_TYPES.TOPIC,
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
     })
   })
@@ -327,6 +328,7 @@ describe('Broker > describeConfigs', () => {
               resourceType: RESOURCE_TYPES.TOPIC,
             }),
           ],
+          clientSideThrottleTime: expect.optional(0),
           throttleTime: 0,
         })
       )

--- a/src/broker/__tests__/describeGroups.spec.js
+++ b/src/broker/__tests__/describeGroups.spec.js
@@ -55,6 +55,7 @@ describe('Broker > DescribeGroups', () => {
     const response = await broker.describeGroups({ groupIds: [groupId] })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       groups: [
         {

--- a/src/broker/__tests__/endTxn.spec.js
+++ b/src/broker/__tests__/endTxn.spec.js
@@ -76,6 +76,7 @@ describe('Broker > EndTxn', () => {
     })
 
     expect(result).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       errorCode: 0,
     })
@@ -92,6 +93,7 @@ describe('Broker > EndTxn', () => {
     })
 
     expect(result).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       errorCode: 0,
     })

--- a/src/broker/__tests__/fetch.spec.js
+++ b/src/broker/__tests__/fetch.spec.js
@@ -137,6 +137,7 @@ describe('Broker > Fetch', () => {
 
     let fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
     expect(fetchResponse).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       responses: [
         {
@@ -211,6 +212,7 @@ describe('Broker > Fetch', () => {
 
     let fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
     expect(fetchResponse).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       responses: [
         {
@@ -296,8 +298,8 @@ describe('Broker > Fetch', () => {
 
       let fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
       expect(fetchResponse).toEqual({
-        throttleTime: 0,
         clientSideThrottleTime: expect.optional(0),
+        throttleTime: 0,
         errorCode: 0,
         sessionId: 0,
         responses: [
@@ -380,8 +382,8 @@ describe('Broker > Fetch', () => {
 
       let fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
       expect(fetchResponse).toEqual({
-        throttleTime: 0,
         clientSideThrottleTime: expect.optional(0),
+        throttleTime: 0,
         errorCode: 0,
         sessionId: 0,
         responses: [
@@ -464,8 +466,8 @@ describe('Broker > Fetch', () => {
 
       let fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
       expect(fetchResponse).toEqual({
-        throttleTime: 0,
         clientSideThrottleTime: expect.optional(0),
+        throttleTime: 0,
         errorCode: 0,
         sessionId: 0,
         responses: [
@@ -587,8 +589,8 @@ describe('Broker > Fetch', () => {
 
         let fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
         expect(fetchResponse).toEqual({
-          throttleTime: 0,
           clientSideThrottleTime: expect.optional(0),
+          throttleTime: 0,
           errorCode: 0,
           sessionId: 0,
           responses: [
@@ -620,8 +622,8 @@ describe('Broker > Fetch', () => {
         await retry(async () => {
           fetchResponse = await broker.fetch({ maxWaitTime, minBytes, maxBytes, topics })
           expect(fetchResponse).toEqual({
-            throttleTime: 0,
             clientSideThrottleTime: expect.optional(0),
+            throttleTime: 0,
             errorCode: 0,
             sessionId: 0,
             responses: [
@@ -750,8 +752,8 @@ describe('Broker > Fetch', () => {
           isolationLevel: ISOLATION_LEVEL.READ_UNCOMMITTED,
         })
         expect(fetchResponse).toEqual({
-          throttleTime: 0,
           clientSideThrottleTime: expect.optional(0),
+          throttleTime: 0,
           errorCode: 0,
           sessionId: 0,
           responses: [
@@ -843,8 +845,8 @@ describe('Broker > Fetch', () => {
             isolationLevel: ISOLATION_LEVEL.READ_UNCOMMITTED,
           })
           expect(fetchResponse).toEqual({
-            throttleTime: 0,
             clientSideThrottleTime: expect.optional(0),
+            throttleTime: 0,
             errorCode: 0,
             sessionId: 0,
             responses: [

--- a/src/broker/__tests__/findGroupCoordinator.spec.js
+++ b/src/broker/__tests__/findGroupCoordinator.spec.js
@@ -26,6 +26,7 @@ describe('Broker > FindGroupCoordinator', () => {
     expect(response).toEqual({
       errorCode: 0,
       errorMessage: expect.toBeOneOf([null, 'NONE']),
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       coordinator: {
         nodeId: expect.any(Number),

--- a/src/broker/__tests__/heartbeat.spec.js
+++ b/src/broker/__tests__/heartbeat.spec.js
@@ -90,6 +90,10 @@ describe('Broker > Heartbeat', () => {
       memberId,
     })
 
-    expect(response).toEqual({ throttleTime: 0, clientSideThrottleTime: 0, errorCode: 0 })
+    expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
+      throttleTime: 0,
+      errorCode: 0,
+    })
   })
 })

--- a/src/broker/__tests__/initProducerId.spec.js
+++ b/src/broker/__tests__/initProducerId.spec.js
@@ -44,8 +44,9 @@ describe('Broker > InitProducerId', () => {
     })
 
     expect(response).toEqual({
-      errorCode: 0,
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
+      errorCode: 0,
       producerId: expect.stringMatching(/\d+/),
       producerEpoch: expect.any(Number),
     })
@@ -55,8 +56,9 @@ describe('Broker > InitProducerId', () => {
     const response = await broker.initProducerId({ transactionTimeout: 30000 })
 
     expect(response).toEqual({
-      errorCode: 0,
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
+      errorCode: 0,
       producerId: expect.stringMatching(/\d+/),
       producerEpoch: expect.any(Number),
     })

--- a/src/broker/__tests__/joinGroup.spec.js
+++ b/src/broker/__tests__/joinGroup.spec.js
@@ -47,8 +47,8 @@ describe('Broker > JoinGroup', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
       errorCode: 0,
       generationId: expect.any(Number),
       groupProtocol: 'AssignerName',

--- a/src/broker/__tests__/leaveGroup.spec.js
+++ b/src/broker/__tests__/leaveGroup.spec.js
@@ -62,8 +62,8 @@ describe('Broker > LeaveGroup', () => {
 
     const response = await groupCoordinator.leaveGroup({ groupId, memberId })
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
       errorCode: 0,
       members: [{ errorCode: 0, memberId, groupInstanceId: null }],
     })

--- a/src/broker/__tests__/listOffsets.spec.js
+++ b/src/broker/__tests__/listOffsets.spec.js
@@ -82,6 +82,7 @@ describe('Broker > ListOffsets', () => {
           ]),
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
     })
   })
@@ -127,6 +128,7 @@ describe('Broker > ListOffsets', () => {
           ]),
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
     })
 
@@ -152,6 +154,7 @@ describe('Broker > ListOffsets', () => {
           ]),
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
     })
   })

--- a/src/broker/__tests__/metadata.spec.js
+++ b/src/broker/__tests__/metadata.spec.js
@@ -41,6 +41,7 @@ describe('Broker > Metadata', () => {
     // setting separately.
     const rackValues = response.brokers.some(({ rack }) => Boolean(rack))
     expect(response).toMatchObject({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       brokers: expect.arrayContaining([
         {

--- a/src/broker/__tests__/offsetCommit.spec.js
+++ b/src/broker/__tests__/offsetCommit.spec.js
@@ -112,8 +112,8 @@ describe('Broker > OffsetCommit', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
       responses: [{ partitions: [{ errorCode: 0, partition: 0 }], topic: topicName }],
     })
   })
@@ -171,8 +171,8 @@ describe('Broker > OffsetCommit', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
       responses: [{ partitions: [{ errorCode: 0, partition: 0 }], topic: topicName }],
     })
   })

--- a/src/broker/__tests__/offsetFetch.spec.js
+++ b/src/broker/__tests__/offsetFetch.spec.js
@@ -109,6 +109,7 @@ describe('Broker > OffsetFetch', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       errorCode: 0,
       responses: [

--- a/src/broker/__tests__/produce.spec.js
+++ b/src/broker/__tests__/produce.spec.js
@@ -113,8 +113,8 @@ describe('Broker > Produce', () => {
           ],
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
     })
 
     const response2 = await broker2.produce({ topicData: createTopicData() })
@@ -133,8 +133,8 @@ describe('Broker > Produce', () => {
           ],
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
     })
   })
 
@@ -179,8 +179,8 @@ describe('Broker > Produce', () => {
           ],
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
     })
 
     const response2 = await broker2.produce({
@@ -203,8 +203,8 @@ describe('Broker > Produce', () => {
           ],
         },
       ],
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
     })
   })
 
@@ -246,8 +246,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
 
       const response2 = await broker2.produce({ topicData: createTopicData() })
@@ -266,8 +266,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
     })
 
@@ -338,8 +338,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
 
       // We have to syncronise the sequence number between the producer and the broker
@@ -407,8 +407,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
 
       const response2 = await broker2.produce({ topicData: createTopicData() })
@@ -427,8 +427,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
     })
 
@@ -473,8 +473,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
 
       const response2 = await broker2.produce({
@@ -497,8 +497,8 @@ describe('Broker > Produce', () => {
             ],
           },
         ],
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
-        clientSideThrottleTime: 0,
       })
     })
 
@@ -563,8 +563,8 @@ describe('Broker > Produce', () => {
               ],
             },
           ],
+          clientSideThrottleTime: expect.optional(0),
           throttleTime: 0,
-          clientSideThrottleTime: 0,
         })
       }
     )

--- a/src/broker/__tests__/syncGroup.spec.js
+++ b/src/broker/__tests__/syncGroup.spec.js
@@ -61,8 +61,8 @@ describe('Broker > SyncGroup', () => {
     })
 
     expect(response).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
-      clientSideThrottleTime: 0,
       errorCode: 0,
       memberAssignment,
     })

--- a/src/broker/__tests__/txnOffsetCommit.spec.js
+++ b/src/broker/__tests__/txnOffsetCommit.spec.js
@@ -102,6 +102,7 @@ describe('Broker > TxnOffsetCommit', () => {
 
     result.topics.forEach(topic => topic.partitions.sort((p1, p2) => p1.partition - p2.partition))
     expect(result).toEqual({
+      clientSideThrottleTime: expect.optional(0),
       throttleTime: 0,
       topics: [
         {

--- a/src/consumer/__tests__/handlerErrorRecovery.spec.js
+++ b/src/consumer/__tests__/handlerErrorRecovery.spec.js
@@ -106,6 +106,7 @@ describe('Consumer', () => {
       })
 
       expect(offsets).toEqual({
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
         errorCode: 0,
         responses: [
@@ -143,6 +144,7 @@ describe('Consumer', () => {
       })
 
       expect(offsets).toEqual({
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
         errorCode: 0,
         responses: [
@@ -229,6 +231,7 @@ describe('Consumer', () => {
       })
 
       expect(offsets).toEqual({
+        clientSideThrottleTime: expect.optional(0),
         throttleTime: 0,
         errorCode: 0,
         responses: [

--- a/src/protocol/requests/addOffsetsToTxn/index.js
+++ b/src/protocol/requests/addOffsetsToTxn/index.js
@@ -4,6 +4,11 @@ const versions = {
     const response = require('./v0/response')
     return { request: request({ transactionalId, producerId, producerEpoch, groupId }), response }
   },
+  1: ({ transactionalId, producerId, producerEpoch, groupId }) => {
+    const request = require('./v1/request')
+    const response = require('./v1/response')
+    return { request: request({ transactionalId, producerId, producerEpoch, groupId }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/addOffsetsToTxn/v1/request.js
+++ b/src/protocol/requests/addOffsetsToTxn/v1/request.js
@@ -1,0 +1,20 @@
+const requestV0 = require('../v0/request')
+
+/**
+ * AddOffsetsToTxn Request (Version: 1) => transactional_id producer_id producer_epoch group_id
+ *   transactional_id => STRING
+ *   producer_id => INT64
+ *   producer_epoch => INT16
+ *   group_id => STRING
+ */
+
+module.exports = ({ transactionalId, producerId, producerEpoch, groupId }) =>
+  Object.assign(
+    requestV0({
+      transactionalId,
+      producerId,
+      producerEpoch,
+      groupId,
+    }),
+    { apiVersion: 1 }
+  )

--- a/src/protocol/requests/addOffsetsToTxn/v1/request.spec.js
+++ b/src/protocol/requests/addOffsetsToTxn/v1/request.spec.js
@@ -1,0 +1,14 @@
+const RequestV1Protocol = require('./request')
+
+describe('Protocol > Requests > AddOffsetsToTxn > v1', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      transactionalId: 'test-transactional-id',
+      producerId: '1001',
+      producerEpoch: 0,
+      groupId: 'foobar',
+    }).encode()
+
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+  })
+})

--- a/src/protocol/requests/addOffsetsToTxn/v1/response.js
+++ b/src/protocol/requests/addOffsetsToTxn/v1/response.js
@@ -1,0 +1,24 @@
+const { parse, decode: decodeV0 } = require('../v0/response')
+
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * AddOffsetsToTxn Response (Version: 1) => throttle_time_ms error_code
+ *   throttle_time_ms => INT32
+ *   error_code => INT16
+ */
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/addOffsetsToTxn/v1/response.spec.js
+++ b/src/protocol/requests/addOffsetsToTxn/v1/response.spec.js
@@ -1,0 +1,21 @@
+const { decode, parse } = require('./response')
+const { unsupportedVersionResponseWithTimeout } = require('testHelpers')
+
+describe('Protocol > Requests > AddPartitionsToTxn > v1', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      errorCode: 0,
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponseWithTimeout())).rejects.toThrow(
+      /The version of API is not supported/
+    )
+  })
+})

--- a/src/protocol/requests/addPartitionsToTxn/index.js
+++ b/src/protocol/requests/addPartitionsToTxn/index.js
@@ -4,6 +4,11 @@ const versions = {
     const response = require('./v0/response')
     return { request: request({ transactionalId, producerId, producerEpoch, topics }), response }
   },
+  1: ({ transactionalId, producerId, producerEpoch, topics }) => {
+    const request = require('./v1/request')
+    const response = require('./v1/response')
+    return { request: request({ transactionalId, producerId, producerEpoch, topics }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/addPartitionsToTxn/v1/request.js
+++ b/src/protocol/requests/addPartitionsToTxn/v1/request.js
@@ -1,0 +1,22 @@
+const requestV0 = require('../v0/request')
+
+/**
+ * AddPartitionsToTxn Request (Version: 1) => transactional_id producer_id producer_epoch [topics]
+ *   transactional_id => STRING
+ *   producer_id => INT64
+ *   producer_epoch => INT16
+ *   topics => topic [partitions]
+ *     topic => STRING
+ *     partitions => INT32
+ */
+
+module.exports = ({ transactionalId, producerId, producerEpoch, topics }) =>
+  Object.assign(
+    requestV0({
+      transactionalId,
+      producerId,
+      producerEpoch,
+      topics,
+    }),
+    { apiVersion: 1 }
+  )

--- a/src/protocol/requests/addPartitionsToTxn/v1/request.spec.js
+++ b/src/protocol/requests/addPartitionsToTxn/v1/request.spec.js
@@ -1,0 +1,19 @@
+const RequestV1Protocol = require('./request')
+
+describe('Protocol > Requests > AddPartitionsToTxn > v1', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      transactionalId: 'test-transactional-id',
+      producerId: '1001',
+      producerEpoch: 0,
+      topics: [
+        {
+          topic: 'test-topic',
+          partitions: [0, 1, 2, 3],
+        },
+      ],
+    }).encode()
+
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+  })
+})

--- a/src/protocol/requests/addPartitionsToTxn/v1/response.js
+++ b/src/protocol/requests/addPartitionsToTxn/v1/response.js
@@ -1,0 +1,28 @@
+const { parse, decode: decodeV0 } = require('../v0/response')
+
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * AddPartitionsToTxn Response (Version: 1) => throttle_time_ms [errors]
+ *   throttle_time_ms => INT32
+ *   errors => topic [partition_errors]
+ *     topic => STRING
+ *     partition_errors => partition error_code
+ *       partition => INT32
+ *       error_code => INT16
+ */
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/addPartitionsToTxn/v1/response.spec.js
+++ b/src/protocol/requests/addPartitionsToTxn/v1/response.spec.js
@@ -1,0 +1,44 @@
+const { decode, parse } = require('./response')
+const { KafkaJSProtocolError } = require('../../../../errors')
+
+describe('Protocol > Requests > AddPartitionsToTxn > v1', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      errors: [
+        {
+          topic: 'test-topic-f6bab978bdca094688e3-37015-ca4f7ad4-5dcc-4bb9-9853-b1e4c4ed78a7',
+          partitionErrors: [
+            { errorCode: 0, partition: 1 },
+            { errorCode: 0, partition: 2 },
+          ],
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if there is an error on any of the partitions', async () => {
+    const data = {
+      throttleTime: 0,
+      errors: [
+        {
+          topic: 'test-topic',
+          partitionErrors: [
+            { errorCode: 0, partition: 1 },
+            { errorCode: 49, partition: 2 },
+          ],
+        },
+      ],
+    }
+
+    await expect(parse(data)).rejects.toEqual(
+      new KafkaJSProtocolError(
+        'The producer attempted to use a producer id which is not currently assigned to its transactional id'
+      )
+    )
+  })
+})

--- a/src/protocol/requests/alterConfigs/index.js
+++ b/src/protocol/requests/alterConfigs/index.js
@@ -4,6 +4,11 @@ const versions = {
     const response = require('./v0/response')
     return { request: request({ resources, validateOnly }), response }
   },
+  1: ({ resources, validateOnly }) => {
+    const request = require('./v1/request')
+    const response = require('./v1/response')
+    return { request: request({ resources, validateOnly }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/alterConfigs/v0/request.spec.js
+++ b/src/protocol/requests/alterConfigs/v0/request.spec.js
@@ -1,28 +1,18 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 const RESOURCE_TYPES = require('../../../resourceTypes')
 
 describe('Protocol > Requests > AlterConfigs > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.AlterConfigs)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('AlterConfigs')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol({
-        resources: [
-          {
-            type: RESOURCE_TYPES.TOPIC,
-            name: 'test-topic-d7fa92c03177d87573b1-38076-21364f66-8613-47e0-b273-bc9de397515e',
-            configEntries: [{ name: 'cleanup.policy', value: 'compact' }],
-          },
-        ],
-        validateOnly: false,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol({
+      resources: [
+        {
+          type: RESOURCE_TYPES.TOPIC,
+          name: 'test-topic-d7fa92c03177d87573b1-38076-21364f66-8613-47e0-b273-bc9de397515e',
+          configEntries: [{ name: 'cleanup.policy', value: 'compact' }],
+        },
+      ],
+      validateOnly: false,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/alterConfigs/v1/request.js
+++ b/src/protocol/requests/alterConfigs/v1/request.js
@@ -1,0 +1,25 @@
+const requestV0 = require('../v0/request')
+
+/**
+ * AlterConfigs Request (Version: 1) => [resources] validate_only
+ *   resources => resource_type resource_name [config_entries]
+ *     resource_type => INT8
+ *     resource_name => STRING
+ *     config_entries => config_name config_value
+ *       config_name => STRING
+ *       config_value => NULLABLE_STRING
+ *   validate_only => BOOLEAN
+ */
+
+/**
+ * @param {Array} resources An array of resources to change
+ * @param {boolean} [validateOnly=false]
+ */
+module.exports = ({ resources, validateOnly }) =>
+  Object.assign(
+    requestV0({
+      resources,
+      validateOnly,
+    }),
+    { apiVersion: 1 }
+  )

--- a/src/protocol/requests/alterConfigs/v1/request.spec.js
+++ b/src/protocol/requests/alterConfigs/v1/request.spec.js
@@ -1,0 +1,18 @@
+const RequestV1Protocol = require('./request')
+const RESOURCE_TYPES = require('../../../resourceTypes')
+
+describe('Protocol > Requests > AlterConfigs > v1', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      resources: [
+        {
+          type: RESOURCE_TYPES.TOPIC,
+          name: 'test-topic-d7fa92c03177d87573b1-38076-21364f66-8613-47e0-b273-bc9de397515e',
+          configEntries: [{ name: 'cleanup.policy', value: 'compact' }],
+        },
+      ],
+      validateOnly: false,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+  })
+})

--- a/src/protocol/requests/alterConfigs/v1/response.js
+++ b/src/protocol/requests/alterConfigs/v1/response.js
@@ -1,0 +1,29 @@
+const { parse, decode: decodeV0 } = require('../v0/response')
+
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * AlterConfigs Response (Version: 1) => throttle_time_ms [resources]
+ *   throttle_time_ms => INT32
+ *   resources => error_code error_message resource_type resource_name
+ *     error_code => INT16
+ *     error_message => NULLABLE_STRING
+ *     resource_type => INT8
+ *     resource_name => STRING
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/alterConfigs/v1/response.spec.js
+++ b/src/protocol/requests/alterConfigs/v1/response.spec.js
@@ -1,0 +1,23 @@
+const { decode, parse } = require('./response')
+const RESOURCE_TYPES = require('../../../resourceTypes')
+
+describe('Protocol > Requests > AlterConfigs > v1', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
+    expect(data).toEqual({
+      resources: [
+        {
+          errorCode: 0,
+          errorMessage: null,
+          resourceName:
+            'test-topic-d7fa92c03177d87573b1-38076-21364f66-8613-47e0-b273-bc9de397515e',
+          resourceType: RESOURCE_TYPES.TOPIC,
+        },
+      ],
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+})

--- a/src/protocol/requests/apiVersions/v0/request.spec.js
+++ b/src/protocol/requests/apiVersions/v0/request.spec.js
@@ -1,18 +1,8 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > ApiVersions > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol()
-      expect(request.apiKey).toEqual(apiKeys.ApiVersions)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('ApiVersions')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol().encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol().encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/apiVersions/v1/request.spec.js
+++ b/src/protocol/requests/apiVersions/v1/request.spec.js
@@ -1,18 +1,8 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > ApiVersions > v1', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol()
-      expect(request.apiKey).toEqual(apiKeys.ApiVersions)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('ApiVersions')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol().encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol().encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/apiVersions/v2/request.spec.js
+++ b/src/protocol/requests/apiVersions/v2/request.spec.js
@@ -1,18 +1,8 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > ApiVersions > v2', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol()
-      expect(request.apiKey).toEqual(apiKeys.ApiVersions)
-      expect(request.apiVersion).toEqual(2)
-      expect(request.apiName).toEqual('ApiVersions')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol().encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol().encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/apiVersions/v2/response.js
+++ b/src/protocol/requests/apiVersions/v2/response.js
@@ -1,6 +1,9 @@
-const { parse: parseV1, decode: decodeV1 } = require('../v1/response')
+const { parse, decode: decodeV1 } = require('../v1/response')
 
 /**
+ * Starting in version 2, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
  * ApiVersions Response (Version: 2) => error_code [api_versions] throttle_time_ms
  *   error_code => INT16
  *   api_versions => api_key min_version max_version
@@ -10,7 +13,17 @@ const { parse: parseV1, decode: decodeV1 } = require('../v1/response')
  *   throttle_time_ms => INT32
  */
 
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
 module.exports = {
-  parse: parseV1,
-  decode: decodeV1,
+  decode,
+  parse,
 }

--- a/src/protocol/requests/apiVersions/v2/response.spec.js
+++ b/src/protocol/requests/apiVersions/v2/response.spec.js
@@ -1,0 +1,105 @@
+const { unsupportedVersionResponse } = require('testHelpers')
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > ApiVersions > v2', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
+    expect(data).toEqual({
+      apiVersions: [
+        { apiKey: 0, maxVersion: 3, minVersion: 0 },
+        { apiKey: 1, maxVersion: 5, minVersion: 0 },
+        { apiKey: 2, maxVersion: 2, minVersion: 0 },
+        { apiKey: 3, maxVersion: 4, minVersion: 0 },
+        { apiKey: 4, maxVersion: 0, minVersion: 0 },
+        { apiKey: 5, maxVersion: 0, minVersion: 0 },
+        { apiKey: 6, maxVersion: 3, minVersion: 0 },
+        { apiKey: 7, maxVersion: 1, minVersion: 1 },
+        { apiKey: 8, maxVersion: 3, minVersion: 0 },
+        { apiKey: 9, maxVersion: 3, minVersion: 0 },
+        { apiKey: 10, maxVersion: 1, minVersion: 0 },
+        { apiKey: 11, maxVersion: 2, minVersion: 0 },
+        { apiKey: 12, maxVersion: 1, minVersion: 0 },
+        { apiKey: 13, maxVersion: 1, minVersion: 0 },
+        { apiKey: 14, maxVersion: 1, minVersion: 0 },
+        { apiKey: 15, maxVersion: 1, minVersion: 0 },
+        { apiKey: 16, maxVersion: 1, minVersion: 0 },
+        { apiKey: 17, maxVersion: 0, minVersion: 0 },
+        { apiKey: 18, maxVersion: 1, minVersion: 0 },
+        { apiKey: 19, maxVersion: 2, minVersion: 0 },
+        { apiKey: 20, maxVersion: 1, minVersion: 0 },
+        { apiKey: 21, maxVersion: 0, minVersion: 0 },
+        { apiKey: 22, maxVersion: 0, minVersion: 0 },
+        { apiKey: 23, maxVersion: 0, minVersion: 0 },
+        { apiKey: 24, maxVersion: 0, minVersion: 0 },
+        { apiKey: 25, maxVersion: 0, minVersion: 0 },
+        { apiKey: 26, maxVersion: 0, minVersion: 0 },
+        { apiKey: 27, maxVersion: 0, minVersion: 0 },
+        { apiKey: 28, maxVersion: 0, minVersion: 0 },
+        { apiKey: 29, maxVersion: 0, minVersion: 0 },
+        { apiKey: 30, maxVersion: 0, minVersion: 0 },
+        { apiKey: 31, maxVersion: 0, minVersion: 0 },
+        { apiKey: 32, maxVersion: 0, minVersion: 0 },
+        { apiKey: 33, maxVersion: 0, minVersion: 0 },
+      ],
+      errorCode: 0,
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  // https://github.com/tulios/kafkajs/issues/491
+  test('defaults throttle_time_ms if it is not provided in the response', async () => {
+    const data = await decode(
+      Buffer.from(require('../fixtures/v1_response_missing_throttle_time.json'))
+    )
+    expect(data).toEqual({
+      apiVersions: [
+        { apiKey: 0, maxVersion: 3, minVersion: 0 },
+        { apiKey: 1, maxVersion: 5, minVersion: 0 },
+        { apiKey: 2, maxVersion: 2, minVersion: 0 },
+        { apiKey: 3, maxVersion: 4, minVersion: 0 },
+        { apiKey: 4, maxVersion: 0, minVersion: 0 },
+        { apiKey: 5, maxVersion: 0, minVersion: 0 },
+        { apiKey: 6, maxVersion: 3, minVersion: 0 },
+        { apiKey: 7, maxVersion: 1, minVersion: 1 },
+        { apiKey: 8, maxVersion: 3, minVersion: 0 },
+        { apiKey: 9, maxVersion: 3, minVersion: 0 },
+        { apiKey: 10, maxVersion: 1, minVersion: 0 },
+        { apiKey: 11, maxVersion: 2, minVersion: 0 },
+        { apiKey: 12, maxVersion: 1, minVersion: 0 },
+        { apiKey: 13, maxVersion: 1, minVersion: 0 },
+        { apiKey: 14, maxVersion: 1, minVersion: 0 },
+        { apiKey: 15, maxVersion: 1, minVersion: 0 },
+        { apiKey: 16, maxVersion: 1, minVersion: 0 },
+        { apiKey: 17, maxVersion: 0, minVersion: 0 },
+        { apiKey: 18, maxVersion: 1, minVersion: 0 },
+        { apiKey: 19, maxVersion: 2, minVersion: 0 },
+        { apiKey: 20, maxVersion: 1, minVersion: 0 },
+        { apiKey: 21, maxVersion: 0, minVersion: 0 },
+        { apiKey: 22, maxVersion: 0, minVersion: 0 },
+        { apiKey: 23, maxVersion: 0, minVersion: 0 },
+        { apiKey: 24, maxVersion: 0, minVersion: 0 },
+        { apiKey: 25, maxVersion: 0, minVersion: 0 },
+        { apiKey: 26, maxVersion: 0, minVersion: 0 },
+        { apiKey: 27, maxVersion: 0, minVersion: 0 },
+        { apiKey: 28, maxVersion: 0, minVersion: 0 },
+        { apiKey: 29, maxVersion: 0, minVersion: 0 },
+        { apiKey: 30, maxVersion: 0, minVersion: 0 },
+        { apiKey: 31, maxVersion: 0, minVersion: 0 },
+        { apiKey: 32, maxVersion: 0, minVersion: 0 },
+        { apiKey: 33, maxVersion: 0, minVersion: 0 },
+      ],
+      errorCode: 0,
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+    })
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponse())).rejects.toThrow(
+      /The version of API is not supported/
+    )
+  })
+})

--- a/src/protocol/requests/createAcls/v0/request.spec.js
+++ b/src/protocol/requests/createAcls/v0/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > CreateAcls > v0', () => {
@@ -18,13 +17,6 @@ describe('Protocol > Requests > CreateAcls > v0', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV1Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.CreateAcls)
-    expect(request.apiVersion).toEqual(0)
-    expect(request.apiName).toEqual('CreateAcls')
   })
 
   test('request', async () => {

--- a/src/protocol/requests/createAcls/v1/request.spec.js
+++ b/src/protocol/requests/createAcls/v1/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > CreateAcls > v1', () => {
@@ -19,13 +18,6 @@ describe('Protocol > Requests > CreateAcls > v1', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV1Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.CreateAcls)
-    expect(request.apiVersion).toEqual(1)
-    expect(request.apiName).toEqual('CreateAcls')
   })
 
   test('request', async () => {

--- a/src/protocol/requests/createAcls/v1/response.js
+++ b/src/protocol/requests/createAcls/v1/response.js
@@ -1,7 +1,9 @@
-const Decoder = require('../../../decoder')
-const { parse: parseV0 } = require('../v0/response')
+const { parse, decode: decodeV0 } = require('../v0/response')
 
 /**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
  * CreateAcls Response (Version: 1) => throttle_time_ms [creation_responses]
  *   throttle_time_ms => INT32
  *   creation_responses => error_code error_message
@@ -9,23 +11,17 @@ const { parse: parseV0 } = require('../v0/response')
  *     error_message => NULLABLE_STRING
  */
 
-const decodeCreationResponse = decoder => ({
-  errorCode: decoder.readInt16(),
-  errorMessage: decoder.readString(),
-})
-
 const decode = async rawData => {
-  const decoder = new Decoder(rawData)
-  const throttleTime = decoder.readInt32()
-  const creationResponses = decoder.readArray(decodeCreationResponse)
+  const decoded = await decodeV0(rawData)
 
   return {
-    clientSideThrottleTime: throttleTime,
-    creationResponses,
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
   }
 }
 
 module.exports = {
   decode,
-  parse: parseV0,
+  parse,
 }

--- a/src/protocol/requests/createAcls/v1/response.spec.js
+++ b/src/protocol/requests/createAcls/v1/response.spec.js
@@ -5,6 +5,7 @@ describe('Protocol > Requests > CreateAcls > v1', () => {
     const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
     expect(data).toEqual({
       clientSideThrottleTime: 0,
+      throttleTime: 0,
       creationResponses: [{ errorCode: 0, errorMessage: null }],
     })
 

--- a/src/protocol/requests/createPartitions/v0/request.spec.js
+++ b/src/protocol/requests/createPartitions/v0/request.spec.js
@@ -1,31 +1,21 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > CreatePartitions > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.CreatePartitions)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('CreatePartitions')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol({
-        topicPartitions: [
-          {
-            topic: 'test-topic-c8d8ca3d95495c6b900d',
-            count: 3,
-          },
-          {
-            topic: 'test-topic-050fb2e6aed13a954288',
-            count: 5,
-            assignments: [[0], [1], [2]],
-          },
-        ],
-        timeout: 5000,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol({
+      topicPartitions: [
+        {
+          topic: 'test-topic-c8d8ca3d95495c6b900d',
+          count: 3,
+        },
+        {
+          topic: 'test-topic-050fb2e6aed13a954288',
+          count: 5,
+          assignments: [[0], [1], [2]],
+        },
+      ],
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/createPartitions/v1/request.spec.js
+++ b/src/protocol/requests/createPartitions/v1/request.spec.js
@@ -1,31 +1,21 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > CreatePartitions > v1', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV1Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.CreatePartitions)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('CreatePartitions')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV1Protocol({
-        topicPartitions: [
-          {
-            topic: 'test-topic-c8d8ca3d95495c6b900d',
-            count: 3,
-          },
-          {
-            topic: 'test-topic-050fb2e6aed13a954288',
-            count: 5,
-            assignments: [[0], [1], [2]],
-          },
-        ],
-        timeout: 5000,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      topicPartitions: [
+        {
+          topic: 'test-topic-c8d8ca3d95495c6b900d',
+          count: 3,
+        },
+        {
+          topic: 'test-topic-050fb2e6aed13a954288',
+          count: 5,
+          assignments: [[0], [1], [2]],
+        },
+      ],
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
   })
 })

--- a/src/protocol/requests/createPartitions/v1/response.js
+++ b/src/protocol/requests/createPartitions/v1/response.js
@@ -1,1 +1,28 @@
-module.exports = require('../v0/response')
+const { parse, decode: decodeV0 } = require('../v0/response')
+
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * CreatePartitions Response (Version: 0) => throttle_time_ms [topic_errors]
+ *   throttle_time_ms => INT32
+ *   topic_errors => topic error_code error_message
+ *     topic => STRING
+ *     error_code => INT16
+ *     error_message => NULLABLE_STRING
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/createPartitions/v1/response.spec.js
+++ b/src/protocol/requests/createPartitions/v1/response.spec.js
@@ -4,6 +4,7 @@ describe('Protocol > Requests > CreatePartitions > v1', () => {
   test('response', async () => {
     const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
     expect(data).toEqual({
+      clientSideThrottleTime: 0,
       throttleTime: 0,
       topicErrors: [
         {

--- a/src/protocol/requests/createTopics/index.js
+++ b/src/protocol/requests/createTopics/index.js
@@ -14,6 +14,11 @@ const versions = {
     const response = require('./v2/response')
     return { request: request({ topics, validateOnly, timeout }), response }
   },
+  3: ({ topics, validateOnly, timeout }) => {
+    const request = require('./v3/request')
+    const response = require('./v3/response')
+    return { request: request({ topics, validateOnly, timeout }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/createTopics/v0/request.spec.js
+++ b/src/protocol/requests/createTopics/v0/request.spec.js
@@ -1,24 +1,14 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > CreateTopics > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.CreateTopics)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('CreateTopics')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol({
-        topics: [
-          { topic: 'test-topic-c8d8ca3d95495c6b900d' },
-          { topic: 'test-topic-050fb2e6aed13a954288' },
-        ],
-        timeout: 5000,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol({
+      topics: [
+        { topic: 'test-topic-c8d8ca3d95495c6b900d' },
+        { topic: 'test-topic-050fb2e6aed13a954288' },
+      ],
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/createTopics/v1/request.spec.js
+++ b/src/protocol/requests/createTopics/v1/request.spec.js
@@ -1,25 +1,15 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > CreateTopics > v1', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV1Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.CreateTopics)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('CreateTopics')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV1Protocol({
-        topics: [
-          { topic: 'test-topic-c8d8ca3d95495c6b900d' },
-          { topic: 'test-topic-050fb2e6aed13a954288' },
-        ],
-        timeout: 5000,
-        validateOnly: true,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      topics: [
+        { topic: 'test-topic-c8d8ca3d95495c6b900d' },
+        { topic: 'test-topic-050fb2e6aed13a954288' },
+      ],
+      timeout: 5000,
+      validateOnly: true,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
   })
 })

--- a/src/protocol/requests/createTopics/v2/request.spec.js
+++ b/src/protocol/requests/createTopics/v2/request.spec.js
@@ -1,25 +1,15 @@
-const apiKeys = require('../../apiKeys')
 const RequestV2Protocol = require('./request')
 
 describe('Protocol > Requests > CreateTopics > v2', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV2Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.CreateTopics)
-      expect(request.apiVersion).toEqual(2)
-      expect(request.apiName).toEqual('CreateTopics')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV2Protocol({
-        topics: [
-          { topic: 'test-topic-fde67b5a797984ac0837-55492-1bf2f30a-cce8-403d-8897-6902a0b86fb0' },
-          { topic: 'test-topic-3d6c53af2e0f9b1d1757-55492-cbde2344-d9d3-4ad7-b408-996cda13e6e5' },
-        ],
-        validateOnly: false,
-        timeout: 5000,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v2_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV2Protocol({
+      topics: [
+        { topic: 'test-topic-fde67b5a797984ac0837-55492-1bf2f30a-cce8-403d-8897-6902a0b86fb0' },
+        { topic: 'test-topic-3d6c53af2e0f9b1d1757-55492-cbde2344-d9d3-4ad7-b408-996cda13e6e5' },
+      ],
+      validateOnly: false,
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v2_request.json')))
   })
 })

--- a/src/protocol/requests/createTopics/v3/request.js
+++ b/src/protocol/requests/createTopics/v3/request.js
@@ -1,0 +1,20 @@
+const requestV2 = require('../v2/request')
+
+/**
+ * CreateTopics Request (Version: 3) => [create_topic_requests] timeout validate_only
+ *   create_topic_requests => topic num_partitions replication_factor [replica_assignment] [config_entries]
+ *     topic => STRING
+ *     num_partitions => INT32
+ *     replication_factor => INT16
+ *     replica_assignment => partition [replicas]
+ *       partition => INT32
+ *       replicas => INT32
+ *     config_entries => config_name config_value
+ *       config_name => STRING
+ *       config_value => NULLABLE_STRING
+ *   timeout => INT32
+ *   validate_only => BOOLEAN
+ */
+
+module.exports = ({ topics, validateOnly, timeout }) =>
+  Object.assign(requestV2({ topics, validateOnly, timeout }), { apiVersion: 3 })

--- a/src/protocol/requests/createTopics/v3/request.spec.js
+++ b/src/protocol/requests/createTopics/v3/request.spec.js
@@ -1,0 +1,15 @@
+const RequestV3Protocol = require('./request')
+
+describe('Protocol > Requests > CreateTopics > v3', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV3Protocol({
+      topics: [
+        { topic: 'test-topic-fde67b5a797984ac0837-55492-1bf2f30a-cce8-403d-8897-6902a0b86fb0' },
+        { topic: 'test-topic-3d6c53af2e0f9b1d1757-55492-cbde2344-d9d3-4ad7-b408-996cda13e6e5' },
+      ],
+      validateOnly: false,
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v2_request.json')))
+  })
+})

--- a/src/protocol/requests/createTopics/v3/response.js
+++ b/src/protocol/requests/createTopics/v3/response.js
@@ -1,0 +1,28 @@
+const { parse, decode: decodeV2 } = require('../v2/response')
+
+/**
+ * Starting in version 3, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * CreateTopics Response (Version: 3) => throttle_time_ms [topic_errors]
+ *   throttle_time_ms => INT32
+ *   topic_errors => topic error_code error_message
+ *     topic => STRING
+ *     error_code => INT16
+ *     error_message => NULLABLE_STRING
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV2(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/createTopics/v3/response.spec.js
+++ b/src/protocol/requests/createTopics/v3/response.spec.js
@@ -1,0 +1,25 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > CreateTopics > v3', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v2_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      topicErrors: [
+        {
+          topic: 'test-topic-3d6c53af2e0f9b1d1757-55492-cbde2344-d9d3-4ad7-b408-996cda13e6e5',
+          errorCode: 0,
+          errorMessage: null,
+        },
+        {
+          errorCode: 0,
+          errorMessage: null,
+          topic: 'test-topic-fde67b5a797984ac0837-55492-1bf2f30a-cce8-403d-8897-6902a0b86fb0',
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+})

--- a/src/protocol/requests/deleteAcls/v0/request.spec.js
+++ b/src/protocol/requests/deleteAcls/v0/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > DeleteAcls > v0', () => {
@@ -19,13 +18,6 @@ describe('Protocol > Requests > DeleteAcls > v0', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV0Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.DeleteAcls)
-    expect(request.apiVersion).toEqual(0)
-    expect(request.apiName).toEqual('DeleteAcls')
   })
 
   test('request', async () => {

--- a/src/protocol/requests/deleteAcls/v1/request.spec.js
+++ b/src/protocol/requests/deleteAcls/v1/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > DeleteAcls > v1', () => {
@@ -19,13 +18,6 @@ describe('Protocol > Requests > DeleteAcls > v1', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV1Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.DeleteAcls)
-    expect(request.apiVersion).toEqual(1)
-    expect(request.apiName).toEqual('DeleteAcls')
   })
 
   test('request', async () => {

--- a/src/protocol/requests/deleteAcls/v1/response.js
+++ b/src/protocol/requests/deleteAcls/v1/response.js
@@ -2,6 +2,11 @@ const Decoder = require('../../../decoder')
 const { parse: parseV0 } = require('../v0/response')
 
 /**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ * Version 1 also introduces a new resource pattern type field.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-290%3A+Support+for+Prefixed+ACLs
+ *
  * DeleteAcls Response (Version: 1) => throttle_time_ms [filter_responses]
  *   throttle_time_ms => INT32
  *   filter_responses => error_code error_message [matching_acls]
@@ -43,6 +48,7 @@ const decode = async rawData => {
   const filterResponses = decoder.readArray(decodeFilterResponse)
 
   return {
+    throttleTime: 0,
     clientSideThrottleTime: throttleTime,
     filterResponses,
   }

--- a/src/protocol/requests/deleteAcls/v1/response.spec.js
+++ b/src/protocol/requests/deleteAcls/v1/response.spec.js
@@ -5,6 +5,7 @@ describe('Protocol > Requests > DeleteAcls > v1', () => {
     const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
     expect(data).toEqual({
       clientSideThrottleTime: 0,
+      throttleTime: 0,
       filterResponses: [
         {
           errorCode: 0,

--- a/src/protocol/requests/deleteGroups/v1/response.js
+++ b/src/protocol/requests/deleteGroups/v1/response.js
@@ -1,3 +1,27 @@
-const responseV0 = require('../v0/response')
+const { parse, decode: decodeV0 } = require('../v0/response')
 
-module.exports = responseV0
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * DeleteGroups Response (Version: 1) => throttle_time_ms [results]
+ *  throttle_time_ms => INT32
+ *  results => group_id error_code
+ *    group_id => STRING
+ *    error_code => INT16
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/deleteRecords/v0/request.spec.js
+++ b/src/protocol/requests/deleteRecords/v0/request.spec.js
@@ -1,31 +1,21 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > DeleteRecords > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.DeleteRecords)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('DeleteRecords')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol({
-        topics: [
-          {
-            topic: 'test-topic-42132ca1c79e5dd6c436-81884-14d3a181-013d-4176-8e7e-7518a67f4813',
-            partitions: [
-              {
-                partition: 0,
-                offset: '7',
-              },
-            ],
-          },
-        ],
-        timeout: 5000,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol({
+      topics: [
+        {
+          topic: 'test-topic-42132ca1c79e5dd6c436-81884-14d3a181-013d-4176-8e7e-7518a67f4813',
+          partitions: [
+            {
+              partition: 0,
+              offset: '7',
+            },
+          ],
+        },
+      ],
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/deleteRecords/v1/response.js
+++ b/src/protocol/requests/deleteRecords/v1/response.js
@@ -1,6 +1,9 @@
 const responseV0 = require('../v0/response')
 
 /**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
  * DeleteRecords Response (Version: 1) => throttle_time_ms [topics]
  *  throttle_time_ms => INT32
  *  topics => name [partitions]
@@ -9,9 +12,6 @@ const responseV0 = require('../v0/response')
  *      partition_index => INT32
  *      low_watermark => INT64
  *      error_code => INT16
- *
- * note: In version 1 on quota violation, brokers send out responses before throttling.
- * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
  */
 
 module.exports = ({ topics }) => {
@@ -22,6 +22,7 @@ module.exports = ({ topics }) => {
 
     return {
       ...decoded,
+      throttleTime: 0,
       clientSideThrottleTime: decoded.throttleTime,
     }
   }

--- a/src/protocol/requests/deleteTopics/v0/request.spec.js
+++ b/src/protocol/requests/deleteTopics/v0/request.spec.js
@@ -1,21 +1,11 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > DeleteTopics > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.DeleteTopics)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('DeleteTopics')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol({
-        topics: ['test-topic-5f80283ca8a1e46d2273', 'test-topic-34631544b8db1d1263b9'],
-        timeout: 5000,
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol({
+      topics: ['test-topic-5f80283ca8a1e46d2273', 'test-topic-34631544b8db1d1263b9'],
+      timeout: 5000,
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/deleteTopics/v1/request.spec.js
+++ b/src/protocol/requests/deleteTopics/v1/request.spec.js
@@ -1,25 +1,15 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > DeleteTopics > v1', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV1Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.DeleteTopics)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('DeleteTopics')
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      topics: [
+        'test-topic-386ea404396d663a8042-56298-e6e26331-de25-48d8-90b6-4710cd0b618b',
+        'test-topic-bb5d4c0c37ae53eb8b53-56298-ac202bf8-78e7-4d8b-ad07-4e01d8148db0',
+      ],
+      timeout: 5000,
+    }).encode()
 
-    test('encode', async () => {
-      const { buffer } = await RequestV1Protocol({
-        topics: [
-          'test-topic-386ea404396d663a8042-56298-e6e26331-de25-48d8-90b6-4710cd0b618b',
-          'test-topic-bb5d4c0c37ae53eb8b53-56298-ac202bf8-78e7-4d8b-ad07-4e01d8148db0',
-        ],
-        timeout: 5000,
-      }).encode()
-
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
-    })
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
   })
 })

--- a/src/protocol/requests/deleteTopics/v1/response.js
+++ b/src/protocol/requests/deleteTopics/v1/response.js
@@ -2,6 +2,9 @@ const Decoder = require('../../../decoder')
 const { parse: parseV0 } = require('../v0/response')
 
 /**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
  * DeleteTopics Response (Version: 1) => throttle_time_ms [topic_error_codes]
  *   throttle_time_ms => INT32
  *   topic_error_codes => topic error_code
@@ -18,8 +21,11 @@ const topicErrors = decoder => ({
 
 const decode = async rawData => {
   const decoder = new Decoder(rawData)
+  const throttleTime = decoder.readInt32()
+
   return {
-    throttleTime: decoder.readInt32(),
+    throttleTime: 0,
+    clientSideThrottleTime: throttleTime,
     topicErrors: decoder.readArray(topicErrors).sort(topicNameComparator),
   }
 }

--- a/src/protocol/requests/deleteTopics/v1/response.spec.js
+++ b/src/protocol/requests/deleteTopics/v1/response.spec.js
@@ -4,6 +4,7 @@ describe('Protocol > Requests > DeleteTopics > v1', () => {
   test('response', async () => {
     const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
     expect(data).toEqual({
+      clientSideThrottleTime: 0,
       throttleTime: 0,
       topicErrors: [
         {

--- a/src/protocol/requests/describeAcls/v0/request.spec.js
+++ b/src/protocol/requests/describeAcls/v0/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > DescribeAcls > v0', () => {
@@ -12,13 +11,6 @@ describe('Protocol > Requests > DescribeAcls > v0', () => {
       operation: 2,
       permissionType: 3,
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV0Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.DescribeAcls)
-    expect(request.apiVersion).toEqual(0)
-    expect(request.apiName).toEqual('DescribeAcls')
   })
 
   test('request', async () => {

--- a/src/protocol/requests/describeAcls/v1/request.spec.js
+++ b/src/protocol/requests/describeAcls/v1/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > DescribeAcls > v1', () => {
@@ -13,13 +12,6 @@ describe('Protocol > Requests > DescribeAcls > v1', () => {
       operation: 2,
       permissionType: 3,
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV1Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.DescribeAcls)
-    expect(request.apiVersion).toEqual(1)
-    expect(request.apiName).toEqual('DescribeAcls')
   })
 
   test('request', async () => {

--- a/src/protocol/requests/describeAcls/v1/response.js
+++ b/src/protocol/requests/describeAcls/v1/response.js
@@ -1,7 +1,12 @@
-const { parse: parseV0 } = require('../v0/response')
+const { parse } = require('../v0/response')
 const Decoder = require('../../../decoder')
 
 /**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ * Version 1 also introduces a new resource pattern type field.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-290%3A+Support+for+Prefixed+ACLs
+ *
  * DescribeAcls Response (Version: 1) => throttle_time_ms error_code error_message [resources]
  *   throttle_time_ms => INT32
  *   error_code => INT16
@@ -38,6 +43,7 @@ const decode = async rawData => {
   const resources = decoder.readArray(decodeResources)
 
   return {
+    throttleTime: 0,
     clientSideThrottleTime: throttleTime,
     errorCode,
     errorMessage,
@@ -47,5 +53,5 @@ const decode = async rawData => {
 
 module.exports = {
   decode,
-  parse: parseV0,
+  parse,
 }

--- a/src/protocol/requests/describeAcls/v1/response.spec.js
+++ b/src/protocol/requests/describeAcls/v1/response.spec.js
@@ -5,6 +5,7 @@ describe('Protocol > Requests > DescribeAcls > v1', () => {
     const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
     expect(data).toEqual({
       clientSideThrottleTime: 0,
+      throttleTime: 0,
       errorCode: 0,
       errorMessage: null,
       resources: [

--- a/src/protocol/requests/describeConfigs/index.js
+++ b/src/protocol/requests/describeConfigs/index.js
@@ -9,6 +9,11 @@ const versions = {
     const response = require('./v1/response')
     return { request: request({ resources, includeSynonyms }), response }
   },
+  2: ({ resources, includeSynonyms }) => {
+    const request = require('./v2/request')
+    const response = require('./v2/response')
+    return { request: request({ resources, includeSynonyms }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/describeConfigs/v0/request.spec.js
+++ b/src/protocol/requests/describeConfigs/v0/request.spec.js
@@ -1,27 +1,17 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 const RESOURCE_TYPES = require('../../../resourceTypes')
 
 describe('Protocol > Requests > DescribeConfigs > v0', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.DescribeConfigs)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('DescribeConfigs')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV0Protocol({
-        resources: [
-          {
-            type: RESOURCE_TYPES.TOPIC,
-            name: 'test-topic-332d38bc4eee2ff29df6',
-            configNames: ['compression.type', 'retention.ms'],
-          },
-        ],
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV0Protocol({
+      resources: [
+        {
+          type: RESOURCE_TYPES.TOPIC,
+          name: 'test-topic-332d38bc4eee2ff29df6',
+          configNames: ['compression.type', 'retention.ms'],
+        },
+      ],
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
   })
 })

--- a/src/protocol/requests/describeConfigs/v1/request.spec.js
+++ b/src/protocol/requests/describeConfigs/v1/request.spec.js
@@ -1,27 +1,17 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > DescribeConfigs > v1', () => {
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV1Protocol({})
-      expect(request.apiKey).toEqual(apiKeys.DescribeConfigs)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('DescribeConfigs')
-    })
-
-    test('encode', async () => {
-      const { buffer } = await RequestV1Protocol({
-        includeSynonyms: true,
-        resources: [
-          {
-            type: 2,
-            name: 'test-topic-e0cadb9e9f1a6396c116-54438-43bb8b69-32cf-4909-af02-cbe20c2d9e3d',
-            configNames: ['compression.type', 'retention.ms'],
-          },
-        ],
-      }).encode()
-      expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
-    })
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      includeSynonyms: true,
+      resources: [
+        {
+          type: 2,
+          name: 'test-topic-e0cadb9e9f1a6396c116-54438-43bb8b69-32cf-4909-af02-cbe20c2d9e3d',
+          configNames: ['compression.type', 'retention.ms'],
+        },
+      ],
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
   })
 })

--- a/src/protocol/requests/describeConfigs/v2/request.js
+++ b/src/protocol/requests/describeConfigs/v2/request.js
@@ -1,0 +1,17 @@
+const requestV1 = require('../v1/request')
+
+/**
+ * DescribeConfigs Request (Version: 1) => [resources] include_synonyms
+ *   resources => resource_type resource_name [config_names]
+ *     resource_type => INT8
+ *     resource_name => STRING
+ *     config_names => STRING
+ *   include_synonyms => BOOLEAN
+ */
+
+/**
+ * @param {Array} resources An array of config resources to be returned
+ * @param [includeSynonyms=false]
+ */
+module.exports = ({ resources, includeSynonyms }) =>
+  Object.assign(requestV1({ resources, includeSynonyms }), { apiVersion: 2 })

--- a/src/protocol/requests/describeConfigs/v2/request.spec.js
+++ b/src/protocol/requests/describeConfigs/v2/request.spec.js
@@ -1,0 +1,17 @@
+const RequestV2Protocol = require('./request')
+
+describe('Protocol > Requests > DescribeConfigs > v2', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV2Protocol({
+      includeSynonyms: true,
+      resources: [
+        {
+          type: 2,
+          name: 'test-topic-e0cadb9e9f1a6396c116-54438-43bb8b69-32cf-4909-af02-cbe20c2d9e3d',
+          configNames: ['compression.type', 'retention.ms'],
+        },
+      ],
+    }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
+  })
+})

--- a/src/protocol/requests/describeConfigs/v2/response.js
+++ b/src/protocol/requests/describeConfigs/v2/response.js
@@ -1,0 +1,39 @@
+const { parse, decode: decodeV1 } = require('../v1/response')
+
+/**
+ * Starting in version 2, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * DescribeConfigs Response (Version: 2) => throttle_time_ms [resources]
+ *   throttle_time_ms => INT32
+ *   resources => error_code error_message resource_type resource_name [config_entries]
+ *     error_code => INT16
+ *     error_message => NULLABLE_STRING
+ *     resource_type => INT8
+ *     resource_name => STRING
+ *     config_entries => config_name config_value read_only config_source is_sensitive [config_synonyms]
+ *       config_name => STRING
+ *       config_value => NULLABLE_STRING
+ *       read_only => BOOLEAN
+ *       config_source => INT8
+ *       is_sensitive => BOOLEAN
+ *       config_synonyms => config_name config_value config_source
+ *         config_name => STRING
+ *         config_value => NULLABLE_STRING
+ *         config_source => INT8
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/describeConfigs/v2/response.spec.js
+++ b/src/protocol/requests/describeConfigs/v2/response.spec.js
@@ -1,0 +1,46 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > DescribeConfigs > v2', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      resources: [
+        {
+          errorCode: 0,
+          errorMessage: null,
+          resourceType: 2,
+          resourceName:
+            'test-topic-e0cadb9e9f1a6396c116-54438-43bb8b69-32cf-4909-af02-cbe20c2d9e3d',
+          configEntries: [
+            {
+              configName: 'compression.type',
+              configValue: 'producer',
+              readOnly: false,
+              isDefault: false,
+              isSensitive: false,
+              configSynonyms: [
+                {
+                  configName: 'compression.type',
+                  configSource: 5,
+                  configValue: 'producer',
+                },
+              ],
+            },
+            {
+              configName: 'retention.ms',
+              configValue: '604800000',
+              readOnly: false,
+              isDefault: false,
+              isSensitive: false,
+              configSynonyms: [],
+            },
+          ],
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+})

--- a/src/protocol/requests/describeGroups/index.js
+++ b/src/protocol/requests/describeGroups/index.js
@@ -9,6 +9,11 @@ const versions = {
     const response = require('./v1/response')
     return { request: request({ groupIds }), response }
   },
+  2: ({ groupIds }) => {
+    const request = require('./v2/request')
+    const response = require('./v2/response')
+    return { request: request({ groupIds }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/describeGroups/v2/request.js
+++ b/src/protocol/requests/describeGroups/v2/request.js
@@ -1,0 +1,8 @@
+const requestV1 = require('../v1/request')
+
+/**
+ * DescribeGroups Request (Version: 2) => [group_ids]
+ *   group_ids => STRING
+ */
+
+module.exports = ({ groupIds }) => Object.assign(requestV1({ groupIds }), { apiVersion: 2 })

--- a/src/protocol/requests/describeGroups/v2/request.spec.js
+++ b/src/protocol/requests/describeGroups/v2/request.spec.js
@@ -1,0 +1,13 @@
+const RequestV2Protocol = require('./request')
+
+describe('Protocol > Requests > DescribeGroups > v2', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV2Protocol({
+      groupIds: [
+        'consumer-group-id-4de0aa10ef94403a397d-53384-d2fee969-1446-4166-bc8e-c88e8daffdfe',
+      ],
+    }).encode()
+
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
+  })
+})

--- a/src/protocol/requests/describeGroups/v2/response.js
+++ b/src/protocol/requests/describeGroups/v2/response.js
@@ -1,0 +1,36 @@
+const { parse, decode: decodeV1 } = require('../v1/response')
+
+/**
+ * Starting in version 2, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * DescribeGroups Response (Version: 2) => throttle_time_ms [groups]
+ *   throttle_time_ms => INT32
+ *   groups => error_code group_id state protocol_type protocol [members]
+ *     error_code => INT16
+ *     group_id => STRING
+ *     state => STRING
+ *     protocol_type => STRING
+ *     protocol => STRING
+ *     members => member_id client_id client_host member_metadata member_assignment
+ *       member_id => STRING
+ *       client_id => STRING
+ *       client_host => STRING
+ *       member_metadata => BYTES
+ *       member_assignment => BYTES
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/describeGroups/v2/response.spec.js
+++ b/src/protocol/requests/describeGroups/v2/response.spec.js
@@ -1,0 +1,33 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > DescribeGroups > v2', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      groups: [
+        {
+          errorCode: 0,
+          groupId:
+            'consumer-group-id-4de0aa10ef94403a397d-53384-d2fee969-1446-4166-bc8e-c88e8daffdfe',
+          state: 'Stable',
+          protocolType: 'consumer',
+          protocol: 'RoundRobinAssigner',
+          members: [
+            {
+              memberId:
+                'test-6ee008af511cbf89b897-53384-55bf525a-2ff5-49ef-8853-5fdf400a9c61-dbdee491-9f08-49d7-aa41-080b89bc69a8',
+              clientId: 'test-6ee008af511cbf89b897-53384-55bf525a-2ff5-49ef-8853-5fdf400a9c61',
+              clientHost: '/172.19.0.1',
+              memberMetadata: Buffer.from(require('../fixtures/v1_memberMetadata.json')),
+              memberAssignment: Buffer.from(require('../fixtures/v1_memberAssignment.json')),
+            },
+          ],
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+})

--- a/src/protocol/requests/endTxn/index.js
+++ b/src/protocol/requests/endTxn/index.js
@@ -7,6 +7,14 @@ const versions = {
       response,
     }
   },
+  1: ({ transactionalId, producerId, producerEpoch, transactionResult }) => {
+    const request = require('./v1/request')
+    const response = require('./v1/response')
+    return {
+      request: request({ transactionalId, producerId, producerEpoch, transactionResult }),
+      response,
+    }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/endTxn/v1/request.js
+++ b/src/protocol/requests/endTxn/v1/request.js
@@ -1,0 +1,14 @@
+const requestV0 = require('../v0/request')
+
+/**
+ * EndTxn Request (Version: 1) => transactional_id producer_id producer_epoch transaction_result
+ *   transactional_id => STRING
+ *   producer_id => INT64
+ *   producer_epoch => INT16
+ *   transaction_result => BOOLEAN
+ */
+
+module.exports = ({ transactionalId, producerId, producerEpoch, transactionResult }) =>
+  Object.assign(requestV0({ transactionalId, producerId, producerEpoch, transactionResult }), {
+    apiVersion: 1,
+  })

--- a/src/protocol/requests/endTxn/v1/request.spec.js
+++ b/src/protocol/requests/endTxn/v1/request.spec.js
@@ -1,0 +1,14 @@
+const RequestV1Protocol = require('./request')
+
+describe('Protocol > Requests > EndTxn > v1', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      transactionalId: 'test-transactional-id',
+      producerId: '1001',
+      producerEpoch: 0,
+      transactionResult: true,
+    }).encode()
+
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+  })
+})

--- a/src/protocol/requests/endTxn/v1/response.js
+++ b/src/protocol/requests/endTxn/v1/response.js
@@ -1,0 +1,25 @@
+const { parse, decode: decodeV0 } = require('../v0/response')
+
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * EndTxn Response (Version: 1) => throttle_time_ms error_code
+ *   throttle_time_ms => INT32
+ *   error_code => INT16
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/endTxn/v1/response.spec.js
+++ b/src/protocol/requests/endTxn/v1/response.spec.js
@@ -1,0 +1,21 @@
+const { decode, parse } = require('./response')
+const { unsupportedVersionResponseWithTimeout } = require('testHelpers')
+
+describe('Protocol > Requests > EndTxn > v1', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      errorCode: 0,
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponseWithTimeout())).rejects.toThrow(
+      /The version of API is not supported/
+    )
+  })
+})

--- a/src/protocol/requests/findCoordinator/index.js
+++ b/src/protocol/requests/findCoordinator/index.js
@@ -11,6 +11,11 @@ const versions = {
     const response = require('./v1/response')
     return { request: request({ coordinatorKey: groupId, coordinatorType }), response }
   },
+  2: ({ groupId, coordinatorType = COORDINATOR_TYPES.GROUP }) => {
+    const request = require('./v2/request')
+    const response = require('./v2/response')
+    return { request: request({ coordinatorKey: groupId, coordinatorType }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/findCoordinator/v2/request.js
+++ b/src/protocol/requests/findCoordinator/v2/request.js
@@ -1,0 +1,10 @@
+const requestV1 = require('../v1/request')
+
+/**
+ * FindCoordinator Request (Version: 2) => coordinator_key coordinator_type
+ *   coordinator_key => STRING
+ *   coordinator_type => INT8
+ */
+
+module.exports = ({ coordinatorKey, coordinatorType }) =>
+  Object.assign(requestV1({ coordinatorKey, coordinatorType }), { apiVersion: 2 })

--- a/src/protocol/requests/findCoordinator/v2/request.spec.js
+++ b/src/protocol/requests/findCoordinator/v2/request.spec.js
@@ -1,0 +1,11 @@
+const RequestV2Protocol = require('./request')
+
+describe('Protocol > Requests > FindCoordinator > v2', () => {
+  test('request', async () => {
+    const coordinatorKey = 'group-id'
+    const coordinatorType = 0
+
+    const { buffer } = await RequestV2Protocol({ coordinatorKey, coordinatorType }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v1_request.json')))
+  })
+})

--- a/src/protocol/requests/findCoordinator/v2/response.js
+++ b/src/protocol/requests/findCoordinator/v2/response.js
@@ -1,0 +1,30 @@
+const { parse, decode: decodeV1 } = require('../v1/response')
+
+/**
+ * Starting in version 2, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * FindCoordinator Response (Version: 1) => throttle_time_ms error_code error_message coordinator
+ *   throttle_time_ms => INT32
+ *   error_code => INT16
+ *   error_message => NULLABLE_STRING
+ *   coordinator => node_id host port
+ *     node_id => INT32
+ *     host => STRING
+ *     port => INT32
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/findCoordinator/v2/response.spec.js
+++ b/src/protocol/requests/findCoordinator/v2/response.spec.js
@@ -1,0 +1,22 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > FindCoordinator > v2', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v1_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      errorCode: 0,
+      errorMessage: null,
+      coordinator: { nodeId: 2, host: '192.168.50.211', port: 9098 },
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(
+      decode(Buffer.from(require('../fixtures/v1_response_version_error.json')))
+    ).rejects.toThrow(/The version of API is not supported/)
+  })
+})

--- a/src/protocol/requests/heartbeat/v2/response.js
+++ b/src/protocol/requests/heartbeat/v2/response.js
@@ -13,6 +13,7 @@ const decode = async rawData => {
 
   return {
     ...decoded,
+    throttleTime: 0,
     clientSideThrottleTime: decoded.throttleTime,
   }
 }

--- a/src/protocol/requests/index.spec.js
+++ b/src/protocol/requests/index.spec.js
@@ -1,52 +1,71 @@
 const { KafkaJSServerDoesNotSupportApiKey } = require('../../errors')
-const { lookup } = require('./index')
+const apiKeys = require('./apiKeys')
+const { lookup, requests } = require('./index')
 
-describe('Protocol > Requests > lookup', () => {
-  describe('when the client support more versions than the server', () => {
-    it('returns the maximum version supported by the server', async () => {
-      const apiKey = 1
-      const protocol = jest.fn(() => true)
+describe('Protocol > Requests', () => {
+  describe('requests', () => {
+    Object.entries(requests).forEach(([apiName, impls]) => {
+      if (!impls.versions) {
+        return
+      }
 
-      // versions supported by the server
-      const versions = { [apiKey]: { minVersion: 0, maxVersion: 1 } }
-
-      // versions supported by the client
-      const definition = { versions: [0, 1, 2], protocol }
-
-      expect(lookup(versions)(apiKey, definition)).toEqual(true)
-      expect(protocol).toHaveBeenCalledWith({ version: 1 })
+      impls.versions.forEach(version => {
+        test(`${apiName} > v${version} > metadata`, () => {
+          const { request } = impls.protocol({ version })({})
+          expect(request.apiKey).toEqual(apiKeys[apiName])
+          expect(request.apiVersion).toEqual(Number(version))
+          expect(request.apiName).toEqual(apiName)
+        })
+      })
     })
   })
+  describe('lookup', () => {
+    describe('when the client support more versions than the server', () => {
+      it('returns the maximum version supported by the server', async () => {
+        const apiKey = 1
+        const protocol = jest.fn(() => true)
 
-  describe('when the server support more versions than the client', () => {
-    it('returns the maximum version supported by the client', () => {
-      const apiKey = 1
-      const protocol = jest.fn(() => true)
+        // versions supported by the server
+        const versions = { [apiKey]: { minVersion: 0, maxVersion: 1 } }
 
-      // versions supported by the server
-      const versions = { [apiKey]: { minVersion: 1, maxVersion: 3 } }
+        // versions supported by the client
+        const definition = { versions: [0, 1, 2], protocol }
 
-      // versions supported by the client
-      const definition = { versions: [0, 1, 2], protocol }
-
-      expect(lookup(versions)(apiKey, definition)).toEqual(true)
-      expect(protocol).toHaveBeenCalledWith({ version: 2 })
+        expect(lookup(versions)(apiKey, definition)).toEqual(true)
+        expect(protocol).toHaveBeenCalledWith({ version: 1 })
+      })
     })
-  })
 
-  describe('when the server does not support the requested version', () => {
-    it('throws KafkaJSServerDoesNotSupportApiKey', () => {
-      // versions supported by the server
-      const versions = { 1: { minVersion: 1, maxVersion: 3 } }
+    describe('when the server support more versions than the client', () => {
+      it('returns the maximum version supported by the client', () => {
+        const apiKey = 1
+        const protocol = jest.fn(() => true)
 
-      // versions supported by the client
-      const protocol = jest.fn(() => true)
-      const definition = { versions: [0, 1, 2], protocol }
+        // versions supported by the server
+        const versions = { [apiKey]: { minVersion: 1, maxVersion: 3 } }
 
-      const apiKeyNotSupportedByTheServer = 34
-      expect(() => lookup(versions)(apiKeyNotSupportedByTheServer, definition)).toThrow(
-        KafkaJSServerDoesNotSupportApiKey
-      )
+        // versions supported by the client
+        const definition = { versions: [0, 1, 2], protocol }
+
+        expect(lookup(versions)(apiKey, definition)).toEqual(true)
+        expect(protocol).toHaveBeenCalledWith({ version: 2 })
+      })
+    })
+
+    describe('when the server does not support the requested version', () => {
+      it('throws KafkaJSServerDoesNotSupportApiKey', () => {
+        // versions supported by the server
+        const versions = { 1: { minVersion: 1, maxVersion: 3 } }
+
+        // versions supported by the client
+        const protocol = jest.fn(() => true)
+        const definition = { versions: [0, 1, 2], protocol }
+
+        const apiKeyNotSupportedByTheServer = 34
+        expect(() => lookup(versions)(apiKeyNotSupportedByTheServer, definition)).toThrow(
+          KafkaJSServerDoesNotSupportApiKey
+        )
+      })
     })
   })
 })

--- a/src/protocol/requests/initProducerId/index.js
+++ b/src/protocol/requests/initProducerId/index.js
@@ -4,6 +4,11 @@ const versions = {
     const response = require('./v0/response')
     return { request: request({ transactionalId, transactionTimeout }), response }
   },
+  1: ({ transactionalId, transactionTimeout = 5000 }) => {
+    const request = require('./v1/request')
+    const response = require('./v1/response')
+    return { request: request({ transactionalId, transactionTimeout }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/initProducerId/index.spec.js
+++ b/src/protocol/requests/initProducerId/index.spec.js
@@ -1,13 +1,17 @@
 const initProducerId = require('./index')
 const requestV0 = require('./v0/request')
+const requestV1 = require('./v1/request')
 
 jest.mock('./v0/request')
+jest.mock('./v1/request')
 
 describe('Protocol > Requests > InitProducerId', () => {
-  describe('version v0', () => {
-    test('provides a default timeout of 5000', async () => {
-      initProducerId.protocol({ version: 0 })({ transactionalId: 'foo' })
-      expect(requestV0).toHaveBeenCalledWith({ transactionalId: 'foo', transactionTimeout: 5000 })
+  ;[requestV0, requestV1].forEach((request, version) => {
+    describe(`version v${version}`, () => {
+      test('provides a default timeout of 5000', async () => {
+        initProducerId.protocol({ version })({ transactionalId: 'foo' })
+        expect(request).toHaveBeenCalledWith({ transactionalId: 'foo', transactionTimeout: 5000 })
+      })
     })
   })
 })

--- a/src/protocol/requests/initProducerId/v1/request.js
+++ b/src/protocol/requests/initProducerId/v1/request.js
@@ -1,0 +1,10 @@
+const requestV0 = require('../v0/request')
+
+/**
+ * InitProducerId Request (Version: 1) => transactional_id transaction_timeout_ms
+ *   transactional_id => NULLABLE_STRING
+ *   transaction_timeout_ms => INT32
+ */
+
+module.exports = ({ transactionalId, transactionTimeout }) =>
+  Object.assign(requestV0({ transactionalId, transactionTimeout }), { apiVersion: 1 })

--- a/src/protocol/requests/initProducerId/v1/request.spec.js
+++ b/src/protocol/requests/initProducerId/v1/request.spec.js
@@ -1,0 +1,11 @@
+const RequestV1Protocol = require('./request')
+
+describe('Protocol > Requests > InitProducerId > v1', () => {
+  test('request', async () => {
+    const transactionalId = 'initproduceridtransaction'
+    const transactionTimeout = 30000
+
+    const { buffer } = await RequestV1Protocol({ transactionalId, transactionTimeout }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+  })
+})

--- a/src/protocol/requests/initProducerId/v1/response.js
+++ b/src/protocol/requests/initProducerId/v1/response.js
@@ -1,0 +1,27 @@
+const { parse, decode: decodeV0 } = require('../v0/response')
+
+/**
+ * Starting in version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * InitProducerId Response (Version: 0) => throttle_time_ms error_code producer_id producer_epoch
+ *   throttle_time_ms => INT32
+ *   error_code => INT16
+ *   producer_id => INT64
+ *   producer_epoch => INT16
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV0(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/initProducerId/v1/response.spec.js
+++ b/src/protocol/requests/initProducerId/v1/response.spec.js
@@ -1,0 +1,23 @@
+const { decode, parse } = require('./response')
+const { unsupportedVersionResponseWithTimeout } = require('testHelpers')
+
+describe('Protocol > Requests > InitProducerId > v1', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      errorCode: 0,
+      producerId: '1006',
+      producerEpoch: 0,
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if the api is not supported', async () => {
+    await expect(decode(unsupportedVersionResponseWithTimeout())).rejects.toThrow(
+      /The version of API is not supported/
+    )
+  })
+})

--- a/src/protocol/requests/joinGroup/v3/response.js
+++ b/src/protocol/requests/joinGroup/v3/response.js
@@ -1,5 +1,4 @@
-const { parse: parseV0 } = require('../v0/response')
-const { decode: decodeV2 } = require('../v2/response')
+const { parse, decode: decodeV2 } = require('../v2/response')
 
 /**
  * Starting in version 3, on quota violation, brokers send out responses
@@ -22,11 +21,12 @@ const decode = async rawData => {
 
   return {
     ...decoded,
+    throttleTime: 0,
     clientSideThrottleTime: decoded.throttleTime,
   }
 }
 
 module.exports = {
   decode,
-  parse: parseV0,
+  parse,
 }

--- a/src/protocol/requests/joinGroup/v5/response.js
+++ b/src/protocol/requests/joinGroup/v5/response.js
@@ -46,7 +46,7 @@ const decode = async rawData => {
   failIfVersionNotSupported(errorCode)
 
   return {
-    throttleTime,
+    throttleTime: 0,
     clientSideThrottleTime: throttleTime,
     errorCode,
     generationId: decoder.readInt32(),

--- a/src/protocol/requests/leaveGroup/v2/response.js
+++ b/src/protocol/requests/leaveGroup/v2/response.js
@@ -13,6 +13,7 @@ const decode = async rawData => {
 
   return {
     ...decoded,
+    throttleTime: 0,
     clientSideThrottleTime: decoded.throttleTime,
   }
 }

--- a/src/protocol/requests/leaveGroup/v3/response.js
+++ b/src/protocol/requests/leaveGroup/v3/response.js
@@ -20,7 +20,7 @@ const decode = async rawData => {
 
   failIfVersionNotSupported(errorCode)
 
-  return { throttleTime, clientSideThrottleTime: throttleTime, errorCode, members }
+  return { throttleTime: 0, clientSideThrottleTime: throttleTime, errorCode, members }
 }
 
 const decodeMembers = decoder => ({

--- a/src/protocol/requests/listGroups/v2/response.js
+++ b/src/protocol/requests/listGroups/v2/response.js
@@ -1,6 +1,9 @@
-const responseV1 = require('../v1/response')
+const { parse, decode: decodeV1 } = require('../v1/response')
 
 /**
+ * In version 2 on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
  * ListGroups Response (Version: 2) => error_code [groups]
  *   throttle_time_ms => INT32
  *   error_code => INT16
@@ -8,5 +11,17 @@ const responseV1 = require('../v1/response')
  *     group_id => STRING
  *     protocol_type => STRING
  */
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
 
-module.exports = responseV1
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/listOffsets/index.js
+++ b/src/protocol/requests/listOffsets/index.js
@@ -19,6 +19,11 @@ const versions = {
     const response = require('./v2/response')
     return { request: request({ replicaId, isolationLevel, topics }), response }
   },
+  3: ({ replicaId = REPLICA_ID, isolationLevel = ISOLATION_LEVEL.READ_COMMITTED, topics }) => {
+    const request = require('./v3/request')
+    const response = require('./v3/response')
+    return { request: request({ replicaId, isolationLevel, topics }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/listOffsets/v3/request.js
+++ b/src/protocol/requests/listOffsets/v3/request.js
@@ -1,0 +1,14 @@
+const requestV2 = require('../v2/request')
+
+/**
+ * ListOffsets Request (Version: 3) => replica_id isolation_level [topics]
+ *   replica_id => INT32
+ *   isolation_level => INT8
+ *   topics => topic [partitions]
+ *     topic => STRING
+ *     partitions => partition timestamp
+ *       partition => INT32
+ *       timestamp => INT64
+ */
+module.exports = ({ replicaId, isolationLevel, topics }) =>
+  Object.assign(requestV2({ replicaId, isolationLevel, topics }), { apiVersion: 3 })

--- a/src/protocol/requests/listOffsets/v3/request.spec.js
+++ b/src/protocol/requests/listOffsets/v3/request.spec.js
@@ -1,0 +1,16 @@
+const RequestV3Protocol = require('./request')
+
+describe('Protocol > Requests > ListOffsets > v3', () => {
+  test('request', async () => {
+    const timestamp = 1509285569484
+    const topics = [
+      {
+        topic: 'test-topic-727705ce68c29fedddf4',
+        partitions: [{ partition: 0, timestamp }],
+      },
+    ]
+
+    const { buffer } = await RequestV3Protocol({ replicaId: -1, topics }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v2_request.json')))
+  })
+})

--- a/src/protocol/requests/listOffsets/v3/response.js
+++ b/src/protocol/requests/listOffsets/v3/response.js
@@ -1,0 +1,30 @@
+const { parse, decode: decodeV2 } = require('../v2/response')
+
+/**
+ * In version 3 on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * ListOffsets Response (Version: 3) => throttle_time_ms [responses]
+ *   throttle_time_ms => INT32
+ *   responses => topic [partition_responses]
+ *     topic => STRING
+ *     partition_responses => partition error_code timestamp offset
+ *       partition => INT32
+ *       error_code => INT16
+ *       timestamp => INT64
+ *       offset => INT64
+ */
+const decode = async rawData => {
+  const decoded = await decodeV2(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/listOffsets/v3/response.spec.js
+++ b/src/protocol/requests/listOffsets/v3/response.spec.js
@@ -1,0 +1,19 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > ListOffsets > v3', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v2_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      responses: [
+        {
+          topic: 'test-topic-84efe7aaafc3844b00c1-36211-2ee431b4-d40b-4df8-b2c8-fc9e33ab5c77',
+          partitions: [{ partition: 0, errorCode: 0, timestamp: '-1', offset: '1' }],
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+})

--- a/src/protocol/requests/metadata/index.js
+++ b/src/protocol/requests/metadata/index.js
@@ -29,6 +29,11 @@ const versions = {
     const response = require('./v5/response')
     return { request: request({ topics, allowAutoTopicCreation }), response }
   },
+  6: ({ topics, allowAutoTopicCreation }) => {
+    const request = require('./v6/request')
+    const response = require('./v6/response')
+    return { request: request({ topics, allowAutoTopicCreation }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/metadata/v0/request.spec.js
+++ b/src/protocol/requests/metadata/v0/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 
 describe('Protocol > Requests > Metadata > v0', () => {
@@ -9,19 +8,10 @@ describe('Protocol > Requests > Metadata > v0', () => {
     topics = ['test-topic-1', 'test-topic-2']
   })
 
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol({ topics })
-      expect(request.apiKey).toEqual(apiKeys.Metadata)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('Metadata')
-    })
-
-    test('encode', async () => {
-      const request = RequestProtocol({ topics })
-      const encoder = new Encoder().writeArray(topics)
-      const data = await request.encode()
-      expect(data.toJSON()).toEqual(encoder.toJSON())
-    })
+  test('request', async () => {
+    const request = RequestProtocol({ topics })
+    const encoder = new Encoder().writeArray(topics)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
   })
 })

--- a/src/protocol/requests/metadata/v1/request.spec.js
+++ b/src/protocol/requests/metadata/v1/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 
 describe('Protocol > Requests > Metadata > v1', () => {
@@ -9,19 +8,10 @@ describe('Protocol > Requests > Metadata > v1', () => {
     topics = ['test-topic-1', 'test-topic-2']
   })
 
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol({ topics })
-      expect(request.apiKey).toEqual(apiKeys.Metadata)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('Metadata')
-    })
-
-    test('encode', async () => {
-      const request = RequestProtocol({ topics })
-      const encoder = new Encoder().writeArray(topics)
-      const data = await request.encode()
-      expect(data.toJSON()).toEqual(encoder.toJSON())
-    })
+  test('request', async () => {
+    const request = RequestProtocol({ topics })
+    const encoder = new Encoder().writeArray(topics)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
   })
 })

--- a/src/protocol/requests/metadata/v2/request.spec.js
+++ b/src/protocol/requests/metadata/v2/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 
 describe('Protocol > Requests > Metadata > v2', () => {
@@ -9,19 +8,10 @@ describe('Protocol > Requests > Metadata > v2', () => {
     topics = ['test-topic-1', 'test-topic-2']
   })
 
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol({ topics })
-      expect(request.apiKey).toEqual(apiKeys.Metadata)
-      expect(request.apiVersion).toEqual(2)
-      expect(request.apiName).toEqual('Metadata')
-    })
-
-    test('encode', async () => {
-      const request = RequestProtocol({ topics })
-      const encoder = new Encoder().writeArray(topics)
-      const data = await request.encode()
-      expect(data.toJSON()).toEqual(encoder.toJSON())
-    })
+  test('request', async () => {
+    const request = RequestProtocol({ topics })
+    const encoder = new Encoder().writeArray(topics)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
   })
 })

--- a/src/protocol/requests/metadata/v3/request.spec.js
+++ b/src/protocol/requests/metadata/v3/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 
 describe('Protocol > Requests > Metadata > v3', () => {
@@ -9,19 +8,10 @@ describe('Protocol > Requests > Metadata > v3', () => {
     topics = ['test-topic-1', 'test-topic-2']
   })
 
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol({ topics })
-      expect(request.apiKey).toEqual(apiKeys.Metadata)
-      expect(request.apiVersion).toEqual(3)
-      expect(request.apiName).toEqual('Metadata')
-    })
-
-    test('encode', async () => {
-      const request = RequestProtocol({ topics })
-      const encoder = new Encoder().writeArray(topics)
-      const data = await request.encode()
-      expect(data.toJSON()).toEqual(encoder.toJSON())
-    })
+  test('request', async () => {
+    const request = RequestProtocol({ topics })
+    const encoder = new Encoder().writeArray(topics)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
   })
 })

--- a/src/protocol/requests/metadata/v4/request.spec.js
+++ b/src/protocol/requests/metadata/v4/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 
 describe('Protocol > Requests > Metadata > v4', () => {
@@ -9,19 +8,10 @@ describe('Protocol > Requests > Metadata > v4', () => {
     topics = ['test-topic-1', 'test-topic-2']
   })
 
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol({ topics })
-      expect(request.apiKey).toEqual(apiKeys.Metadata)
-      expect(request.apiVersion).toEqual(4)
-      expect(request.apiName).toEqual('Metadata')
-    })
-
-    test('encode', async () => {
-      const request = RequestProtocol({ topics, allowAutoTopicCreation: true })
-      const encoder = new Encoder().writeArray(topics).writeBoolean(true)
-      const data = await request.encode()
-      expect(data.toJSON()).toEqual(encoder.toJSON())
-    })
+  test('request', async () => {
+    const request = RequestProtocol({ topics, allowAutoTopicCreation: true })
+    const encoder = new Encoder().writeArray(topics).writeBoolean(true)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
   })
 })

--- a/src/protocol/requests/metadata/v5/request.spec.js
+++ b/src/protocol/requests/metadata/v5/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 
 describe('Protocol > Requests > Metadata > v5', () => {
@@ -9,19 +8,10 @@ describe('Protocol > Requests > Metadata > v5', () => {
     topics = ['test-topic-1', 'test-topic-2']
   })
 
-  describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol({ topics })
-      expect(request.apiKey).toEqual(apiKeys.Metadata)
-      expect(request.apiVersion).toEqual(5)
-      expect(request.apiName).toEqual('Metadata')
-    })
-
-    test('encode', async () => {
-      const request = RequestProtocol({ topics, allowAutoTopicCreation: true })
-      const encoder = new Encoder().writeArray(topics).writeBoolean(true)
-      const data = await request.encode()
-      expect(data.toJSON()).toEqual(encoder.toJSON())
-    })
+  test('request', async () => {
+    const request = RequestProtocol({ topics, allowAutoTopicCreation: true })
+    const encoder = new Encoder().writeArray(topics).writeBoolean(true)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
   })
 })

--- a/src/protocol/requests/metadata/v6/request.js
+++ b/src/protocol/requests/metadata/v6/request.js
@@ -1,0 +1,10 @@
+const requestV5 = require('../v5/request')
+
+/**
+ * Metadata Request (Version: 6) => [topics] allow_auto_topic_creation
+ *   topics => STRING
+ *   allow_auto_topic_creation => BOOLEAN
+ */
+
+module.exports = ({ topics, allowAutoTopicCreation = true }) =>
+  Object.assign(requestV5({ topics, allowAutoTopicCreation }), { apiVersion: 6 })

--- a/src/protocol/requests/metadata/v6/request.spec.js
+++ b/src/protocol/requests/metadata/v6/request.spec.js
@@ -1,0 +1,17 @@
+const Encoder = require('../../../encoder')
+const RequestProtocol = require('./request')
+
+describe('Protocol > Requests > Metadata > v6', () => {
+  let topics
+
+  beforeEach(() => {
+    topics = ['test-topic-1', 'test-topic-2']
+  })
+
+  test('request', async () => {
+    const request = RequestProtocol({ topics, allowAutoTopicCreation: true })
+    const encoder = new Encoder().writeArray(topics).writeBoolean(true)
+    const data = await request.encode()
+    expect(data.toJSON()).toEqual(encoder.toJSON())
+  })
+})

--- a/src/protocol/requests/metadata/v6/response.js
+++ b/src/protocol/requests/metadata/v6/response.js
@@ -1,0 +1,41 @@
+const { parse, decode: decodeV1 } = require('../v5/response')
+
+/**
+ * In version 6 on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * Metadata Response (Version: 6) => throttle_time_ms [brokers] cluster_id controller_id [topic_metadata]
+ *   throttle_time_ms => INT32
+ *   brokers => node_id host port rack
+ *     node_id => INT32
+ *     host => STRING
+ *     port => INT32
+ *     rack => NULLABLE_STRING
+ *   cluster_id => NULLABLE_STRING
+ *   controller_id => INT32
+ *   topic_metadata => error_code topic is_internal [partition_metadata]
+ *     error_code => INT16
+ *     topic => STRING
+ *     is_internal => BOOLEAN
+ *     partition_metadata => error_code partition leader [replicas] [isr] [offline_replicas]
+ *       error_code => INT16
+ *       partition => INT32
+ *       leader => INT32
+ *       replicas => INT32
+ *       isr => INT32
+ *       offline_replicas => INT32
+ */
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/metadata/v6/response.spec.js
+++ b/src/protocol/requests/metadata/v6/response.spec.js
@@ -1,0 +1,153 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > Metadata > v6', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v5_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      brokers: [
+        {
+          nodeId: 2,
+          host: '10.3.220.89',
+          port: 9098,
+          rack: null,
+        },
+        {
+          nodeId: 1,
+          host: '10.3.220.89',
+          port: 9095,
+          rack: null,
+        },
+        {
+          nodeId: 0,
+          host: '10.3.220.89',
+          port: 9092,
+          rack: null,
+        },
+      ],
+      clusterId: 'wyOEk0m7Tn-08oGZjtVgEg',
+      controllerId: 2,
+      topicMetadata: [
+        {
+          topicErrorCode: 0,
+          topic: 'test-topic-f5e17a86896ebfdeb429-80829-a37b6dde-1adc-4687-813d-52d75a0a0f78',
+          isInternal: false,
+          partitionMetadata: [
+            {
+              partitionErrorCode: 0,
+              partitionId: 0,
+              leader: 0,
+              replicas: [0],
+              isr: [0],
+              offlineReplicas: [],
+            },
+          ],
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('response with offline replicas', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v5_offline_replicas_response.json')))
+
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      brokers: [
+        {
+          nodeId: 1,
+          host: '10.3.223.121',
+          port: 9095,
+          rack: null,
+        },
+        {
+          nodeId: 0,
+          host: '10.3.223.121',
+          port: 9092,
+          rack: null,
+        },
+      ],
+      clusterId: 'tDr4DgFsS96sOEZu6e-N-Q',
+      controllerId: 1,
+      topicMetadata: [
+        {
+          topicErrorCode: 0,
+          topic: 'topic-test',
+          isInternal: false,
+          partitionMetadata: [
+            {
+              isr: [],
+              leader: -1,
+              offlineReplicas: [2],
+              partitionErrorCode: 5,
+              partitionId: 2,
+              replicas: [2],
+            },
+            {
+              isr: [],
+              leader: -1,
+              offlineReplicas: [2],
+              partitionErrorCode: 5,
+              partitionId: 5,
+              replicas: [2],
+            },
+            {
+              isr: [1],
+              leader: 1,
+              offlineReplicas: [],
+              partitionErrorCode: 0,
+              partitionId: 4,
+              replicas: [1],
+            },
+            {
+              isr: [1],
+              leader: 1,
+              offlineReplicas: [],
+              partitionErrorCode: 0,
+              partitionId: 1,
+              replicas: [1],
+            },
+            {
+              isr: [0],
+              leader: 0,
+              offlineReplicas: [],
+              partitionErrorCode: 0,
+              partitionId: 3,
+              replicas: [0],
+            },
+            {
+              isr: [0],
+              leader: 0,
+              offlineReplicas: [],
+              partitionErrorCode: 0,
+              partitionId: 0,
+              replicas: [0],
+            },
+          ],
+        },
+        {
+          isInternal: false,
+          partitionMetadata: [
+            {
+              isr: [],
+              leader: -1,
+              offlineReplicas: [2],
+              partitionErrorCode: 5,
+              partitionId: 0,
+              replicas: [2],
+            },
+          ],
+          topic: 'test-topic-tommy',
+          topicErrorCode: 0,
+        },
+      ],
+    })
+
+    await expect(parse(data)).rejects.toThrow(
+      'There is no leader for this topic-partition as we are in the middle of a leadership election'
+    )
+  })
+})

--- a/src/protocol/requests/offsetFetch/index.js
+++ b/src/protocol/requests/offsetFetch/index.js
@@ -14,6 +14,11 @@ const versions = {
     const response = require('./v3/response')
     return { request: request({ groupId, topics }), response }
   },
+  4: ({ groupId, topics }) => {
+    const request = require('./v4/request')
+    const response = require('./v4/response')
+    return { request: request({ groupId, topics }), response }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/offsetFetch/v4/request.js
+++ b/src/protocol/requests/offsetFetch/v4/request.js
@@ -1,0 +1,13 @@
+const requestV3 = require('../v3/request')
+
+/**
+ * OffsetFetch Request (Version: 4) => group_id [topics]
+ *   group_id => STRING
+ *   topics => topic [partitions]
+ *     topic => STRING
+ *     partitions => partition
+ *       partition => INT32
+ */
+
+module.exports = ({ groupId, topics }) =>
+  Object.assign(requestV3({ groupId, topics }), { apiVersion: 4 })

--- a/src/protocol/requests/offsetFetch/v4/request.spec.js
+++ b/src/protocol/requests/offsetFetch/v4/request.spec.js
@@ -1,0 +1,18 @@
+const RequestV4Protocol = require('./request')
+
+describe('Protocol > Requests > OffsetFetch > v4', () => {
+  test('request', async () => {
+    const groupId =
+      'consumer-group-id-d1492d7a3c14a838a28f-20117-ae82781b-863d-4f23-9377-d165ca585f31'
+
+    const topics = [
+      {
+        topic: 'test-topic-df48241c4bf2fca9d16b-20117-aff9b64c-69a2-4456-be7b-de5bcd78984e',
+        partitions: [{ partition: 0 }],
+      },
+    ]
+
+    const { buffer } = await RequestV4Protocol({ groupId, topics }).encode()
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v3_request.json')))
+  })
+})

--- a/src/protocol/requests/offsetFetch/v4/response.js
+++ b/src/protocol/requests/offsetFetch/v4/response.js
@@ -1,0 +1,32 @@
+const { parse, decode: decodeV3 } = require('../v3/response')
+
+/**
+ * Starting in version 4, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * OffsetFetch Response (Version: 4) => throttle_time_ms [responses] error_code
+ *   throttle_time_ms => INT32
+ *   responses => topic [partition_responses]
+ *     topic => STRING
+ *     partition_responses => partition offset metadata error_code
+ *       partition => INT32
+ *       offset => INT64
+ *       metadata => NULLABLE_STRING
+ *       error_code => INT16
+ *   error_code => INT16
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV3(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/offsetFetch/v4/response.spec.js
+++ b/src/protocol/requests/offsetFetch/v4/response.spec.js
@@ -1,0 +1,20 @@
+const { decode, parse } = require('./response')
+
+describe('Protocol > Requests > OffsetFetch > v4', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v3_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      responses: [
+        {
+          topic: 'test-topic-df48241c4bf2fca9d16b-20117-aff9b64c-69a2-4456-be7b-de5bcd78984e',
+          partitions: [{ partition: 0, offset: '-1', metadata: '', errorCode: 0 }],
+        },
+      ],
+      errorCode: 0,
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+})

--- a/src/protocol/requests/produce/index.spec.js
+++ b/src/protocol/requests/produce/index.spec.js
@@ -1,0 +1,12 @@
+const { versions, protocol } = require('./index')
+
+describe('Protocol > Requests > Produce', () => {
+  versions.forEach(version => {
+    describe(`v${version}`, () => {
+      test('metadata about the API', () => {
+        const { request } = protocol({ version })({})
+        expect(request.expectResponse()).toEqual(true)
+      })
+    })
+  })
+})

--- a/src/protocol/requests/produce/v0/request.spec.js
+++ b/src/protocol/requests/produce/v0/request.spec.js
@@ -1,5 +1,4 @@
 const Encoder = require('../../../encoder')
-const apiKeys = require('../../apiKeys')
 const RequestProtocol = require('./request')
 const MessageSet = require('../../../messageSet')
 
@@ -28,14 +27,6 @@ describe('Protocol > Requests > Produce > v0', () => {
   })
 
   describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestProtocol(args)
-      expect(request.apiKey).toEqual(apiKeys.Produce)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('Produce')
-      expect(request.expectResponse()).toEqual(true)
-    })
-
     describe('when acks=0', () => {
       test('expectResponse returns false', () => {
         const request = RequestProtocol({ ...args, acks: 0 })

--- a/src/protocol/requests/produce/v2/request.spec.js
+++ b/src/protocol/requests/produce/v2/request.spec.js
@@ -1,5 +1,4 @@
 const os = require('os')
-const apiKeys = require('../../apiKeys')
 const RequestV2Protocol = require('./request')
 const { Types } = require('../../../message/compression')
 
@@ -31,14 +30,6 @@ describe('Protocol > Requests > Produce > v2', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV2Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.Produce)
-    expect(request.apiVersion).toEqual(2)
-    expect(request.apiName).toEqual('Produce')
-    expect(request.expectResponse()).toEqual(true)
   })
 
   describe('when acks=0', () => {

--- a/src/protocol/requests/produce/v3/request.spec.js
+++ b/src/protocol/requests/produce/v3/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV3Protocol = require('./request')
 
 describe('Protocol > Requests > Produce > v3', () => {
@@ -30,14 +29,6 @@ describe('Protocol > Requests > Produce > v3', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV3Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.Produce)
-    expect(request.apiVersion).toEqual(3)
-    expect(request.apiName).toEqual('Produce')
-    expect(request.expectResponse()).toEqual(true)
   })
 
   describe('when acks=0', () => {

--- a/src/protocol/requests/produce/v4/request.spec.js
+++ b/src/protocol/requests/produce/v4/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV4Protocol = require('./request')
 
 describe('Protocol > Requests > Produce > v4', () => {
@@ -54,14 +53,6 @@ describe('Protocol > Requests > Produce > v4', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV4Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.Produce)
-    expect(request.apiVersion).toEqual(4)
-    expect(request.apiName).toEqual('Produce')
-    expect(request.expectResponse()).toEqual(true)
   })
 
   describe('when acks=0', () => {

--- a/src/protocol/requests/produce/v5/request.spec.js
+++ b/src/protocol/requests/produce/v5/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV5Protocol = require('./request')
 
 describe('Protocol > Requests > Produce > v5', () => {
@@ -51,14 +50,6 @@ describe('Protocol > Requests > Produce > v5', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV5Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.Produce)
-    expect(request.apiVersion).toEqual(5)
-    expect(request.apiName).toEqual('Produce')
-    expect(request.expectResponse()).toEqual(true)
   })
 
   describe('when acks=0', () => {

--- a/src/protocol/requests/produce/v6/request.spec.js
+++ b/src/protocol/requests/produce/v6/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV6Protocol = require('./request')
 
 describe('Protocol > Requests > Produce > v6', () => {
@@ -126,14 +125,6 @@ describe('Protocol > Requests > Produce > v6', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV6Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.Produce)
-    expect(request.apiVersion).toEqual(6)
-    expect(request.apiName).toEqual('Produce')
-    expect(request.expectResponse()).toEqual(true)
   })
 
   describe('when acks=0', () => {

--- a/src/protocol/requests/produce/v6/response.js
+++ b/src/protocol/requests/produce/v6/response.js
@@ -1,5 +1,4 @@
-const Decoder = require('../../../decoder')
-const { parse: parseV5 } = require('../v5/response')
+const { parse, decode: decodeV5 } = require('../v5/response')
 
 /**
  * The version number is bumped to indicate that on quota violation brokers send out responses before throttling.
@@ -17,35 +16,17 @@ const { parse: parseV5 } = require('../v5/response')
  *   throttle_time_ms => INT32
  */
 
-const partition = decoder => ({
-  partition: decoder.readInt32(),
-  errorCode: decoder.readInt16(),
-  baseOffset: decoder.readInt64().toString(),
-  logAppendTime: decoder.readInt64().toString(),
-  logStartOffset: decoder.readInt64().toString(),
-})
-
 const decode = async rawData => {
-  const decoder = new Decoder(rawData)
-  const topics = decoder.readArray(decoder => ({
-    topicName: decoder.readString(),
-    partitions: decoder.readArray(partition),
-  }))
-
-  const throttleTime = decoder.readInt32()
-
-  // Report a `throttleTime` of 0: The broker will not have throttled
-  // this request, but if the `clientSideThrottleTime` is >0 then it
-  // expects us to do that -- and it will ignore requests.
+  const decoded = await decodeV5(rawData)
 
   return {
-    topics,
+    ...decoded,
     throttleTime: 0,
-    clientSideThrottleTime: throttleTime,
+    clientSideThrottleTime: decoded.throttleTime,
   }
 }
 
 module.exports = {
   decode,
-  parse: parseV5,
+  parse,
 }

--- a/src/protocol/requests/produce/v7/request.spec.js
+++ b/src/protocol/requests/produce/v7/request.spec.js
@@ -1,4 +1,3 @@
-const apiKeys = require('../../apiKeys')
 const RequestV7Protocol = require('./request')
 
 describe('Protocol > Requests > Produce > v7', () => {
@@ -126,14 +125,6 @@ describe('Protocol > Requests > Produce > v7', () => {
         },
       ],
     }
-  })
-
-  test('metadata about the API', () => {
-    const request = RequestV7Protocol(args)
-    expect(request.apiKey).toEqual(apiKeys.Produce)
-    expect(request.apiVersion).toEqual(7)
-    expect(request.apiName).toEqual('Produce')
-    expect(request.expectResponse()).toEqual(true)
   })
 
   describe('when acks=0', () => {

--- a/src/protocol/requests/saslAuthenticate/v0/request.spec.js
+++ b/src/protocol/requests/saslAuthenticate/v0/request.spec.js
@@ -1,15 +1,7 @@
-const apiKeys = require('../../apiKeys')
 const RequestV0Protocol = require('./request')
 
 describe('Protocol > Requests > SaslAuthenticate > v0', () => {
   describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV0Protocol({ authBytes: Buffer.alloc(0) })
-      expect(request.apiKey).toEqual(apiKeys.SaslAuthenticate)
-      expect(request.apiVersion).toEqual(0)
-      expect(request.apiName).toEqual('SaslAuthenticate')
-    })
-
     describe('PLAIN', () => {
       test('encode', async () => {
         const { buffer } = await RequestV0Protocol({

--- a/src/protocol/requests/saslAuthenticate/v1/request.spec.js
+++ b/src/protocol/requests/saslAuthenticate/v1/request.spec.js
@@ -1,15 +1,7 @@
-const apiKeys = require('../../apiKeys')
 const RequestV1Protocol = require('./request')
 
 describe('Protocol > Requests > SaslAuthenticate > v1', () => {
   describe('request', () => {
-    test('metadata about the API', () => {
-      const request = RequestV1Protocol({ authBytes: Buffer.alloc(0) })
-      expect(request.apiKey).toEqual(apiKeys.SaslAuthenticate)
-      expect(request.apiVersion).toEqual(1)
-      expect(request.apiName).toEqual('SaslAuthenticate')
-    })
-
     describe('PLAIN', () => {
       test('encode', async () => {
         const { buffer } = await RequestV1Protocol({

--- a/src/protocol/requests/syncGroup/v2/response.js
+++ b/src/protocol/requests/syncGroup/v2/response.js
@@ -1,4 +1,4 @@
-const { decode: decodeV1, parse: parseV1 } = require('../v1/response')
+const { parse, decode: decodeV1 } = require('../v1/response')
 
 /**
  * In version 2, on quota violation, brokers send out responses before throttling.
@@ -9,16 +9,18 @@ const { decode: decodeV1, parse: parseV1 } = require('../v1/response')
  *   error_code => INT16
  *   member_assignment => BYTES
  */
+
 const decode = async rawData => {
   const decoded = await decodeV1(rawData)
 
   return {
     ...decoded,
+    throttleTime: 0,
     clientSideThrottleTime: decoded.throttleTime,
   }
 }
 
 module.exports = {
   decode,
-  parse: parseV1,
+  parse,
 }

--- a/src/protocol/requests/syncGroup/v3/response.spec.js
+++ b/src/protocol/requests/syncGroup/v3/response.spec.js
@@ -4,8 +4,8 @@ describe('Protocol > Requests > SyncGroup > v3', () => {
   test('response', async () => {
     const data = await decode(Buffer.from(require('../fixtures/v3_response.json')))
     expect(data).toEqual({
-      throttleTime: 0,
       clientSideThrottleTime: 0,
+      throttleTime: 0,
       errorCode: 0,
       memberAssignment: Buffer.from(require('../fixtures/v1_memberAssignment.json')),
     })

--- a/src/protocol/requests/txnOffsetCommit/index.js
+++ b/src/protocol/requests/txnOffsetCommit/index.js
@@ -7,6 +7,14 @@ const versions = {
       response,
     }
   },
+  1: ({ transactionalId, groupId, producerId, producerEpoch, topics }) => {
+    const request = require('./v1/request')
+    const response = require('./v1/response')
+    return {
+      request: request({ transactionalId, groupId, producerId, producerEpoch, topics }),
+      response,
+    }
+  },
 }
 
 module.exports = {

--- a/src/protocol/requests/txnOffsetCommit/v1/request.js
+++ b/src/protocol/requests/txnOffsetCommit/v1/request.js
@@ -1,0 +1,20 @@
+const requestV0 = require('../v0/request')
+
+/**
+ * TxnOffsetCommit Request (Version: 1) => transactional_id group_id producer_id producer_epoch [topics]
+ *   transactional_id => STRING
+ *   group_id => STRING
+ *   producer_id => INT64
+ *   producer_epoch => INT16
+ *   topics => topic [partitions]
+ *     topic => STRING
+ *     partitions => partition offset metadata
+ *       partition => INT32
+ *       offset => INT64
+ *       metadata => NULLABLE_STRING
+ */
+
+module.exports = ({ transactionalId, groupId, producerId, producerEpoch, topics }) =>
+  Object.assign(requestV0({ transactionalId, groupId, producerId, producerEpoch, topics }), {
+    apiVersion: 1,
+  })

--- a/src/protocol/requests/txnOffsetCommit/v1/request.spec.js
+++ b/src/protocol/requests/txnOffsetCommit/v1/request.spec.js
@@ -1,0 +1,23 @@
+const RequestV1Protocol = require('./request')
+
+describe('Protocol > Requests > TxnOffsetCommit > v1', () => {
+  test('request', async () => {
+    const { buffer } = await RequestV1Protocol({
+      transactionalId: 'test-transactional-id',
+      groupId: 'test-group-id',
+      producerId: 20000,
+      producerEpoch: 0,
+      topics: [
+        {
+          topic: 'test-topic',
+          partitions: [
+            { partition: 1, offset: 0 },
+            { partition: 2, offset: 0 },
+          ],
+        },
+      ],
+    }).encode()
+
+    expect(buffer).toEqual(Buffer.from(require('../fixtures/v0_request.json')))
+  })
+})

--- a/src/protocol/requests/txnOffsetCommit/v1/response.js
+++ b/src/protocol/requests/txnOffsetCommit/v1/response.js
@@ -1,0 +1,29 @@
+const { parse, decode: decodeV1 } = require('../v0/response')
+
+/**
+ * In version 1, on quota violation, brokers send out responses before throttling.
+ * @see https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication
+ *
+ * TxnOffsetCommit Response (Version: 1) => throttle_time_ms [topics]
+ *   throttle_time_ms => INT32
+ *   topics => topic [partitions]
+ *     topic => STRING
+ *     partitions => partition error_code
+ *       partition => INT32
+ *       error_code => INT16
+ */
+
+const decode = async rawData => {
+  const decoded = await decodeV1(rawData)
+
+  return {
+    ...decoded,
+    throttleTime: 0,
+    clientSideThrottleTime: decoded.throttleTime,
+  }
+}
+
+module.exports = {
+  decode,
+  parse,
+}

--- a/src/protocol/requests/txnOffsetCommit/v1/response.spec.js
+++ b/src/protocol/requests/txnOffsetCommit/v1/response.spec.js
@@ -1,0 +1,44 @@
+const { decode, parse } = require('./response')
+const { KafkaJSProtocolError } = require('../../../../errors')
+
+describe('Protocol > Requests > TxnOffsetCommit > v1', () => {
+  test('response', async () => {
+    const data = await decode(Buffer.from(require('../fixtures/v0_response.json')))
+    expect(data).toEqual({
+      clientSideThrottleTime: 0,
+      throttleTime: 0,
+      topics: [
+        {
+          topic: 'test-topic-0ba33173f7664d75c6b2-63632-a0dab079-1c9a-44ba-be25-ca3d50df5003',
+          partitions: [
+            { errorCode: 0, partition: 1 },
+            { errorCode: 0, partition: 2 },
+          ],
+        },
+      ],
+    })
+
+    await expect(parse(data)).resolves.toBeTruthy()
+  })
+
+  test('throws KafkaJSProtocolError if there is an error on any of the partitions', async () => {
+    const data = {
+      throttleTime: 0,
+      topics: [
+        {
+          topic: 'test-topic',
+          partitions: [
+            { errorCode: 0, partition: 1 },
+            { errorCode: 49, partition: 2 },
+          ],
+        },
+      ],
+    }
+
+    await expect(parse(data)).rejects.toEqual(
+      new KafkaJSProtocolError(
+        'The producer attempted to use a producer id which is not currently assigned to its transactional id'
+      )
+    )
+  })
+})


### PR DESCRIPTION
This is a fairly big, but rather mechanical piece of work: Review the existing requests and ensure that the bump for https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication is done (i.e. the throttleTime is reported as clientSideThrottleTime), and for all APIs used by KafkaJS that didn't support the client-side throttling yet add the needed API versions.

The first commit of the PR ensures that when adding the new APIs I didn't accidentally miss a bump somewhere, by moving the 'metadata about the API' test from the individual request.spec.js files into src/prototol/requests/index.spec.js, and making it generic over all requests defined.

