### PR TITLE
doc: use forEach instead map

### DIFF
--- a/docs/ConsumerExample.md
+++ b/docs/ConsumerExample.md
@@ -40,7 +40,7 @@ run().catch(e => console.error(`[example/consumer] ${e.message}`, e))
 const errorTypes = ['unhandledRejection', 'uncaughtException']
 const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2']
 
-errorTypes.map(type => {
+errorTypes.forEach(type => {
   process.on(type, async e => {
     try {
       console.log(`process.on ${type}`)
@@ -53,7 +53,7 @@ errorTypes.map(type => {
   })
 })
 
-signalTraps.map(type => {
+signalTraps.forEach(type => {
   process.once(type, async () => {
     try {
       await consumer.disconnect()
@@ -187,7 +187,7 @@ run().catch(e => console.error(`[example/consumer] ${e.message}`, e))
 const errorTypes = ['unhandledRejection', 'uncaughtException']
 const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2']
 
-errorTypes.map(type => {
+errorTypes.forEach(type => {
   process.on(type, async e => {
     try {
       console.log(`process.on ${type}`)
@@ -200,7 +200,7 @@ errorTypes.map(type => {
   })
 })
 
-signalTraps.map(type => {
+signalTraps.forEach(type => {
   process.once(type, async () => {
     try {
       await consumer.disconnect()


### PR DESCRIPTION
In the examples, the .map function should be a .forEach function instead.