### PR TITLE
Add UNKNOWN_TOPIC_OR_PARTITION check for addMultipleTargetTopics

### DIFF
--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -190,7 +190,7 @@ module.exports = class Cluster {
         try {
           await this.refreshMetadata()
         } catch (e) {
-          if (e.type === 'INVALID_TOPIC_EXCEPTION') {
+          if (e.type === 'INVALID_TOPIC_EXCEPTION' || e.type === 'UNKNOWN_TOPIC_OR_PARTITION') {
             this.targetTopics = previousTopics
           }
 


### PR DESCRIPTION
addMultipleTargetTopics cluster method fails to restore 'targetTopics' property
when kafka has `KAFKA_AUTO_CREATE_TOPICS_ENABLE  `set to false. 
This pull request aims to fix this by restoring `targetTopics` to its original state
when an `UNKNOWN_TOPIC_OR_PARTITION` error is thrown after trying 
to push messages to kafka using a topic
that does not exist and will not be automatically created after refreshing metadata. 

Just to give more context, consider a kafka cluster where all nodes have auto create topic set to false. The driver goes to a faulty state after doing the following steps:

1. Publish a message to an existing topic, it returns success;
2. Try to send a message to an inexistent topic returns failure;
3. Try to send a message to an **existing** topic again. It fails because the driver kept the invalid one from previous request and it cannot recover, even after refreshing metadata.

The only way to make it work again is restarting the connection which is not ideal.

