### PR TITLE
Allow injecting authentication mechanisms

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -171,6 +171,21 @@ You can also programmatically retrieve the `aws:userid` for currently available 
 A complete breakdown can be found in the IAM User Guide's
 [Reference on Policy Variables](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#policy-vars-infotouse).
 
+### Custom Authentication Mechanisms
+
+If an authentication mechanism is not supported out of the box in KafkaJS, a custom authentication
+mechanism can be introduced as a plugin:
+
+```js
+const CustomAuthenticationMechanism = require('custom-authentication-mechanism')
+const { AuthenticationMechanisms } = require('kafkajs')
+
+AuthenticationMechanisms['CUSTOM_AUTHENTICATION'] = CustomAuthenticationMechanism
+```
+
+See [Custom Authentication Mechanisms](CustomAuthenticationMechanism.md) for more information on how to implement your own
+authentication mechanism.
+
 ### Use Encrypted Protocols
 
 It is **highly recommended** that you use SSL for encryption when using `PLAIN` or `AWS`,

--- a/docs/CustomAuthenticationMechanism.md
+++ b/docs/CustomAuthenticationMechanism.md
@@ -1,0 +1,150 @@
+---
+id: custom-authentication-mechanism
+title: Custom Authentication Mechanisms
+---
+
+To use an authentication mechanism that is not supported out of the box by KafkaJS,
+custom authentication mechanisms can be introduced:
+
+```js
+const CustomAuthenticationMechanism = require('custom-authentication-mechanism')
+const { AuthenticationMechanisms } = require('kafkajs')
+
+AuthenticationMechanisms['CUSTOM_AUTHENTICATION'] = CustomAuthenticationMechanism
+```
+
+`CUSTOM_AUTHENTICATION` needs to match the SASL mechanism configured in the `sasl.enabled.mechanisms`
+property in `server.properties`. See the Kafka documentation for information on how to
+configure your brokers.
+
+## Writing a custom authentication mechanism
+
+A custom authentication mechanism needs to fulfill the following interface:
+
+```ts
+type AuthenticationMechanismCreator = (params: {
+  sasl: Record<string, any>,
+  connection: { host: string, port: number },
+  logger: Logger,
+  saslAuthenticate: (handlers: { request: SaslAuthenticationRequest, response?: SaslAuthenticationResponse }) => Promise<void>
+}) => AuthenticationMechanism
+
+type AuthenticationMechanism = {
+  authenticate(): Promise<void>
+}
+
+type SaslAuthenticationRequest = (sasl: Record<string, any>) => {
+  encode: () => Buffer
+}
+
+type SaslAuthenticationResponse = () => {
+  decode: (rawResponse: Buffer) => Buffer
+  parse: (data: Buffer) => any
+}
+```
+
+* `sasl` - Whatever is passed into the client constructor as `sasl`
+* `connection` - The host and port that the client will authenticate against
+* `logger` - A logger instance namespaced to the authentication mechanism
+* `saslAuthenticate` - an async function to make [`SaslAuthenticate](https://kafka.apache.org/protocol.html#The_Messages_SaslAuthenticate)
+requests towards the broker.
+
+### Example
+
+In this example we will create a custom authentication mechanism called `SIMON`. The general
+flow will be:
+
+1. Read `sasl.simonSays` from the client configuration
+2. Send a [`SaslAuthenticate`](https://kafka.apache.org/protocol.html#The_Messages_SaslAuthenticate)
+request with the value of `sasl.simonSays` as `auth_bytes`.
+3. Read the response from the broker and validate that it returned the same value.
+
+```js
+function SimonAuthenticator({ sasl, connection, logger, saslAuthenticate }) {
+  const INT32_SIZE = 4
+
+  const request = ({
+    /**
+     * Encodes the value for `auth_bytes` in SaslAuthenticate request
+     * @see https://kafka.apache.org/protocol.html#The_Messages_SaslAuthenticate
+     * 
+     * In this example, we are just sending `sasl.simonSays` as a string,
+     * with the length of the string in bytes prepended as an int32
+     **/
+    encode: async () => {
+      const byteLength = Buffer.byteLength(sasl.simonSays, 'utf8')
+      const buf = Buffer.alloc(INT32_SIZE + byteLength)
+      buf.writeUInt32BE(byteLength, 0)
+      buf.write(sasl.simonSays, INT32_SIZE, byteLength, 'utf8')
+      return buf
+    },
+  })
+
+  const response = {
+    /**
+     * Decodes the `auth_bytes` in SaslAuthenticate response
+     * @see https://kafka.apache.org/protocol.html#The_Messages_SaslAuthenticate
+     * 
+     * This is essentially the reverse of `request.encode`, where
+     * we read the length of the string as an int32 and then read
+     * that many bytes
+     */
+    decode: async rawData => {
+      const byteLength = rawData.readInt32BE(0)
+      return rawData.slice(INT32_SIZE, INT32_SIZE + byteLength)
+    },
+
+    /**
+     * The return value from `response.decode` is passed into
+     * this function, which is responsible for interpreting
+     * the data. In this case, we just turn the buffer back
+     * into a string
+     */
+    parse: async data => {
+      return data.toString()
+    },
+  }
+
+  return {
+    /**
+     * This function is responsible for orchestrating the authentication flow.
+     * Essentially we will send a SaslAuthenticate request with the
+     * value of `sasl.simonSays` to the broker, and expect to
+     * get the same value back.
+     * 
+     * Other authentication methods may do any other operations they
+     * like, but communication with the brokers goes through
+     * the SaslAuthenticate request.
+     */
+    authenticate: async () => {
+      if (sasl.simonSays == null) {
+        throw new Error('SASL Simon: Invalid "simonSays"')
+      }
+
+      const { host, port } = connection
+      const broker = `${host}:${port}`
+
+      try {
+        logger.debug('Authenticate with SASL Simon', { broker })
+        const authenticateResponse = await saslAuthenticate({ request, response })
+
+        if (authenticateResponse !== sasl.simonSays) {
+            throw new Error("Mismatching response from broker")
+        }
+
+        logger.debug('SASL Simon authentication successful', { broker })
+      } catch (e) {
+        const error = new Error(
+          `SASL Simon authentication failed: ${e.message}`
+        )
+        logger.error(error.message, { broker })
+        throw error
+      }
+    },
+  }
+}
+```
+
+The `response` argument to `saslAuthenticate` is optional, in case the authentication
+method does not require the `auth_bytes` in the response.
+

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const AclOperationTypes = require('./src/protocol/aclOperationTypes')
 const AclPermissionTypes = require('./src/protocol/aclPermissionTypes')
 const ResourcePatternTypes = require('./src/protocol/resourcePatternTypes')
 const { LEVELS } = require('./src/loggers')
+const { AuthenticationMechanisms } = require('./src/broker/saslAuthenticator')
 
 module.exports = {
   Kafka,
@@ -33,4 +34,5 @@ module.exports = {
   AclPermissionTypes,
   ResourcePatternTypes,
   ConfigSource,
+  AuthenticationMechanisms,
 }

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -4,7 +4,7 @@ const { Types: Compression } = require('../protocol/message/compression')
 const { requests, lookup } = require('../protocol/requests')
 const { KafkaJSNonRetriableError } = require('../errors')
 const apiKeys = require('../protocol/requests/apiKeys')
-const SASLAuthenticator = require('./saslAuthenticator')
+const { SASLAuthenticator } = require('./saslAuthenticator')
 const shuffle = require('../utils/shuffle')
 
 const PRIVATE = {

--- a/src/broker/saslAuthenticator/authenticators.js
+++ b/src/broker/saslAuthenticator/authenticators.js
@@ -1,0 +1,11 @@
+const AuthenticationMechanisms = {
+  PLAIN: () => require('./plain'),
+  'SCRAM-SHA-256': () => require('./scram256'),
+  'SCRAM-SHA-512': () => require('./scram512'),
+  AWS: () => require('./awsIam'),
+  OAUTHBEARER: () => require('./oauthBearer'),
+}
+
+module.exports = {
+  AuthenticationMechanisms,
+}

--- a/src/broker/saslAuthenticator/awsIam.js
+++ b/src/broker/saslAuthenticator/awsIam.js
@@ -1,43 +1,38 @@
-const awsIam = require('../../protocol/sasl/awsIam')
+const { request } = require('../../protocol/sasl/awsIam')
 const { KafkaJSSASLAuthenticationError } = require('../../errors')
 
-module.exports = class AWSIAMAuthenticator {
-  constructor(connection, logger, saslAuthenticate) {
-    this.connection = connection
-    this.logger = logger.namespace('SASLAWSIAMAuthenticator')
-    this.saslAuthenticate = saslAuthenticate
-  }
+function AWSIAMAuthenticator({ sasl, connection, logger, saslAuthenticate }) {
+  return {
+    authenticate: async () => {
+      if (!sasl.authorizationIdentity) {
+        throw new KafkaJSSASLAuthenticationError('SASL AWS-IAM: Missing authorizationIdentity')
+      }
+      if (!sasl.accessKeyId) {
+        throw new KafkaJSSASLAuthenticationError('SASL AWS-IAM: Missing accessKeyId')
+      }
+      if (!sasl.secretAccessKey) {
+        throw new KafkaJSSASLAuthenticationError('SASL AWS-IAM: Missing secretAccessKey')
+      }
+      if (!sasl.sessionToken) {
+        sasl.sessionToken = ''
+      }
 
-  async authenticate() {
-    const { sasl } = this.connection
-    if (!sasl.authorizationIdentity) {
-      throw new KafkaJSSASLAuthenticationError('SASL AWS-IAM: Missing authorizationIdentity')
-    }
-    if (!sasl.accessKeyId) {
-      throw new KafkaJSSASLAuthenticationError('SASL AWS-IAM: Missing accessKeyId')
-    }
-    if (!sasl.secretAccessKey) {
-      throw new KafkaJSSASLAuthenticationError('SASL AWS-IAM: Missing secretAccessKey')
-    }
-    if (!sasl.sessionToken) {
-      sasl.sessionToken = ''
-    }
+      const { host, port } = connection
+      const broker = `${host}:${port}`
 
-    const request = awsIam.request(sasl)
-    const response = awsIam.response
-    const { host, port } = this.connection
-    const broker = `${host}:${port}`
-
-    try {
-      this.logger.debug('Authenticate with SASL AWS-IAM', { broker })
-      await this.saslAuthenticate({ request, response })
-      this.logger.debug('SASL AWS-IAM authentication successful', { broker })
-    } catch (e) {
-      const error = new KafkaJSSASLAuthenticationError(
-        `SASL AWS-IAM authentication failed: ${e.message}`
-      )
-      this.logger.error(error.message, { broker })
-      throw error
-    }
+      try {
+        logger.debug('Authenticate with SASL AWS-IAM', { broker })
+        await saslAuthenticate({ request: request(sasl) })
+        logger.debug('SASL AWS-IAM authentication successful', { broker })
+      } catch (e) {
+        const error = new KafkaJSSASLAuthenticationError(
+          `SASL AWS-IAM authentication failed: ${e.message}`
+        )
+        logger.error(error.message, { broker })
+        throw error
+      }
+    },
   }
 }
+
+module.exports = AWSIAMAuthenticator

--- a/src/broker/saslAuthenticator/awsIam.spec.js
+++ b/src/broker/saslAuthenticator/awsIam.spec.js
@@ -3,30 +3,44 @@ const AWSIAM = require('./awsIam')
 
 describe('Broker > SASL Authenticator > AWS-IAM', () => {
   it('throws KafkaJSSASLAuthenticationError for missing authorizationIdentity', async () => {
-    const awsIam = new AWSIAM({ sasl: {} }, newLogger())
+    const awsIam = AWSIAM({
+      sasl: {},
+      connection: { host: 'host', port: 9094 },
+      logger: newLogger(),
+      saslAuthenticate: () => {},
+    })
     await expect(awsIam.authenticate()).rejects.toThrow(
       'SASL AWS-IAM: Missing authorizationIdentity'
     )
   })
 
   it('throws KafkaJSSASLAuthenticationError for invalid accessKeyId', async () => {
-    const awsIam = new AWSIAM(
-      {
-        sasl: {
-          authorizationIdentity: '<authorizationIdentity>',
-          secretAccessKey: '<secretAccessKey>',
-        },
+    const awsIam = AWSIAM({
+      sasl: {
+        authorizationIdentity: '<authorizationIdentity>',
+        secretAccessKey: '<secretAccessKey>',
       },
-      newLogger()
-    )
+      connection: {
+        host: 'host',
+        port: 9092,
+      },
+      logger: newLogger(),
+    })
     await expect(awsIam.authenticate()).rejects.toThrow('SASL AWS-IAM: Missing accessKeyId')
   })
 
   it('throws KafkaJSSASLAuthenticationError for invalid secretAccessKey', async () => {
-    const awsIam = new AWSIAM(
-      { sasl: { authorizationIdentity: '<authorizationIdentity>', accessKeyId: '<accessKeyId>' } },
-      newLogger()
-    )
+    const awsIam = AWSIAM({
+      sasl: {
+        authorizationIdentity: '<authorizationIdentity>',
+        accessKeyId: '<accessKeyId>',
+      },
+      connection: {
+        host: 'host',
+        port: 9092,
+      },
+      logger: newLogger(),
+    })
     await expect(awsIam.authenticate()).rejects.toThrow('SASL AWS-IAM: Missing secretAccessKey')
   })
 })

--- a/src/broker/saslAuthenticator/index.js
+++ b/src/broker/saslAuthenticator/index.js
@@ -1,24 +1,11 @@
 const { requests, lookup } = require('../../protocol/requests')
 const apiKeys = require('../../protocol/requests/apiKeys')
-const PlainAuthenticator = require('./plain')
-const SCRAM256Authenticator = require('./scram256')
-const SCRAM512Authenticator = require('./scram512')
-const AWSIAMAuthenticator = require('./awsIam')
-const OAuthBearerAuthenticator = require('./oauthBearer')
 const { KafkaJSSASLAuthenticationError } = require('../../errors')
+const { AuthenticationMechanisms } = require('./authenticators')
 
-const AUTHENTICATORS = {
-  PLAIN: PlainAuthenticator,
-  'SCRAM-SHA-256': SCRAM256Authenticator,
-  'SCRAM-SHA-512': SCRAM512Authenticator,
-  AWS: AWSIAMAuthenticator,
-  OAUTHBEARER: OAuthBearerAuthenticator,
-}
-
-const SUPPORTED_MECHANISMS = Object.keys(AUTHENTICATORS)
 const UNLIMITED_SESSION_LIFETIME = '0'
 
-module.exports = class SASLAuthenticator {
+class SASLAuthenticator {
   constructor(connection, logger, versions, supportAuthenticationProtocol) {
     this.connection = connection
     this.logger = logger
@@ -33,7 +20,7 @@ module.exports = class SASLAuthenticator {
 
   async authenticate() {
     const mechanism = this.connection.sasl.mechanism.toUpperCase()
-    if (!SUPPORTED_MECHANISMS.includes(mechanism)) {
+    if (!Object.keys(AuthenticationMechanisms).includes(mechanism)) {
       throw new KafkaJSSASLAuthenticationError(
         `SASL ${mechanism} mechanism is not supported by the client`
       )
@@ -46,9 +33,9 @@ module.exports = class SASLAuthenticator {
       )
     }
 
-    const saslAuthenticate = async ({ request, response, authExpectResponse }) => {
+    const saslAuthenticate = async ({ request, response }) => {
       if (this.protocolAuthentication) {
-        const { buffer: requestAuthBytes } = await request.encode()
+        const requestAuthBytes = await request.encode()
         const authResponse = await this.connection.send(
           this.protocolAuthentication({ authBytes: requestAuthBytes })
         )
@@ -57,7 +44,7 @@ module.exports = class SASLAuthenticator {
         // This is not present in SaslAuthenticateV0, so we default to `"0"`
         this.sessionLifetime = authResponse.sessionLifetimeMs || UNLIMITED_SESSION_LIFETIME
 
-        if (!authExpectResponse) {
+        if (!response) {
           return
         }
 
@@ -66,10 +53,23 @@ module.exports = class SASLAuthenticator {
         return response.parse(payloadDecoded)
       }
 
-      return this.connection.authenticate({ request, response, authExpectResponse })
+      return this.connection.authenticate({ request })
     }
 
-    const Authenticator = AUTHENTICATORS[mechanism]
-    await new Authenticator(this.connection, this.logger, saslAuthenticate).authenticate()
+    const createAuthenticationMechanism = AuthenticationMechanisms[mechanism]()
+    await createAuthenticationMechanism({
+      sasl: this.connection.sasl,
+      connection: {
+        host: this.connection.host,
+        port: this.connection.port,
+      },
+      logger: this.logger.namespace(`SaslAuthenticator-${mechanism}`),
+      saslAuthenticate,
+    }).authenticate()
   }
+}
+
+module.exports = {
+  SASLAuthenticator,
+  AuthenticationMechanisms,
 }

--- a/src/broker/saslAuthenticator/oauthBearer.js
+++ b/src/broker/saslAuthenticator/oauthBearer.js
@@ -10,47 +10,42 @@
  * reused and refreshed when appropriate.
  */
 
-const oauthBearer = require('../../protocol/sasl/oauthBearer')
+const { request } = require('../../protocol/sasl/oauthBearer')
 const { KafkaJSSASLAuthenticationError } = require('../../errors')
 
-module.exports = class OAuthBearerAuthenticator {
-  constructor(connection, logger, saslAuthenticate) {
-    this.connection = connection
-    this.logger = logger.namespace('SASLOAuthBearerAuthenticator')
-    this.saslAuthenticate = saslAuthenticate
-  }
+function OAuthBearerAuthenticator({ sasl, connection, logger, saslAuthenticate }) {
+  return {
+    authenticate: async () => {
+      if (sasl.oauthBearerProvider == null) {
+        throw new KafkaJSSASLAuthenticationError(
+          'SASL OAUTHBEARER: Missing OAuth bearer token provider'
+        )
+      }
 
-  async authenticate() {
-    const { sasl } = this.connection
-    if (sasl.oauthBearerProvider == null) {
-      throw new KafkaJSSASLAuthenticationError(
-        'SASL OAUTHBEARER: Missing OAuth bearer token provider'
-      )
-    }
+      const { oauthBearerProvider } = sasl
 
-    const { oauthBearerProvider } = sasl
+      const oauthBearerToken = await oauthBearerProvider()
 
-    const oauthBearerToken = await oauthBearerProvider()
+      if (oauthBearerToken.value == null) {
+        throw new KafkaJSSASLAuthenticationError('SASL OAUTHBEARER: Invalid OAuth bearer token')
+      }
 
-    if (oauthBearerToken.value == null) {
-      throw new KafkaJSSASLAuthenticationError('SASL OAUTHBEARER: Invalid OAuth bearer token')
-    }
+      const { host, port } = connection
+      const broker = `${host}:${port}`
 
-    const request = await oauthBearer.request(sasl, oauthBearerToken)
-    const response = oauthBearer.response
-    const { host, port } = this.connection
-    const broker = `${host}:${port}`
-
-    try {
-      this.logger.debug('Authenticate with SASL OAUTHBEARER', { broker })
-      await this.saslAuthenticate({ request, response })
-      this.logger.debug('SASL OAUTHBEARER authentication successful', { broker })
-    } catch (e) {
-      const error = new KafkaJSSASLAuthenticationError(
-        `SASL OAUTHBEARER authentication failed: ${e.message}`
-      )
-      this.logger.error(error.message, { broker })
-      throw error
-    }
+      try {
+        logger.debug('Authenticate with SASL OAUTHBEARER', { broker })
+        await saslAuthenticate({ request: await request(sasl, oauthBearerToken) })
+        logger.debug('SASL OAUTHBEARER authentication successful', { broker })
+      } catch (e) {
+        const error = new KafkaJSSASLAuthenticationError(
+          `SASL OAUTHBEARER authentication failed: ${e.message}`
+        )
+        logger.error(error.message, { broker })
+        throw error
+      }
+    },
   }
 }
+
+module.exports = OAuthBearerAuthenticator

--- a/src/broker/saslAuthenticator/oauthBearer.spec.js
+++ b/src/broker/saslAuthenticator/oauthBearer.spec.js
@@ -3,7 +3,11 @@ const OAuthBearer = require('./oauthBearer')
 
 describe('Broker > SASL Authenticator > OAUTHBEARER', () => {
   it('throws KafkaJSSASLAuthenticationError for missing oauthBearerProvider', async () => {
-    const oauthBearer = new OAuthBearer({ sasl: {} }, newLogger())
+    const oauthBearer = OAuthBearer({
+      sasl: {},
+      connection: { host: 'host', port: 9094 },
+      logger: newLogger(),
+    })
     await expect(oauthBearer.authenticate()).rejects.toThrow('Missing OAuth bearer token provider')
   })
 
@@ -12,7 +16,11 @@ describe('Broker > SASL Authenticator > OAUTHBEARER', () => {
       return {}
     }
 
-    const oauthBearer = new OAuthBearer({ sasl: { oauthBearerProvider } }, newLogger())
+    const oauthBearer = OAuthBearer({
+      sasl: { oauthBearerProvider },
+      connection: { host: 'host', port: 9094 },
+      logger: newLogger(),
+    })
     await expect(oauthBearer.authenticate()).rejects.toThrow('Invalid OAuth bearer token')
   })
 })

--- a/src/broker/saslAuthenticator/plain.js
+++ b/src/broker/saslAuthenticator/plain.js
@@ -1,34 +1,29 @@
-const plain = require('../../protocol/sasl/plain')
+const { request } = require('../../protocol/sasl/plain')
 const { KafkaJSSASLAuthenticationError } = require('../../errors')
 
-module.exports = class PlainAuthenticator {
-  constructor(connection, logger, saslAuthenticate) {
-    this.connection = connection
-    this.logger = logger.namespace('SASLPlainAuthenticator')
-    this.saslAuthenticate = saslAuthenticate
-  }
+function PlainAuthenticator({ sasl, connection, logger, saslAuthenticate }) {
+  return {
+    authenticate: async () => {
+      if (sasl.username == null || sasl.password == null) {
+        throw new KafkaJSSASLAuthenticationError('SASL Plain: Invalid username or password')
+      }
 
-  async authenticate() {
-    const { sasl } = this.connection
-    if (sasl.username == null || sasl.password == null) {
-      throw new KafkaJSSASLAuthenticationError('SASL Plain: Invalid username or password')
-    }
+      const { host, port } = connection
+      const broker = `${host}:${port}`
 
-    const request = plain.request(sasl)
-    const response = plain.response
-    const { host, port } = this.connection
-    const broker = `${host}:${port}`
-
-    try {
-      this.logger.debug('Authenticate with SASL PLAIN', { broker })
-      await this.saslAuthenticate({ request, response })
-      this.logger.debug('SASL PLAIN authentication successful', { broker })
-    } catch (e) {
-      const error = new KafkaJSSASLAuthenticationError(
-        `SASL PLAIN authentication failed: ${e.message}`
-      )
-      this.logger.error(error.message, { broker })
-      throw error
-    }
+      try {
+        logger.debug('Authenticate with SASL PLAIN', { broker })
+        await saslAuthenticate({ request: request(sasl) })
+        logger.debug('SASL PLAIN authentication successful', { broker })
+      } catch (e) {
+        const error = new KafkaJSSASLAuthenticationError(
+          `SASL PLAIN authentication failed: ${e.message}`
+        )
+        logger.error(error.message, { broker })
+        throw error
+      }
+    },
   }
 }
+
+module.exports = PlainAuthenticator

--- a/src/broker/saslAuthenticator/plain.spec.js
+++ b/src/broker/saslAuthenticator/plain.spec.js
@@ -3,12 +3,22 @@ const Plain = require('./plain')
 
 describe('Broker > SASL Authenticator > PLAIN', () => {
   it('throws KafkaJSSASLAuthenticationError for invalid username', async () => {
-    const plain = new Plain({ sasl: {} }, newLogger())
+    const plain = Plain({
+      sasl: {},
+      connection: {},
+      logger: newLogger(),
+      saslAuthenticate: async () => {},
+    })
     await expect(plain.authenticate()).rejects.toThrow('Invalid username or password')
   })
 
   it('throws KafkaJSSASLAuthenticationError for invalid password', async () => {
-    const plain = new Plain({ sasl: { username: '<username>' } }, newLogger())
+    const plain = Plain({
+      sasl: { username: '<username>' },
+      connection: {},
+      logger: newLogger(),
+      saslAuthenticate: async () => {},
+    })
     await expect(plain.authenticate()).rejects.toThrow('Invalid username or password')
   })
 })

--- a/src/broker/saslAuthenticator/scram.spec.js
+++ b/src/broker/saslAuthenticator/scram.spec.js
@@ -1,29 +1,35 @@
 const Decoder = require('../../protocol/decoder')
 const { newLogger } = require('testHelpers')
 const SCRAM256 = require('./scram256')
+const { SCRAM, DIGESTS } = require('./scram')
 
 describe('Broker > SASL Authenticator > SCRAM', () => {
-  let connection, saslAuthenticate, logger
+  let connection, saslAuthenticate, logger, sasl
 
   beforeEach(() => {
+    sasl = { username: 'user', password: 'pencil' }
     connection = {
-      authenticate: jest.fn(),
-      sasl: { username: 'user', password: 'pencil' },
+      host: 'host',
+      port: 9094,
     }
-    saslAuthenticate = ({ request, response, authExpectResponse }) =>
-      connection.authenticate({ request, response, authExpectResponse })
+    saslAuthenticate = jest.fn()
 
     logger = { debug: jest.fn() }
     logger.namespace = () => logger
   })
 
   it('throws KafkaJSSASLAuthenticationError for invalid username', async () => {
-    const scram = new SCRAM256({ sasl: {} }, newLogger(), saslAuthenticate)
+    const scram = SCRAM256({ sasl: {}, connection, logger: newLogger(), saslAuthenticate })
     await expect(scram.authenticate()).rejects.toThrow('Invalid username or password')
   })
 
   it('throws KafkaJSSASLAuthenticationError for invalid password', async () => {
-    const scram = new SCRAM256({ sasl: { username: '<username>' } }, newLogger(), saslAuthenticate)
+    const scram = SCRAM256({
+      sasl: { username: '<username>' },
+      connection,
+      logger: newLogger(),
+      saslAuthenticate,
+    })
     await expect(scram.authenticate()).rejects.toThrow('Invalid username or password')
   })
 
@@ -31,11 +37,11 @@ describe('Broker > SASL Authenticator > SCRAM', () => {
     let scram
 
     beforeEach(() => {
-      scram = new SCRAM256(connection, logger, saslAuthenticate)
+      scram = new SCRAM(sasl, connection, logger, saslAuthenticate, DIGESTS.SHA256)
     })
 
     test('saltPassword', async () => {
-      connection.sasl.password = 'password'
+      sasl.password = 'password'
       const clientMessageResponse = {
         s: 'enBxNzV4aGphMjJmbnZ0ejF5M2o4Y3JjdA==',
         i: '4096',
@@ -47,7 +53,7 @@ describe('Broker > SASL Authenticator > SCRAM', () => {
     })
 
     test('clientKey', async () => {
-      connection.sasl.password = 'password'
+      sasl.password = 'password'
       const clientMessageResponse = {
         s: 'enBxNzV4aGphMjJmbnZ0ejF5M2o4Y3JjdA==',
         i: '4096',
@@ -59,7 +65,7 @@ describe('Broker > SASL Authenticator > SCRAM', () => {
     })
 
     test('storedKey', async () => {
-      connection.sasl.password = 'password'
+      sasl.password = 'password'
       const clientMessageResponse = {
         s: 'enBxNzV4aGphMjJmbnZ0ejF5M2o4Y3JjdA==',
         i: '4096',
@@ -75,45 +81,42 @@ describe('Broker > SASL Authenticator > SCRAM', () => {
       test('regular use case', async () => {
         scram.currentNonce = 'rOprNGfwEbeRWgbNEkqO'
         await scram.sendClientFirstMessage()
-        expect(connection.authenticate).toHaveBeenCalledWith({
-          authExpectResponse: true,
+        expect(saslAuthenticate).toHaveBeenCalledWith({
           request: expect.any(Object),
           response: expect.any(Object),
         })
 
-        const { request } = connection.authenticate.mock.calls[0][0]
-        const encoder = await request.encode()
-        const decoder = new Decoder(encoder.buffer)
+        const { request } = saslAuthenticate.mock.calls[0][0]
+        const buffer = await request.encode()
+        const decoder = new Decoder(buffer)
         expect(decoder.readBytes().toString()).toEqual(`n,,n=user,r=${scram.currentNonce}`)
       })
 
       test('username with comma', async () => {
-        connection.sasl.username = 'bob,'
+        sasl.username = 'bob,'
         await scram.sendClientFirstMessage()
-        expect(connection.authenticate).toHaveBeenCalledWith({
-          authExpectResponse: true,
+        expect(saslAuthenticate).toHaveBeenCalledWith({
           request: expect.any(Object),
           response: expect.any(Object),
         })
 
-        const { request } = connection.authenticate.mock.calls[0][0]
-        const encoder = await request.encode()
-        const decoder = new Decoder(encoder.buffer)
+        const { request } = saslAuthenticate.mock.calls[0][0]
+        const buffer = await request.encode()
+        const decoder = new Decoder(buffer)
         expect(decoder.readBytes().toString()).toEqual(`n,,n=bob=2C,r=${scram.currentNonce}`)
       })
 
       test('username with equals', async () => {
-        connection.sasl.username = 'bob='
+        sasl.username = 'bob='
         await scram.sendClientFirstMessage()
-        expect(connection.authenticate).toHaveBeenCalledWith({
-          authExpectResponse: true,
+        expect(saslAuthenticate).toHaveBeenCalledWith({
           request: expect.any(Object),
           response: expect.any(Object),
         })
 
-        const { request } = connection.authenticate.mock.calls[0][0]
-        const encoder = await request.encode()
-        const decoder = new Decoder(encoder.buffer)
+        const { request } = saslAuthenticate.mock.calls[0][0]
+        const buffer = await request.encode()
+        const decoder = new Decoder(buffer)
         expect(decoder.readBytes().toString()).toEqual(`n,,n=bob=3D,r=${scram.currentNonce}`)
       })
     })
@@ -130,15 +133,14 @@ describe('Broker > SASL Authenticator > SCRAM', () => {
         }
 
         await scram.sendClientFinalMessage(clientMessageResponse)
-        expect(connection.authenticate).toHaveBeenCalledWith({
-          authExpectResponse: true,
+        expect(saslAuthenticate).toHaveBeenCalledWith({
           request: expect.any(Object),
           response: expect.any(Object),
         })
 
-        const { request } = connection.authenticate.mock.calls[0][0]
-        const encoder = await request.encode()
-        const decoder = new Decoder(encoder.buffer)
+        const { request } = saslAuthenticate.mock.calls[0][0]
+        const buffer = await request.encode()
+        const decoder = new Decoder(buffer)
         expect(decoder.readBytes().toString()).toEqual(
           'c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ='
         )

--- a/src/broker/saslAuthenticator/scram256.js
+++ b/src/broker/saslAuthenticator/scram256.js
@@ -1,7 +1,11 @@
 const { SCRAM, DIGESTS } = require('./scram')
 
-module.exports = class SCRAM256Authenticator extends SCRAM {
-  constructor(connection, logger, saslAuthenticate) {
-    super(connection, logger.namespace('SCRAM256Authenticator'), saslAuthenticate, DIGESTS.SHA256)
+function SCRAM256Authenticator({ sasl, connection, logger, saslAuthenticate }) {
+  const scram = new SCRAM(sasl, connection, logger, saslAuthenticate, DIGESTS.SHA256)
+
+  return {
+    authenticate: async () => scram.authenticate(),
   }
 }
+
+module.exports = SCRAM256Authenticator

--- a/src/broker/saslAuthenticator/scram512.js
+++ b/src/broker/saslAuthenticator/scram512.js
@@ -1,7 +1,11 @@
 const { SCRAM, DIGESTS } = require('./scram')
 
-module.exports = class SCRAM512Authenticator extends SCRAM {
-  constructor(connection, logger, saslAuthenticate) {
-    super(connection, logger.namespace('SCRAM512Authenticator'), saslAuthenticate, DIGESTS.SHA512)
+function SCRAM256Authenticator({ sasl, connection, logger, saslAuthenticate }) {
+  const scram = new SCRAM(sasl, connection, logger, saslAuthenticate, DIGESTS.SHA512)
+
+  return {
+    authenticate: async () => scram.authenticate(),
   }
 }
+
+module.exports = SCRAM256Authenticator

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -223,8 +223,8 @@ module.exports = class Connection {
    * @public
    * @returns {Promise}
    */
-  authenticate({ authExpectResponse = false, request, response }) {
-    this.authExpectResponse = authExpectResponse
+  authenticate({ request, response }) {
+    this.authExpectResponse = !!response
 
     /**
      * TODO: rewrite removing the async promise executor

--- a/src/protocol/sasl/awsIam/index.js
+++ b/src/protocol/sasl/awsIam/index.js
@@ -1,4 +1,3 @@
 module.exports = {
   request: require('./request'),
-  response: require('./response'),
 }

--- a/src/protocol/sasl/awsIam/request.js
+++ b/src/protocol/sasl/awsIam/request.js
@@ -6,6 +6,6 @@ module.exports = ({ authorizationIdentity, accessKeyId, secretAccessKey, session
   encode: async () => {
     return new Encoder().writeBytes(
       [authorizationIdentity, accessKeyId, secretAccessKey, sessionToken].join(US_ASCII_NULL_CHAR)
-    )
+    ).buffer
   },
 })

--- a/src/protocol/sasl/awsIam/response.js
+++ b/src/protocol/sasl/awsIam/response.js
@@ -1,4 +1,0 @@
-module.exports = {
-  decode: async () => true,
-  parse: async () => true,
-}

--- a/src/protocol/sasl/oauthBearer/index.js
+++ b/src/protocol/sasl/oauthBearer/index.js
@@ -1,4 +1,3 @@
 module.exports = {
   request: require('./request'),
-  response: require('./response'),
 }

--- a/src/protocol/sasl/oauthBearer/request.js
+++ b/src/protocol/sasl/oauthBearer/request.js
@@ -56,7 +56,7 @@ module.exports = async ({ authorizationIdentity = null }, oauthBearerToken) => {
 
   return {
     encode: async () => {
-      return new Encoder().writeBytes(Buffer.from(oauthMsg))
+      return new Encoder().writeBytes(Buffer.from(oauthMsg)).buffer
     },
   }
 }

--- a/src/protocol/sasl/oauthBearer/response.js
+++ b/src/protocol/sasl/oauthBearer/response.js
@@ -1,4 +1,0 @@
-module.exports = {
-  decode: async () => true,
-  parse: async () => true,
-}

--- a/src/protocol/sasl/plain/index.js
+++ b/src/protocol/sasl/plain/index.js
@@ -1,4 +1,3 @@
 module.exports = {
   request: require('./request'),
-  response: require('./response'),
 }

--- a/src/protocol/sasl/plain/request.js
+++ b/src/protocol/sasl/plain/request.js
@@ -23,6 +23,6 @@ module.exports = ({ authorizationIdentity = null, username, password }) => ({
   encode: async () => {
     return new Encoder().writeBytes(
       [authorizationIdentity, username, password].join(US_ASCII_NULL_CHAR)
-    )
+    ).buffer
   },
 })

--- a/src/protocol/sasl/plain/response.js
+++ b/src/protocol/sasl/plain/response.js
@@ -1,4 +1,0 @@
-module.exports = {
-  decode: async () => true,
-  parse: async () => true,
-}

--- a/src/protocol/sasl/scram/finalMessage/request.js
+++ b/src/protocol/sasl/scram/finalMessage/request.js
@@ -1,5 +1,5 @@
 const Encoder = require('../../../encoder')
 
 module.exports = ({ finalMessage }) => ({
-  encode: async () => new Encoder().writeBytes(finalMessage),
+  encode: async () => new Encoder().writeBytes(finalMessage).buffer,
 })

--- a/src/protocol/sasl/scram/firstMessage/request.js
+++ b/src/protocol/sasl/scram/firstMessage/request.js
@@ -18,5 +18,5 @@
 const Encoder = require('../../../encoder')
 
 module.exports = ({ clientFirstMessage }) => ({
-  encode: async () => new Encoder().writeBytes(clientFirstMessage),
+  encode: async () => new Encoder().writeBytes(clientFirstMessage).buffer,
 })

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -21,8 +21,12 @@ import {
   KafkaJSTopicMetadataNotLoaded,
   KafkaJSStaleTopicMetadataAssignment,
   PartitionMetadata,
-  KafkaJSServerDoesNotSupportApiKey,
+  KafkaJSServerDoesNotSupportApiKey
 } from './index'
+
+interface SASLMechanismOptionsMap {
+  "FAKE-MECHANISM": { myProp1: string, myProp2: string }
+}
 
 const { roundRobin } = PartitionAssigners
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -9,6 +9,7 @@
       "consuming",
       "admin",
       "instrumentation-events",
+      "custom-authentication-mechanism",
       "custom-logger",
       "retry-detailed",
       "faq",


### PR DESCRIPTION
This allows users to inject their own custom authentication mechanisms, similar to what's done for compression codecs.

```js
const { AuthenticationMechanisms } = require('kafkajs')
const { Mechanism, Type } = require('customauth')

AuthenticationMechanisms[Type] = () => Mechanism
```

The existing authentication mechanisms use the same interface, which meant I had to rework them some. Primarily, I moved them from being classes to functions. This isn't strictly necessary, but I find it easier to have people implement a function than to have them extend a class or similar - especially if they are using different compile-to-js languages.

The other thing was that I changed the interface to not expose any internal classes. That means moving from Encoders/Decoders to just buffers, and to not pass in the Connection anymore, and instead provide the `sasl` options and the broker host + port.

One thing that is missing is documentation on Typescript usage. After getting some advice from the internet, I opted for a closed type for the `AuthenticationMechanisms`, so someone implementing their own authentication mechanism in Typescript should use declaration merging to extend that type with their own type. But I haven't tried this out yet myself, which is why I haven't documented it yet.

Fixes #840 