### PR TITLE
Don't set default offset if autoCommit is disabled

### DIFF
--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -633,6 +633,13 @@ module.exports = class ConsumerGroup {
         memberId: this.memberId,
       })
       delete preferredReadReplicas[e.partition]
+    } else if (!this.autoCommit) {
+      this.logger.error('Offset out of range', {
+        topic: e.topic,
+        partition: e.partition,
+        groupId: this.groupId,
+        memberId: this.memberId,
+      })
     } else {
       this.logger.error('Offset out of range, resetting to default offset', {
         topic: e.topic,


### PR DESCRIPTION
`this.autoCommit` is disabled but committed when the offset in consumer.seek goes out of range.
(e.g. offset expired)