### PR TITLE
Minor grammar update in docs - Consuming.md

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -173,7 +173,7 @@ When disabling [`autoCommit`](#auto-commit) you can still manually commit messag
 - By [sending message offsets in a transaction](Transactions.md#offsets).
 - By using the `commitOffsets` method of the consumer (see below).
 
-The `consumer.commitOffsets` is the lowest-level option and will ignore all other auto commit settings, but in doing so allows the committed offset to be set to any offset and committing various offsets at once. This can be useful, for example, for building an processing reset tool. It can only be called after `consumer.run`. Committing offsets does not change what message we'll consume next once we've started consuming, but instead is only used to determine **from which place to start**. To immediately change from what offset you're consuming messages, you'll want to [seek](#seek), instead.
+The `consumer.commitOffsets` is the lowest-level option and will ignore all other auto commit settings, but in doing so allows the committed offset to be set to any offset and committing various offsets at once. This can be useful, for example, for building a processing reset tool. It can only be called after `consumer.run`. Committing offsets does not change what message we'll consume next once we've started consuming, but instead is only used to determine **from which place to start**. To immediately change from what offset you're consuming messages, you'll want to [seek](#seek), instead.
 
 ```javascript
 consumer.run({


### PR DESCRIPTION
Grammar error around the use of 'an'

_"for building an processing reset tool"_ should use `a` rather than `an`