### PR TITLE
Update sasl options to support AWS specific fields

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,6 +49,10 @@ export interface SASLOptions {
   mechanism: SASLMechanism
   username?: string
   password?: string
+  authorizationIdentity?: string
+  accessKeyId?: string
+  secretAccessKey?: string
+  sessionToken?: string
   oauthBearerProvider?: () => Promise<OauthbearerProviderResponse>
 }
 


### PR DESCRIPTION
Adds optional fields to the `SASLOption` interface. #935 