### PR TITLE
Re-enable skipped tests

### DIFF
--- a/src/utils/long.spec.js
+++ b/src/utils/long.spec.js
@@ -46,10 +46,20 @@ describe('Utils > Long', () => {
       expect(typeof output.value).toEqual('bigint')
     })
 
-    it('toInt()', () => {
-      const expectedInt = max.toInt()
-      expect(expectedInt).toEqual(4294967295)
-      expect(typeof expectedInt).toEqual('number')
+    describe('toInt()', () => {
+      it('should return an int', () => {
+        const maxInt32 = 2 ** 31 - 1
+        const expectedInt = new Long(BigInt(maxInt32)).toInt()
+        expect(expectedInt).toEqual(2147483647)
+        expect(typeof expectedInt).toEqual('number')
+      })
+
+      it('should wrap around if the number is too big to be represented as an int32', () => {
+        const maxInt32 = 2 ** 31 - 1
+        const expectedInt = new Long(BigInt(maxInt32 + 1)).toInt()
+        expect(expectedInt).toEqual(-2147483648)
+        expect(typeof expectedInt).toEqual('number')
+      })
     })
 
     it('toNumber()', () => {
@@ -144,7 +154,7 @@ describe('Utils > Long', () => {
       input2 = new Long(BigInt(13))
     })
 
-    it.only('getHighBits() & getLowBits()', () => {
+    it('getHighBits() & getLowBits()', () => {
       expect(input1.getHighBits()).toEqual(0)
       expect(input1.getLowBits()).toEqual(5)
 


### PR DESCRIPTION
I guess I left an `.only` in there at some point. Re-enabling the tests showed me I had one failing test, but I would say it was failing for good reason. The `toInt` method is meant to return a int32, but it was expecting it to return a number larger than the range of a signed int32. Maybe at some point I thought it should return a uint32 or something. Fixed the tests to match what the code is actually supposed to do.