### PR TITLE
Shared concurrent heartbeat() promise

### DIFF
--- a/src/utils/sharedPromiseTo.js
+++ b/src/utils/sharedPromiseTo.js
@@ -1,0 +1,14 @@
+/**
+ * @param { () => Promise<void> } [func]
+ * @returns { (() => Promise<void>?) => Promise<void> }
+ */
+module.exports = defaultFunc => {
+  let promise = null
+  return async func => {
+    if (promise) {
+      return await promise
+    }
+    promise = defaultFunc ? defaultFunc() : func()
+    return await promise.finally(() => (promise = null))
+  }
+}

--- a/src/utils/sharedPromiseTo.js
+++ b/src/utils/sharedPromiseTo.js
@@ -4,11 +4,9 @@
  */
 module.exports = defaultFunc => {
   let promise = null
-  return async func => {
-    if (promise) {
-      return await promise
-    }
-    promise = defaultFunc ? defaultFunc() : func()
-    return await promise.finally(() => (promise = null))
+  return func => {
+    if (promise == null)
+      promise = (defaultFunc ? defaultFunc() : func()).finally(() => (promise = null))
+    return promise
   }
 }

--- a/src/utils/sharedPromiseTo.js
+++ b/src/utils/sharedPromiseTo.js
@@ -1,13 +1,18 @@
 /**
  * @template T
- * @param { () => Promise<T> } [defaultFunc]
- * @returns { (func?: () => Promise<T>) => Promise<T> }
+ * @param { (...args: any) => Promise<T> } [asyncFunction]
+ * Promise returning function that will only ever be invoked sequentially.
+ * @returns { (...args: any) => Promise<T> }
+ * Function that may invoke asyncFunction if there is not a currently executing invocation.
+ * Returns promise from the currently executing invocation.
  */
-module.exports = defaultFunc => {
+module.exports = asyncFunction => {
   let promise = null
-  return func => {
-    if (promise == null)
-      promise = (defaultFunc ? defaultFunc() : func()).finally(() => (promise = null))
+
+  return (...args) => {
+    if (promise == null) {
+      promise = asyncFunction(...args).finally(() => (promise = null))
+    }
     return promise
   }
 }

--- a/src/utils/sharedPromiseTo.js
+++ b/src/utils/sharedPromiseTo.js
@@ -1,6 +1,7 @@
 /**
- * @param { () => Promise<void> } [func]
- * @returns { (() => Promise<void>?) => Promise<void> }
+ * @template T
+ * @param { () => Promise<T> } [defaultFunc]
+ * @returns { (func?: () => Promise<T>) => Promise<T> }
  */
 module.exports = defaultFunc => {
   let promise = null

--- a/src/utils/sharedPromiseTo.spec.js
+++ b/src/utils/sharedPromiseTo.spec.js
@@ -1,0 +1,5 @@
+// const sharedPromiseTo = require('./sharedPromiseTo')
+
+describe.skip('Utils > sharedPromiseTo', () => {
+  it('Returns the same pending promise', () => {})
+})

--- a/src/utils/sharedPromiseTo.spec.js
+++ b/src/utils/sharedPromiseTo.spec.js
@@ -1,5 +1,91 @@
-// const sharedPromiseTo = require('./sharedPromiseTo')
+const sharedPromiseTo = require('./sharedPromiseTo')
 
-describe.skip('Utils > sharedPromiseTo', () => {
-  it('Returns the same pending promise', () => {})
+describe('Utils > sharedPromiseTo', () => {
+  let resolvePromise1, rejectPromise1, sharedPromise1
+
+  const setResolveReject1 = () =>
+    new Promise((resolve, reject) => {
+      resolvePromise1 = resolve
+      rejectPromise1 = reject
+    })
+
+  describe('pass async function at creation time', () => {
+    beforeEach(() => {
+      sharedPromise1 = sharedPromiseTo(setResolveReject1)
+    })
+
+    it('Returns the same pending promise for every invocation', async () => {
+      const p1 = sharedPromise1()
+      const p2 = sharedPromise1()
+      const p3 = sharedPromise1()
+      expect(Object.is(p1, p2)).toBe(true)
+      expect(Object.is(p2, p3)).toBe(true)
+    })
+
+    it('After resolving, returns a new promise on next invocation', async () => {
+      const message = 'Resolved promise #1'
+      const p1 = sharedPromise1()
+      resolvePromise1(message)
+
+      await expect(p1).resolves.toBe(message)
+      const p2 = sharedPromise1()
+      expect(Object.is(p1, p2)).toBe(false)
+    })
+
+    it('After rejecting, returns a new promise on next invocation', async () => {
+      const message = 'Rejected promise #1'
+      const p1 = sharedPromise1()
+      rejectPromise1(new Error(message))
+
+      await expect(p1).rejects.toThrow(message)
+      const p2 = sharedPromise1()
+      expect(Object.is(p1, p2)).toBe(false)
+    })
+
+    it('Ignores function passed at call time', async () => {
+      const f = jest.fn()
+      const p1 = sharedPromise1(f)
+      resolvePromise1()
+      await p1
+      expect(f).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pass async function at call time', () => {
+    beforeEach(() => {
+      sharedPromise1 = sharedPromiseTo()
+    })
+
+    it('Returns the same pending promise for every invocation', async () => {
+      const p1 = sharedPromise1(setResolveReject1)
+      const p2 = sharedPromise1(setResolveReject1)
+      const p3 = sharedPromise1(setResolveReject1)
+      expect(Object.is(p1, p2)).toBe(true)
+      expect(Object.is(p2, p3)).toBe(true)
+    })
+
+    it('After resolving, returns a new promise on next invocation', async () => {
+      const message = 'Resolved promise #1'
+      const p1 = sharedPromise1(setResolveReject1)
+      resolvePromise1(message)
+
+      await expect(p1).resolves.toBe(message)
+      const p2 = sharedPromise1(setResolveReject1)
+      expect(Object.is(p1, p2)).toBe(false)
+    })
+
+    it('After rejecting, returns a new promise on next invocation', async () => {
+      const message = 'Rejected promise #1'
+      const p1 = sharedPromise1(setResolveReject1)
+      rejectPromise1(new Error(message))
+
+      await expect(p1).rejects.toThrow(message)
+      const p2 = sharedPromise1(setResolveReject1)
+      expect(Object.is(p1, p2)).toBe(false)
+    })
+
+    it('Errors out if no function passed', async () => {
+      expect(() => sharedPromise1()).toThrow()
+    })
+  })
 })

--- a/src/utils/sharedPromiseTo.spec.js
+++ b/src/utils/sharedPromiseTo.spec.js
@@ -3,97 +3,53 @@ const sharedPromiseTo = require('./sharedPromiseTo')
 describe('Utils > sharedPromiseTo', () => {
   let resolvePromise1, rejectPromise1, sharedPromise1, asyncFunction
 
-  const setResolveReject1 = () =>
-    new Promise((resolve, reject) => {
-      resolvePromise1 = resolve
-      rejectPromise1 = reject
-    })
-
-  describe('pass async function at creation time', () => {
-    beforeEach(() => {
-      asyncFunction = jest.fn(setResolveReject1)
-      sharedPromise1 = sharedPromiseTo(asyncFunction)
-    })
-
-    it('Returns the same pending promise for every invocation', async () => {
-      const p1 = sharedPromise1()
-      const p2 = sharedPromise1()
-      const p3 = sharedPromise1()
-      expect(Object.is(p1, p2)).toBe(true)
-      expect(Object.is(p2, p3)).toBe(true)
-      expect(asyncFunction).toHaveBeenCalledTimes(1)
-    })
-
-    it('After resolving, returns a new promise on next invocation', async () => {
-      const message = 'Resolved promise #1'
-      const p1 = sharedPromise1()
-      resolvePromise1(message)
-
-      await expect(p1).resolves.toBe(message)
-      const p2 = sharedPromise1()
-      expect(Object.is(p1, p2)).toBe(false)
-      expect(asyncFunction).toHaveBeenCalledTimes(2)
-    })
-
-    it('After rejecting, returns a new promise on next invocation', async () => {
-      const message = 'Rejected promise #1'
-      const p1 = sharedPromise1()
-      rejectPromise1(new Error(message))
-
-      await expect(p1).rejects.toThrow(message)
-      const p2 = sharedPromise1()
-      expect(Object.is(p1, p2)).toBe(false)
-      expect(asyncFunction).toHaveBeenCalledTimes(2)
-    })
-
-    it('Ignores function passed at invocation time', async () => {
-      const f = jest.fn()
-      const p1 = sharedPromise1(f)
-      resolvePromise1()
-      await p1
-      expect(f).not.toHaveBeenCalled()
-    })
+  beforeEach(() => {
+    asyncFunction = jest.fn(
+      () =>
+        new Promise((resolve, reject) => {
+          resolvePromise1 = resolve
+          rejectPromise1 = reject
+        })
+    )
+    sharedPromise1 = sharedPromiseTo(asyncFunction)
   })
 
-  describe('pass async function at invocation time', () => {
-    beforeEach(() => {
-      asyncFunction = jest.fn(setResolveReject1)
-      sharedPromise1 = sharedPromiseTo()
-    })
+  it('Returns the same pending promise for every invocation', async () => {
+    const p1 = sharedPromise1()
+    const p2 = sharedPromise1()
+    const p3 = sharedPromise1()
+    expect(Object.is(p1, p2)).toBe(true)
+    expect(Object.is(p2, p3)).toBe(true)
+    expect(asyncFunction).toHaveBeenCalledTimes(1)
+  })
 
-    it('Returns the same pending promise for every invocation (function at invocation)', async () => {
-      const p1 = sharedPromise1(asyncFunction)
-      const p2 = sharedPromise1(asyncFunction)
-      const p3 = sharedPromise1(asyncFunction)
-      expect(Object.is(p1, p2)).toBe(true)
-      expect(Object.is(p2, p3)).toBe(true)
-      expect(asyncFunction).toHaveBeenCalledTimes(1)
-    })
+  it('After resolving, returns a new promise on next invocation', async () => {
+    const message = 'Resolved promise #1'
+    const p1 = sharedPromise1()
+    resolvePromise1(message)
 
-    it('After resolving, returns a new promise on next invocation (function at invocation)', async () => {
-      const message = 'Resolved promise #1'
-      const p1 = sharedPromise1(asyncFunction)
-      resolvePromise1(message)
+    await expect(p1).resolves.toBe(message)
+    const p2 = sharedPromise1()
+    expect(Object.is(p1, p2)).toBe(false)
+    expect(asyncFunction).toHaveBeenCalledTimes(2)
+  })
 
-      await expect(p1).resolves.toBe(message)
-      const p2 = sharedPromise1(asyncFunction)
-      expect(Object.is(p1, p2)).toBe(false)
-      expect(asyncFunction).toHaveBeenCalledTimes(2)
-    })
+  it('After rejecting, returns a new promise on next invocation', async () => {
+    const message = 'Rejected promise #1'
+    const p1 = sharedPromise1()
+    rejectPromise1(new Error(message))
 
-    it('After rejecting, returns a new promise on next invocation (function at invocation)', async () => {
-      const message = 'Rejected promise #1'
-      const p1 = sharedPromise1(asyncFunction)
-      rejectPromise1(new Error(message))
+    await expect(p1).rejects.toThrow(message)
+    const p2 = sharedPromise1()
+    expect(Object.is(p1, p2)).toBe(false)
+    expect(asyncFunction).toHaveBeenCalledTimes(2)
+  })
 
-      await expect(p1).rejects.toThrow(message)
-      const p2 = sharedPromise1(asyncFunction)
-      expect(Object.is(p1, p2)).toBe(false)
-      expect(asyncFunction).toHaveBeenCalledTimes(2)
-    })
-
-    it('Errors out if no function passed at invocation', async () => {
-      expect(() => sharedPromise1()).toThrow()
-    })
+  it('Passes through arguments passed at invocation time', async () => {
+    const args = ['arg1', 'arg2']
+    const p1 = sharedPromise1(...args)
+    resolvePromise1()
+    await p1
+    expect(asyncFunction).toHaveBeenCalledWith(...args)
   })
 })


### PR DESCRIPTION
All concurrent heartbeat() calls will return the same promise object.  Proposed solution to https://github.com/tulios/kafkajs/issues/1025

Added a test that reproduces https://github.com/tulios/kafkajs/issues/1025 but more tests needed.