### PR TITLE
fix assigner with builtin method topics

### DIFF
--- a/src/consumer/assigners/roundRobinAssigner/index.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.js
@@ -52,7 +52,7 @@ module.exports = ({ cluster }) => ({
       const assignee = sortedMembers[i % membersCount]
 
       if (!assignment[assignee]) {
-        assignment[assignee] = []
+        assignment[assignee] = Object.create(null)
       }
 
       if (!assignment[assignee][topicPartition.topic]) {

--- a/src/consumer/assigners/roundRobinAssigner/index.spec.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.spec.js
@@ -73,6 +73,28 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
         },
       ])
     })
+
+    test('assign topics with names taken from builtin functions', async () => {
+      topics = ['shift', 'toString']
+      metadata['shift'] = [{ partitionId: 0 }]
+      metadata['toString'] = [{ partitionId: 0 }]
+      const members = [{ memberId: 'member-1' }]
+
+      const assignment = await assigner.assign({ members, topics })
+
+      expect(assignment).toEqual([
+        {
+          memberId: 'member-1',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              shift: [0],
+              toString: [0],
+            },
+          }),
+        },
+      ])
+    })
   })
 
   describe('#protocol', () => {


### PR DESCRIPTION
This fixes #994.

I would have used `hasOwnProperty` on line 58, but the linter prevented me from doing that, so I'm creating an object without a prototype to hold the assignments info and avoid conflicts with builtin methods.