### PR TITLE
Add function to override metadata brokers

### DIFF
--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -41,6 +41,7 @@ module.exports = class Cluster {
    * @param {import("../../types").ISocketFactory} options.socketFactory
    * @param {Map} [options.offsets]
    * @param {import("../instrumentation/emitter")} [options.instrumentationEmitter=null]
+   * @param {function} [options.getMetadataBrokers]
    */
   constructor({
     logger: rootLogger,
@@ -61,6 +62,7 @@ module.exports = class Cluster {
     isolationLevel,
     instrumentationEmitter = null,
     offsets = new Map(),
+    getMetadataBrokers,
   }) {
     this.rootLogger = rootLogger
     this.logger = rootLogger.namespace('Cluster')
@@ -93,6 +95,7 @@ module.exports = class Cluster {
       authenticationTimeout,
       reauthenticationThreshold,
       metadataMaxAge,
+      getMetadataBrokers,
     })
     this.committedOffsetsByGroup = offsets
   }

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ module.exports = class Client {
    * @param {boolean} [options.enforceRequestTimeout]
    * @param {import("../types").RetryOptions} [options.retry]
    * @param {import("../types").ISocketFactory} [options.socketFactory]
+   * @param {function} [options.getMetadataBrokers]
    */
   constructor({
     brokers,
@@ -50,6 +51,7 @@ module.exports = class Client {
     socketFactory = defaultSocketFactory(),
     logLevel = INFO,
     logCreator = LoggerConsole,
+    getMetadataBrokers,
   }) {
     this[PRIVATE.OFFSETS] = new Map()
     this[PRIVATE.LOGGER] = createLogger({ level: logLevel, logCreator })
@@ -80,6 +82,7 @@ module.exports = class Client {
         allowAutoTopicCreation,
         maxInFlightRequests,
         isolationLevel,
+        getMetadataBrokers,
       })
   }
 


### PR DESCRIPTION
If we are connecting to a kafka cluster via ssh tunnel. We cannot connect to the brokers that the cluster meta data provided. So this provides a way for us to override the brokers provided by the metadata so we can connect to the ip and port we are tunneling through.

This can be useful in any case where the client cannot connect directly to the host name and port that is set in the metadata. Another use case would be when using port forwarding via the kubernates cli. 