### PR TITLE
Dont commit on consumer seek

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -329,6 +329,17 @@ consumer.seek({ topic: 'example', partition: 0, offset: 12384 })
 
 Upon seeking to an offset, any messages in active batches are marked as stale and discarded, making sure the next message read for the partition is from the offset sought to. Make sure to check `isStale()` before processing a message using [the `eachBatch` interface](#each-batch) of `consumer.run`.
 
+By default, the consumer will commit the offset seeked. To disable this, set the [`autoCommit`](#auto-commit) option to `false` on the consumer.
+
+```javascript
+consumer.run({
+    autoCommit: false,
+    eachMessage: async ({ topic, message }) => true
+})
+// This will now only resolve the previous offset, not commit it
+consumer.seek({ topic: 'example', partition: 0, offset: 12384 })
+```
+
 ## <a name="custom-partition-assigner"></a> Custom partition assigner
 
 It's possible to configure the strategy the consumer will use to distribute partitions amongst the consumer group. KafkaJS has a round robin assigner configured by default.

--- a/src/consumer/__tests__/seek.spec.js
+++ b/src/consumer/__tests__/seek.spec.js
@@ -1,3 +1,4 @@
+const createAdmin = require('../../admin')
 const createProducer = require('../../producer')
 const createConsumer = require('../index')
 const { KafkaJSNonRetriableError } = require('../../errors')
@@ -162,6 +163,52 @@ describe('Consumer', () => {
           message: expect.objectContaining({ offset: '0' }),
         },
       ])
+    })
+
+    describe('When "autoCommit" is false', () => {
+      let admin
+
+      beforeEach(() => {
+        admin = createAdmin({ logger: newLogger(), cluster })
+      })
+
+      afterEach(async () => {
+        admin && (await admin.disconnect())
+      })
+
+      it('should not commit the offset', async () => {
+        await Promise.all([consumer, producer, admin].map(client => client.connect()))
+
+        await producer.send({
+          acks: 1,
+          topic: topicName,
+          messages: [1, 2, 3].map(n => ({ key: `key-${n}`, value: `value-${n}` })),
+        })
+        await consumer.subscribe({ topic: topicName, fromBeginning: true })
+
+        const messagesConsumed = []
+        consumer.run({
+          autoCommit: false,
+          eachMessage: async event => messagesConsumed.push(event),
+        })
+        consumer.seek({ topic: topicName, partition: 0, offset: 2 })
+
+        await waitForConsumerToJoinGroup(consumer)
+        await expect(waitForMessages(messagesConsumed, { number: 1 })).resolves.toEqual([
+          {
+            topic: topicName,
+            partition: 0,
+            message: expect.objectContaining({ offset: '2' }),
+          },
+        ])
+
+        await expect(admin.fetchOffsets({ groupId, topic: topicName })).resolves.toEqual([
+          expect.objectContaining({
+            partition: 0,
+            offset: '-1',
+          }),
+        ])
+      })
     })
   })
 })

--- a/src/consumer/__tests__/seek.spec.js
+++ b/src/consumer/__tests__/seek.spec.js
@@ -186,7 +186,7 @@ describe('Consumer', () => {
         })
         await consumer.subscribe({ topic: topicName, fromBeginning: true })
 
-        const messagesConsumed = []
+        let messagesConsumed = []
         consumer.run({
           autoCommit: false,
           eachMessage: async event => messagesConsumed.push(event),
@@ -207,6 +207,22 @@ describe('Consumer', () => {
             partition: 0,
             offset: '-1',
           }),
+        ])
+
+        messagesConsumed = []
+        consumer.seek({ topic: topicName, partition: 0, offset: 1 })
+
+        await expect(waitForMessages(messagesConsumed, { number: 2 })).resolves.toEqual([
+          {
+            topic: topicName,
+            partition: 0,
+            message: expect.objectContaining({ offset: '1' }),
+          },
+          {
+            topic: topicName,
+            partition: 0,
+            message: expect.objectContaining({ offset: '2' }),
+          },
         ])
       })
     })

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -55,6 +55,7 @@ module.exports = class ConsumerGroup {
     minBytes,
     maxBytes,
     maxWaitTimeInMs,
+    autoCommit,
     autoCommitInterval,
     autoCommitThreshold,
     isolationLevel,
@@ -77,6 +78,7 @@ module.exports = class ConsumerGroup {
     this.minBytes = minBytes
     this.maxBytes = maxBytes
     this.maxWaitTime = maxWaitTimeInMs
+    this.autoCommit = autoCommit
     this.autoCommitInterval = autoCommitInterval
     this.autoCommitThreshold = autoCommitThreshold
     this.isolationLevel = isolationLevel
@@ -274,6 +276,7 @@ module.exports = class ConsumerGroup {
         }),
         {}
       ),
+      autoCommit: this.autoCommit,
       autoCommitInterval: this.autoCommitInterval,
       autoCommitThreshold: this.autoCommitThreshold,
       coordinator,

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -82,7 +82,7 @@ module.exports = ({
     )
   }
 
-  const createConsumerGroup = ({ autoCommitInterval, autoCommitThreshold }) => {
+  const createConsumerGroup = ({ autoCommit, autoCommitInterval, autoCommitThreshold }) => {
     return new ConsumerGroup({
       logger: rootLogger,
       topics: keys(topics),
@@ -98,6 +98,7 @@ module.exports = ({
       maxBytes,
       maxWaitTimeInMs,
       instrumentationEmitter,
+      autoCommit,
       autoCommitInterval,
       autoCommitThreshold,
       isolationLevel,
@@ -218,6 +219,7 @@ module.exports = ({
     }
 
     consumerGroup = createConsumerGroup({
+      autoCommit,
       autoCommitInterval,
       autoCommitThreshold,
     })

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -167,7 +167,7 @@ module.exports = class Runner extends EventEmitter {
 
       this.consumerGroup.resolveOffset({ topic, partition, offset: message.offset })
       await this.consumerGroup.heartbeat({ interval: this.heartbeatInterval })
-      await this.consumerGroup.commitOffsetsIfNecessary()
+      await this.autoCommitOffsetsIfNecessary()
     }
   }
 


### PR DESCRIPTION
This changes the behavior of `consumer.seek` so that when the consumer is running with `autoCommit: false`, the offsets that are seeked to are not committed. Instead, the previous offset is just resolved.

I opted for using `autoCommit` instead of an explicit flag in `consumer.seek` because I figured if you are using `autoCommit: false` it's because you don't want to us to commit offsets for you. I'm open to feedback on this, as I first did implement the flag, which wasn't any harder, it just seemed more elegant with less chances of accidental offset commits this way.

It's late and I'm very sleepy, so I'm not sure yet if I did this properly.  One thing I know I need to check is: do we actually change the resolved offset if we seek to an offset that is lower than the previously resolved one? If not, I need to special case this and "force" the resolved offset to change.

Fixes #395