### PR TITLE
Use fixed zookeeper image version (5.4.2)

### DIFF
--- a/docker-compose.2_4.yml
+++ b/docker-compose.2_4.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:5.4.2
     hostname: zookeeper
     container_name: zookeeper
     ports:


### PR DESCRIPTION
- Modify `zookeeper` image version to use the same version as `kafka`
  (An error occurred due to a setting change in the `zookeeper` latest version)
  - error logs: `Unable to access datadir, exiting abnormally`