### PR TITLE
Update maxInFlightRequests to 5

### DIFF
--- a/docs/Transactions.md
+++ b/docs/Transactions.md
@@ -13,18 +13,18 @@ You initialize a transaction by making an async call to `producer.transaction()`
 
 > Note: Kafka requires that the transactional producer have the following configuration to _guarantee_ EoS ("Exactly-once-semantics"):
 >
-> - The producer must have a max in flight requests of 1
+> - The producer must have a max in flight requests of 5
 > - The producer must wait for acknowledgement from all replicas (acks=-1)
 > - The producer must have unlimited retries
 
-Configure the producer client with `maxInFlightRequests: 1` and `idempotent: true` to guarantee EOS. Configuring the two options will enable the settings mentioned above.
+Configure the producer client with `maxInFlightRequests: 5` and `idempotent: true` to guarantee EOS. Configuring the two options will enable the settings mentioned above.
 
 ```javascript
 const client = new Kafka({
   clientId: 'transactional-client',
   brokers: ['kafka1:9092', 'kafka2:9092'],
 })
-const producer = client.producer({ maxInFlightRequests: 1, idempotent: true })
+const producer = client.producer({ maxInFlightRequests: 5, idempotent: true })
 ```
 
 Within a transaction, you can produce one or more messages. If `transaction.abort` is called, all messages will be rolled back.


### PR DESCRIPTION
The kafkajs require Kafka version >= 0.11, so We can use maxInFlightRequests with value 5.

Here more document for guarantee with this value. https://issues.apache.org/jira/browse/KAFKA-5494

So, It's not required to set the maxInFlightRequests to 1. (It's only use for ordering message but not relate to transaction purpose).