### PR TITLE
Rename acl -> acls in DescribeAclResource

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -384,7 +384,7 @@ export interface AclResource {
 export type AclEntry = Acl & AclResource
 
 export type DescribeAclResource = AclResource & {
-  acl: Acl[]
+  acls: Acl[]
 }
 
 export interface DescribeAclResponse {

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -226,7 +226,7 @@ const runAdmin = async () => {
       resourceType: r.resourceType,
       resourceName: r.resourceName,
       resourcePatternType: r.resourcePatternType,
-      acls: r.acl,
+      acls: r.acls,
     })),
   })
 


### PR DESCRIPTION
At the moment the type for `DescribeAclResource` has the property `acl` , however as detailed [in the docs for describeAcls](https://kafka.js.org/docs/admin#describe-acl) the data structure that comes back from calling `describeAcls` has the key `acls`.

This PR updates the type to reflect this.