### PR TITLE
Use Array.push() instead of spread/concat

### DIFF
--- a/src/protocol/requests/fetch/v4/decodeMessages.js
+++ b/src/protocol/requests/fetch/v4/decodeMessages.js
@@ -20,12 +20,12 @@ const decodeMessages = async decoder => {
   const magicByte = messagesBuffer.slice(MAGIC_OFFSET).readInt8(0)
 
   if (magicByte === MAGIC_BYTE) {
-    let records = []
+    const records = []
 
     while (messagesDecoder.canReadBytes(RECORD_BATCH_OVERHEAD)) {
       try {
         const recordBatch = await RecordBatchDecoder(messagesDecoder)
-        records = [...records, ...recordBatch.records]
+        records.push(...recordBatch.records)
       } catch (e) {
         // The tail of the record batches can have incomplete records
         // due to how maxBytes works. See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-FetchAPI


### PR DESCRIPTION
Found this via profiling.  The change made a significant improvement for my use case - restoring multi Gigabyte state stores with 10s millions of messages (passing the key and value Buffers directly on to leveldb.)

Full data load time:
Before: 136s
After: 39s

With an empty eachBatch function:
Before: 127s
After: 28s