### PR TITLE
Emit GROUP_JOIN event on stale partition assignments

### DIFF
--- a/src/consumer/__tests__/runner.spec.js
+++ b/src/consumer/__tests__/runner.spec.js
@@ -263,11 +263,12 @@ describe('Consumer > Runner', () => {
     })
 
     it('should throw when group is rebalancing, while triggering another join', async () => {
+      const error = rebalancingError()
       consumerGroup.commitOffsets.mockImplementationOnce(() => {
-        throw rebalancingError()
+        throw error
       })
 
-      expect(runner.commitOffsets(offsets)).rejects.toThrow('The group is rebalancing')
+      expect(runner.commitOffsets(offsets)).rejects.toThrow(error.message)
       expect(consumerGroup.joinAndSync).toHaveBeenCalledTimes(0)
 
       await sleep(100)
@@ -342,7 +343,7 @@ describe('Consumer > Runner', () => {
         throw rebalancingError()
       })
 
-      expect(runner.commitOffsets(offsets)).rejects.toThrow('The group is rebalancing')
+      expect(runner.commitOffsets(offsets)).rejects.toThrow(rebalancingError().message)
 
       await sleep(100)
 

--- a/src/consumer/__tests__/runner.spec.js
+++ b/src/consumer/__tests__/runner.spec.js
@@ -30,6 +30,7 @@ describe('Consumer > Runner', () => {
       connect: jest.fn(),
       join: jest.fn(),
       sync: jest.fn(),
+      joinAndSync: jest.fn(),
       fetch: jest.fn(() => BufferedAsyncIterator([Promise.resolve([emptyBatch])])),
       resolveOffset: jest.fn(),
       commitOffsets: jest.fn(),
@@ -209,7 +210,7 @@ describe('Consumer > Runner', () => {
 
   it('calls onCrash for any other errors', async () => {
     const unknownError = new KafkaJSProtocolError(createErrorFromCode(UNKNOWN))
-    consumerGroup.join
+    consumerGroup.joinAndSync
       .mockImplementationOnce(() => {
         throw unknownError
       })
@@ -248,7 +249,7 @@ describe('Consumer > Runner', () => {
       offsets = { topics: [{ topic: topicName, partitions: [{ offset: '1', partition }] }] }
       await runner.start()
 
-      consumerGroup.join.mockClear()
+      consumerGroup.joinAndSync.mockClear()
       consumerGroup.commitOffsetsIfNecessary.mockClear()
       consumerGroup.commitOffsets.mockClear()
     })
@@ -267,11 +268,11 @@ describe('Consumer > Runner', () => {
       })
 
       expect(runner.commitOffsets(offsets)).rejects.toThrow('The group is rebalancing')
-      expect(consumerGroup.join).toHaveBeenCalledTimes(0)
+      expect(consumerGroup.joinAndSync).toHaveBeenCalledTimes(0)
 
       await sleep(100)
 
-      expect(consumerGroup.join).toHaveBeenCalledTimes(1)
+      expect(consumerGroup.joinAndSync).toHaveBeenCalledTimes(1)
     })
 
     it('correctly catch exceptions in parallel "eachBatch" processing', async () => {
@@ -334,7 +335,7 @@ describe('Consumer > Runner', () => {
 
     it('a triggered rejoin failing should cause a crash', async () => {
       const unknownError = new KafkaJSProtocolError(createErrorFromCode(UNKNOWN))
-      consumerGroup.join.mockImplementationOnce(() => {
+      consumerGroup.joinAndSync.mockImplementationOnce(() => {
         throw unknownError
       })
       consumerGroup.commitOffsets.mockImplementationOnce(() => {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -309,11 +309,11 @@ module.exports = class ConsumerGroup {
         this.logger.info('Consumer has joined the group', payload)
       } catch (e) {
         if (isRebalancing(e)) {
-          // Rebalance in progress isn't a retriable error since the consumer
+          // Rebalance in progress isn't a retriable protocol error since the consumer
           // has to go through find coordinator and join again before it can
-          // actually retry. Throwing a retriable error to allow the retrier
-          // to keep going
-          throw new KafkaJSError('The group is rebalancing')
+          // actually retry the operation. We wrap the original error in a retriable error
+          // here instead in order to restart the join + sync sequence using the retrier.
+          throw new KafkaJSError(e)
         }
 
         bail(e)

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -3,13 +3,14 @@ const sleep = require('../utils/sleep')
 const BufferedAsyncIterator = require('../utils/bufferedAsyncIterator')
 const websiteUrl = require('../utils/websiteUrl')
 const arrayDiff = require('../utils/arrayDiff')
+const createRetry = require('../retry')
 
 const OffsetManager = require('./offsetManager')
 const Batch = require('./batch')
 const SeekOffsets = require('./seekOffsets')
 const SubscriptionState = require('./subscriptionState')
 const {
-  events: { HEARTBEAT, CONNECT, RECEIVED_UNSUBSCRIBED_TOPICS },
+  events: { GROUP_JOIN, HEARTBEAT, CONNECT, RECEIVED_UNSUBSCRIBED_TOPICS },
 } = require('./instrumentationEvents')
 const { MemberAssignment } = require('./assignerProtocol')
 const {
@@ -30,8 +31,12 @@ const STALE_METADATA_ERRORS = [
   'UNKNOWN_TOPIC_OR_PARTITION',
 ]
 
+const isRebalancing = e =>
+  e.type === 'REBALANCE_IN_PROGRESS' || e.type === 'NOT_COORDINATOR_FOR_GROUP'
+
 module.exports = class ConsumerGroup {
   constructor({
+    retry,
     cluster,
     groupId,
     topics,
@@ -59,6 +64,7 @@ module.exports = class ConsumerGroup {
     this.topicConfigurations = topicConfigurations
     this.logger = logger.namespace('ConsumerGroup')
     this.instrumentationEmitter = instrumentationEmitter
+    this.retrier = createRetry(Object.assign({}, retry))
     this.assigners = assigners
     this.sessionTimeout = sessionTimeout
     this.rebalanceTimeout = rebalanceTimeout
@@ -269,6 +275,44 @@ module.exports = class ConsumerGroup {
       groupId,
       generationId,
       memberId,
+    })
+  }
+
+  joinAndSync() {
+    const startJoin = Date.now()
+    return this.retrier(async bail => {
+      try {
+        await this.join()
+        await this.sync()
+
+        const memberAssignment = this.assigned().reduce(
+          (result, { topic, partitions }) => ({ ...result, [topic]: partitions }),
+          {}
+        )
+
+        const payload = {
+          groupId: this.groupId,
+          memberId: this.memberId,
+          leaderId: this.leaderId,
+          isLeader: this.isLeader(),
+          memberAssignment,
+          groupProtocol: this.groupProtocol,
+          duration: Date.now() - startJoin,
+        }
+
+        this.instrumentationEmitter.emit(GROUP_JOIN, payload)
+        this.logger.info('Consumer has joined the group', payload)
+      } catch (e) {
+        if (isRebalancing(e)) {
+          // Rebalance in progress isn't a retriable error since the consumer
+          // has to go through find coordinator and join again before it can
+          // actually retry. Throwing a retriable error to allow the retrier
+          // to keep going
+          throw new KafkaJSError('The group is rebalancing')
+        }
+
+        bail(e)
+      }
     })
   }
 
@@ -528,8 +572,7 @@ module.exports = class ConsumerGroup {
       })
 
       await this.cluster.refreshMetadata()
-      await this.join()
-      await this.sync()
+      await this.joinAndSync()
       throw new KafkaJSError(e.message)
     }
 
@@ -541,8 +584,7 @@ module.exports = class ConsumerGroup {
         unknownPartitions: e.unknownPartitions,
       })
 
-      await this.join()
-      await this.sync()
+      await this.joinAndSync()
     }
 
     if (e.name === 'KafkaJSOffsetOutOfRange') {

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -87,6 +87,7 @@ module.exports = ({
       logger: rootLogger,
       topics: keys(topics),
       topicConfigurations: topics,
+      retry,
       cluster,
       groupId,
       assigners,

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -497,7 +497,7 @@ module.exports = class Runner extends EventEmitter {
 
           setImmediate(() => this.scheduleJoin())
 
-          bail(new KafkaJSError('The group is rebalancing'))
+          bail(new KafkaJSError(e))
         }
 
         if (e.type === 'UNKNOWN_MEMBER_ID') {
@@ -512,7 +512,7 @@ module.exports = class Runner extends EventEmitter {
           this.consumerGroup.memberId = null
           setImmediate(() => this.scheduleJoin())
 
-          bail(new KafkaJSError('The group is rebalancing'))
+          bail(new KafkaJSError(e))
         }
 
         if (e.name === 'KafkaJSNotImplemented') {


### PR DESCRIPTION
Doing this, it occurs to me that `GROUP_JOIN` is not exactly the right name for this event. It's more like `REBALANCED` or `GROUP_STABLE` or something, as it implies that the consumer has not only joined the group but also gone through the synchronization barrier.

Regardless, the join + sync is moved into the consumer group instead of living in the runner, and the `join` and `sync` methods become private so that we don't have the same issue again somewhere else.

Fixes #923