### PR TITLE
Prevent uncaught exception on errors.js when 'bugs' field is missing from package.json

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,4 +1,5 @@
 const pkgJson = require('../package.json')
+const { bugs } = pkgJson
 
 class KafkaJSError extends Error {
   constructor(e, { retriable = true } = {}) {
@@ -195,7 +196,7 @@ class KafkaJSDeleteTopicRecordsError extends KafkaJSError {
   }
 }
 
-const issueUrl = pkgJson.bugs.url
+const issueUrl = bugs ? bugs.url : null
 
 class KafkaJSInvariantViolation extends KafkaJSNonRetriableError {
   constructor(e) {
@@ -203,8 +204,10 @@ class KafkaJSInvariantViolation extends KafkaJSNonRetriableError {
     super(`Invariant violated: ${message}. This is likely a bug and should be reported.`)
     this.name = 'KafkaJSInvariantViolation'
 
-    const issueTitle = encodeURIComponent(`Invariant violation: ${message}`)
-    this.helpUrl = `${issueUrl}/new?assignees=&labels=bug&template=bug_report.md&title=${issueTitle}`
+    if (issueUrl !== null) {
+      const issueTitle = encodeURIComponent(`Invariant violation: ${message}`)
+      this.helpUrl = `${issueUrl}/new?assignees=&labels=bug&template=bug_report.md&title=${issueTitle}`
+    }
   }
 }
 


### PR DESCRIPTION
Addresses edge case where uncaught exception can occur in errors.js if "bugs" field is missing from package.json.

Tests for 'bugs' field, and if missing, sets issueUrl to null. Side effect is that, if null, the `helpUrl` will not point to new issue path should a KafkaJSInvariantViolation error get thrown.