### PR TITLE
fix: deadlock on connection onError handler

### DIFF
--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -155,8 +155,8 @@ module.exports = class Connection {
         })
 
         this.logError(error.message, { stack: e.stack })
-        await this.disconnect()
         this.rejectRequests(error)
+        await this.disconnect()
 
         reject(error)
       }


### PR DESCRIPTION
Issue described here: https://github.com/tulios/kafkajs/issues/943
