### PR TITLE
Add a missing '}' in a JSDoc @type annotation

### DIFF
--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -98,7 +98,7 @@ module.exports = class ConsumerGroup {
      * Each of the partitions tracks the preferred read replica (`nodeId`) and a timestamp
      * until when that preference is valid.
      *
-     * @type {{[topicName: string]: {[partition: number]: {nodeId: number, expireAt: number}}}
+     * @type {{[topicName: string]: {[partition: number]: {nodeId: number, expireAt: number}}}}
      */
     this.preferredReadReplicasPerTopicPartition = {}
     this.offsetManager = null


### PR DESCRIPTION
This is almost cosmetical, except that when looking at KafkaJS sources from my other projects vscode is unhappy for some reason :)