### PR TITLE
Offset manager setDefaultOffset check if autoCommit is enabled

### DIFF
--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -143,6 +143,15 @@ module.exports = class OffsetManager {
     const defaultOffset = this.cluster.defaultOffset(this.topicConfigurations[topic])
     const coordinator = await this.getCoordinator()
 
+    if (!this.autoCommit) {
+      this.resolveOffset({
+        topic,
+        partition,
+        offset: defaultOffset,
+      })
+      return
+    }
+
     await coordinator.offsetCommit({
       groupId,
       memberId,


### PR DESCRIPTION
> 2. The offset manager already knows if autoCommit is enabled or not, so if it isn't, setDefaultOffset could just set the resolved offset to be the default offset, instead of committing it. That way the high-level behavior is the same, whether autocommit is enabled or not, but we don't end up committing offsets.

I agree with the second alternative.
So I modified the code. Is this similar to the fix you were thinking of?
@Nevon 

https://github.com/tulios/kafkajs/pull/1133#issuecomment-870280517