### PR TITLE
Refresh metadata on any connection error

### DIFF
--- a/src/cluster/__tests__/brokerPool.spec.js
+++ b/src/cluster/__tests__/brokerPool.spec.js
@@ -6,6 +6,7 @@ const {
   secureRandom,
 } = require('testHelpers')
 const { KafkaJSProtocolError, KafkaJSConnectionError } = require('../../errors')
+const { createErrorFromCode, errorCodes } = require('../../protocol/error')
 const BrokerPool = require('../brokerPool')
 const Broker = require('../../broker')
 
@@ -393,14 +394,14 @@ describe('Cluster > BrokerPool', () => {
       expect(broker.isConnected()).toEqual(true)
     })
 
-    it('recreates the connection on connection errors', async () => {
+    it('recreates the connection on ILLEGAL_SASL_STATE error', async () => {
       const nodeId = 'fakebroker'
       const mockBroker = new Broker({
         connection: createConnection(),
         logger: newLogger(),
       })
       jest.spyOn(mockBroker, 'connect').mockImplementationOnce(() => {
-        throw new KafkaJSConnectionError('Connection lost')
+        throw createErrorFromCode(errorCodes.find(({ type }) => type === 'ILLEGAL_SASL_STATE').code)
       })
       brokerPool.brokers[nodeId] = mockBroker
 

--- a/src/cluster/brokerPool.js
+++ b/src/cluster/brokerPool.js
@@ -314,7 +314,7 @@ module.exports = class BrokerPool {
 
           // Connection refused means this node is down, or the cluster is restarting,
           // which requires metadata refresh to discover the new nodes
-          if (e.code === 'ECONNREFUSED') {
+          if (e.name === 'KafkaJSConnectionError') {
             return bail(e)
           }
 

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -215,7 +215,7 @@ module.exports = class Cluster {
       if (
         e.name === 'KafkaJSBrokerNotFound' ||
         e.name === 'KafkaJSLockTimeout' ||
-        e.code === 'ECONNREFUSED'
+        e.name === 'KafkaJSConnectionError'
       ) {
         await this.refreshMetadata()
       }

--- a/src/errors.js
+++ b/src/errors.js
@@ -19,8 +19,8 @@ class KafkaJSNonRetriableError extends KafkaJSError {
 }
 
 class KafkaJSProtocolError extends KafkaJSError {
-  constructor(e) {
-    super(e, { retriable: e.retriable })
+  constructor(e, { retriable = e.retriable } = {}) {
+    super(e, { retriable })
     this.type = e.type
     this.code = e.code
     this.name = 'KafkaJSProtocolError'


### PR DESCRIPTION
In case we get a connection timeout, we currently don't refresh metadata in all cases, only if we get an `ECONNREFUSED`. 

Fixes #950 with the help of @smartinio.