### PR TITLE
Adding generation id check to isStale

### DIFF
--- a/src/consumer/batch.js
+++ b/src/consumer/batch.js
@@ -7,7 +7,7 @@ const filterAbortedMessages = require('./filterAbortedMessages')
  * A batch could contain _multiple_ Kafka RecordBatches.
  */
 module.exports = class Batch {
-  constructor(topic, fetchedOffset, partitionData) {
+  constructor(topic, fetchedOffset, partitionData, generationId) {
     this.fetchedOffset = fetchedOffset
     const longFetchedOffset = Long.fromValue(this.fetchedOffset)
     const { abortedTransactions, messages } = partitionData
@@ -31,6 +31,8 @@ module.exports = class Batch {
       messages: this.messagesWithinOffset,
       abortedTransactions,
     }).filter(message => !message.isControlRecord)
+
+    this.generationId = generationId
   }
 
   isEmpty() {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -545,7 +545,7 @@ module.exports = class ConsumerGroup {
               )
 
               const fetchedOffset = partitionRequestData.fetchOffset
-              const batch = new Batch(topicName, fetchedOffset, partitionData)
+              const batch = new Batch(topicName, fetchedOffset, partitionData, this.generationId)
 
               /**
                * Resolve the offset to skip the control batch since `eachBatch` or `eachMessage` callbacks
@@ -684,6 +684,10 @@ module.exports = class ConsumerGroup {
 
   hasSeekOffset({ topic, partition }) {
     return this.seekOffset.has(topic, partition)
+  }
+
+  isStaleGeneration({ generationId }) {
+    return this.generationId !== generationId
   }
 
   /**

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -172,7 +172,7 @@ module.exports = class Runner extends EventEmitter {
   }
 
   async processEachBatch(batch) {
-    const { topic, partition } = batch
+    const { topic, partition, generationId } = batch
     const lastFilteredMessage = batch.messages[batch.messages.length - 1]
 
     try {
@@ -215,7 +215,9 @@ module.exports = class Runner extends EventEmitter {
         },
         uncommittedOffsets: () => this.consumerGroup.uncommittedOffsets(),
         isRunning: () => this.running,
-        isStale: () => this.consumerGroup.hasSeekOffset({ topic, partition }),
+        isStale: () =>
+          this.consumerGroup.hasSeekOffset({ topic, partition }) ||
+          this.consumerGroup.isStaleGeneration({ generationId }),
       })
     } catch (e) {
       if (!isKafkaJSError(e)) {


### PR DESCRIPTION
Adding a check to isStale to see if the current generationId matches the generationId when the batch was created.

Intended as a partial solution for unnecessary duplicate processing as described in #1046.  Does not address the issue of commits to unassigned partitions.