### PR TITLE
Document the possible values for the state of a consumer group

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -657,12 +657,15 @@ export type MemberDescription = {
   memberMetadata: Buffer
 }
 
+// See https://github.com/apache/kafka/blob/2.4.0/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java#L25
+export type ConsumerGroupState = 'Unknown' | 'PreparingRebalance' | 'CompletingRebalance' | 'Stable' | 'Dead' | 'Empty';
+
 export type GroupDescription = {
   groupId: string
   members: MemberDescription[]
   protocol: string
   protocolType: string
-  state: string
+  state: ConsumerGroupState
 }
 
 export type GroupDescriptions = {


### PR DESCRIPTION
It took me quite a while to understand that non-existing consumer groups aren't reported as non-existing (no value), but rather come as a group with the literal value 'Dead'. The Kafka protocol documentation doesn't say that clearly either, but luckily I found a unit test inside KafkaJS that explicitly described the case.

This PR then adds the actual possible values for the consumer group `state` as a type, so that anyone else trying to work with them gets a headstart :)

Note that I suspect Kafka could introduce new states, and these new states would appear then as values as well. From a typing view that "sucks", as the compiler wouldn't be able to notice the problem. 

But, any code written would need to learn about any new state as well, and could temporarily cast the `state` property back to `string` until KafkaJS would follow such a hypothetical change.

