### PR TITLE
Fix typings for LoggerEntryContent timestamp

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -526,7 +526,7 @@ export interface LogEntry {
 }
 
 export interface LoggerEntryContent {
-  readonly timestamp: Date
+  readonly timestamp: string
   readonly message: string
   [key: string]: any
 }

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -43,7 +43,9 @@ const kafka = new Kafka({
     username: 'test',
     password: 'testtest',
   },
-  logCreator: (logLevel: logLevel) => (entry: LogEntry) => {},
+  logCreator: (logLevel: logLevel) => (entry: LogEntry) => {
+    Date.parse(entry.log.timestamp);
+  },
 })
 
 kafka.logger().error('Instantiated KafkaJS')


### PR DESCRIPTION
The previous typings had `LoggerEntryContent['timestamp']` as a `Date`, but it's actually a `string`.

See: https://github.com/tulios/kafkajs/blob/a00d664fb2a25330c5b5e5e1ffe6d80c26d5c671/src/loggers/index.js#L22