### PR TITLE
Fix failing connection test in WSL2

### DIFF
--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -9,10 +9,6 @@ const { CONNECTION_STATUS } = require('./connectionStatus')
 const EventEmitter = require('events')
 
 describe('Network > Connection', () => {
-  // According to RFC 5737:
-  // The blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2),
-  // and 203.0.113.0/24 (TEST-NET-3) are provided for use in documentation.
-  const invalidIP = '203.0.113.1'
   const invalidHost = 'kafkajs.test'
   let connection
 


### PR DESCRIPTION
Replaces the Socket in the connection timeout test with a fake socket to avoid triggering
the error handler before the timeout handler. Apparently we get a sychronous error in
WSL2 when the address is unreachable, so the timeout handler was never called.

Fixes #1109