### PR TITLE
docs: fix TOC links in Client Configuration page

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -69,7 +69,7 @@ new Kafka({
 
 Refer to [TLS create secure context](https://nodejs.org/dist/latest-v8.x/docs/api/tls.html#tls_tls_createsecurecontext_options) for more information. `NODE_EXTRA_CA_CERTS` can be used to add custom CAs. Use `ssl: true` if you don't have any extra configurations and want to enable SSL.
 
-## <a name="sasl"></a> SASL
+## SASL
 
 Kafka has support for using SASL to authenticate clients. The `sasl` option can be used to configure the authentication mechanism. Currently, KafkaJS supports `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`, and `AWS` mechanisms.
 
@@ -200,7 +200,7 @@ new Kafka({
 })
 ```
 
-## <a name="retry"></a> Default Retry
+## Default Retry
 
 The `retry` option can be used to set the configuration of the retry mechanism, which is used to retry connections and API calls to Kafka (when using producers or consumers).
 
@@ -233,7 +233,7 @@ new Kafka({
 })
 ```
 
-### <a name="restart-on-failure"></a> `restartOnFailure`
+### `restartOnFailure`
 
 An async function that will be invoked after the consumer exhausts all retries, to decide whether or not to restart the consumer (essentially resetting `consumer.run`). This can be used to, for example, cleanly shut down resources before crashing, if that is preferred. The function will be passed the error, which allows it to decide based on the type of error whether or not to exit the application or allow it to restart.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -218,7 +218,7 @@ __Available options:__
 | factor              | Randomization factor                                                                                                    | `0.2`               |
 | multiplier          | Exponential factor                                                                                                      | `2`                 |
 | retries             | Max number of retries per call                                                                                          | `5`                 |
-| restartOnFailure    | Only used in consumer. See [`restartOnFailure`](#restart-on-failure)                                                    | `async () => true`  |
+| restartOnFailure    | Only used in consumer. See [`restartOnFailure`](#restartonfailure)                                                      | `async () => true`  |
 
 Example:
 


### PR DESCRIPTION
Currently some links the TOC of https://kafka.js.org/docs/configuration are not working.

For example, _Default Retry_: https://kafka.js.org/docs/configuration#default-retry

These commits attempt to fix them.