### PR TITLE
Allow a library user to call consumer->disconnect() and for it to stop reconnect attempt

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -129,16 +129,19 @@ module.exports = ({
       partitionsConsumedConcurrently,
     })
   }
+  let allowCrashReconnect = true
 
   /** @type {import("../../types").Consumer["connect"]} */
   const connect = async () => {
+    allowCrashReconnect = true
     await cluster.connect()
     instrumentationEmitter.emit(CONNECT)
   }
 
   /** @type {import("../../types").Consumer["disconnect"]} */
-  const disconnect = async () => {
+  const disconnect = async (lAllowCrashReconnect = false) => {
     try {
+      allowCrashReconnect = lAllowCrashReconnect
       await stop()
       logger.debug('consumer has stopped, disconnecting', { groupId })
       await cluster.disconnect()
@@ -239,6 +242,9 @@ module.exports = ({
     }
 
     const restart = onCrash => {
+      if (!allowCrashReconnect) {
+        return
+      }
       consumerGroup = createConsumerGroup({
         autoCommitInterval,
         autoCommitThreshold,
@@ -258,9 +264,9 @@ module.exports = ({
         cluster.removeBroker({ host: e.host, port: e.port })
       }
 
-      await disconnect()
+      await disconnect(allowCrashReconnect)
 
-      const isErrorRetriable = e.name === 'KafkaJSNumberOfRetriesExceeded' || e.retriable === true
+      const isErrorRetriable = (e.name === 'KafkaJSNumberOfRetriesExceeded' || e.retriable === true)
       const shouldRestart =
         isErrorRetriable &&
         (!retry ||
@@ -281,8 +287,12 @@ module.exports = ({
       instrumentationEmitter.emit(CRASH, {
         error: e,
         groupId,
-        restart: shouldRestart,
+        restart: shouldRestart && allowCrashReconnect,
       })
+
+      if (!allowCrashReconnect) {
+        return
+      }
 
       if (shouldRestart) {
         const retryTime = e.retryTime || (retry && retry.initialRetryTime) || initialRetryTime


### PR DESCRIPTION
as per https://github.com/tulios/kafkajs/issues/1147

When a library user calls disconnect and the library is trying to reconnect to a kafka node, the disconnect is effectively ignored.
A library user cannot clean up connections and close out.

This change fixes that issue.