### PR TITLE
Fixed connections to brokers that share the same host and port

### DIFF
--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -37,6 +37,7 @@ module.exports = class Broker {
    *                                                are true, topics that don't exist will be created when
    *                                                fetching metadata.
    * @param {boolean} [options.supportAuthenticationProtocol=null] If the server supports the SASLAuthenticate protocol
+   * @param {() => void)} [options.onDisconnect=null] A callback function that is called on disconnect
    */
   constructor({
     connection,
@@ -47,6 +48,7 @@ module.exports = class Broker {
     reauthenticationThreshold = 10000,
     allowAutoTopicCreation = true,
     supportAuthenticationProtocol = null,
+    onDisconnect = null,
   }) {
     this.connection = connection
     this.nodeId = nodeId
@@ -57,6 +59,7 @@ module.exports = class Broker {
     this.reauthenticationThreshold = reauthenticationThreshold
     this.allowAutoTopicCreation = allowAutoTopicCreation
     this.supportAuthenticationProtocol = supportAuthenticationProtocol
+    this.onDisconnect = onDisconnect
 
     this.authenticatedAt = null
     this.sessionLifetime = Long.ZERO
@@ -142,6 +145,10 @@ module.exports = class Broker {
   async disconnect() {
     this.authenticatedAt = null
     await this.connection.disconnect()
+
+    if (this.onDisconnect) {
+      this.onDisconnect(this)
+    }
   }
 
   /**

--- a/src/cluster/__tests__/brokerPool.spec.js
+++ b/src/cluster/__tests__/brokerPool.spec.js
@@ -244,12 +244,10 @@ describe('Cluster > BrokerPool', () => {
       await brokerPool.refreshMetadata([topicName])
 
       const nodeId = 'fakebroker'
-      const fakeBroker = new Broker({
-        nodeId,
+      const fakeBroker = brokerPool.createBroker({
         connection: createConnection(),
         logger: newLogger(),
       })
-      fakeBroker.connection.onDisconnect = () => brokerPool.removeBroker({ broker: fakeBroker })
 
       jest.spyOn(fakeBroker, 'disconnect')
       brokerPool.brokers[nodeId] = fakeBroker
@@ -426,7 +424,6 @@ describe('Cluster > BrokerPool', () => {
         connection: createConnection(),
         logger: newLogger(),
       })
-      mockBroker.connection.onDisconnect = () => brokerPool.removeBroker({ broker: mockBroker })
 
       jest.spyOn(mockBroker, 'connect').mockImplementationOnce(() => {
         throw createErrorFromCode(errorCodes.find(({ type }) => type === 'ILLEGAL_SASL_STATE').code)

--- a/src/cluster/__tests__/brokerPool.spec.js
+++ b/src/cluster/__tests__/brokerPool.spec.js
@@ -90,7 +90,7 @@ describe('Cluster > BrokerPool', () => {
       await broker.connect()
       expect(broker.isConnected()).toEqual(true)
 
-      await brokerPool.seedBroker.disconnect()
+      await brokerPool.seedBroker.connection.disconnect()
       expect(brokerPool.seedBroker.isConnected()).toEqual(false)
 
       jest.spyOn(brokerPool.seedBroker, 'connect')
@@ -424,7 +424,6 @@ describe('Cluster > BrokerPool', () => {
         connection: createConnection(),
         logger: newLogger(),
       })
-
       jest.spyOn(mockBroker, 'connect').mockImplementationOnce(() => {
         throw createErrorFromCode(errorCodes.find(({ type }) => type === 'ILLEGAL_SASL_STATE').code)
       })
@@ -432,6 +431,7 @@ describe('Cluster > BrokerPool', () => {
 
       const broker = await brokerPool.findBroker({ nodeId })
       expect(broker.isConnected()).toEqual(true)
+      expect(brokerPool.brokers[nodeId]).toEqual(broker)
     })
 
     it('throws an error when the broker is not found', async () => {

--- a/src/cluster/brokerPool.js
+++ b/src/cluster/brokerPool.js
@@ -165,7 +165,10 @@ module.exports = class BrokerPool {
 
         // Update the seed broker if necessary
         let seedNodeMetadata = this.metadata.brokers.find(
-          broker => broker.host === seedHost && broker.port === seedPort && broker.nodeId === this.seedBroker.nodeId
+          broker =>
+            broker.host === seedHost &&
+            broker.port === seedPort &&
+            broker.nodeId === this.seedBroker.nodeId
         )
         if (!seedNodeMetadata) {
           seedNodeMetadata = this.metadata.brokers.find(
@@ -189,7 +192,7 @@ module.exports = class BrokerPool {
               replacedBrokers.push(result[nodeId])
             }
 
-            if (host === seedHost && port === seedPort && node === this.seedBroker.nodeId) {
+            if (host === seedHost && port === seedPort && nodeId === this.seedBroker.nodeId) {
               return assign(result, {
                 [nodeId]: this.seedBroker,
               })

--- a/src/cluster/brokerPool.js
+++ b/src/cluster/brokerPool.js
@@ -163,21 +163,16 @@ module.exports = class BrokerPool {
 
         const replacedBrokers = []
 
-        // Update the seed broker if necessary
-        let seedNodeMetadata = this.metadata.brokers.find(
-          broker =>
-            broker.host === seedHost &&
-            broker.port === seedPort &&
-            broker.nodeId === this.seedBroker.nodeId
-        )
-        if (!seedNodeMetadata) {
-          seedNodeMetadata = this.metadata.brokers.find(
+        // The seed broker starts without any nodeId or rack
+        // Set those here if necessary
+        if (!this.seedBroker.nodeId) {
+          const seedNodeMetadata = this.metadata.brokers.find(
             broker => broker.host === seedHost && broker.port === seedPort
           )
-        }
-        if (seedNodeMetadata) {
-          this.seedBroker.nodeId = seedNodeMetadata.nodeId
-          this.seedBroker.connection.rack = seedNodeMetadata.rack
+          if (seedNodeMetadata) {
+            this.seedBroker.nodeId = seedNodeMetadata.nodeId
+            this.seedBroker.connection.rack = seedNodeMetadata.rack
+          }
         }
 
         this.brokers = await this.metadata.brokers.reduce(

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -119,16 +119,6 @@ module.exports = class Cluster {
 
   /**
    * @public
-   * @param {object} destination
-   * @param {String} destination.host
-   * @param {Number} destination.port
-   */
-  removeBroker({ host, port }) {
-    this.brokerPool.removeBroker({ host, port })
-  }
-
-  /**
-   * @public
    * @returns {Promise<void>}
    */
   async refreshMetadata() {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -610,10 +610,6 @@ module.exports = class ConsumerGroup {
       await this.recoverFromOffsetOutOfRange(e)
     }
 
-    if (e.name === 'KafkaJSConnectionClosedError') {
-      this.cluster.removeBroker({ host: e.host, port: e.port })
-    }
-
     if (e.name === 'KafkaJSBrokerNotFound' || e.name === 'KafkaJSConnectionClosedError') {
       this.logger.debug(`${e.message}, refreshing metadata and retrying...`)
       await this.cluster.refreshMetadata()

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -254,10 +254,6 @@ module.exports = ({
         stack: e.stack,
       })
 
-      if (e.name === 'KafkaJSConnectionClosedError') {
-        cluster.removeBroker({ host: e.host, port: e.port })
-      }
-
       await disconnect()
 
       const isErrorRetriable = e.name === 'KafkaJSNumberOfRetriesExceeded' || e.retriable === true

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -32,6 +32,7 @@ module.exports = class Connection {
    * @param {number} [options.maxInFlightRequests=null] The maximum number of unacknowledged requests on a connection before
    *                                            enqueuing
    * @param {import("../instrumentation/emitter")} [options.instrumentationEmitter=null]
+   * @param {() => void)} [options.onDisconnect=null] A callback function that is called on disconnect
    */
   constructor({
     host,
@@ -47,6 +48,7 @@ module.exports = class Connection {
     enforceRequestTimeout = false,
     maxInFlightRequests = null,
     instrumentationEmitter = null,
+    onDisconnect = null,
   }) {
     this.host = host
     this.port = port
@@ -61,6 +63,7 @@ module.exports = class Connection {
 
     this.requestTimeout = requestTimeout
     this.connectionTimeout = connectionTimeout
+    this.onDisconnect = onDisconnect
 
     this.bytesBuffered = 0
     this.bytesNeeded = Decoder.int32Size()
@@ -216,6 +219,10 @@ module.exports = class Connection {
 
     this.connectionStatus = CONNECTION_STATUS.DISCONNECTED
     this.logDebug('disconnected')
+
+    if (this.onDisconnect) {
+      this.onDisconnect()
+    }
     return true
   }
 

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -47,7 +47,6 @@ module.exports = class Connection {
     enforceRequestTimeout = false,
     maxInFlightRequests = null,
     instrumentationEmitter = null,
-    onDisconnect = null,
   }) {
     this.host = host
     this.port = port
@@ -217,7 +216,6 @@ module.exports = class Connection {
 
     this.connectionStatus = CONNECTION_STATUS.DISCONNECTED
     this.logDebug('disconnected')
-
     return true
   }
 

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -32,7 +32,6 @@ module.exports = class Connection {
    * @param {number} [options.maxInFlightRequests=null] The maximum number of unacknowledged requests on a connection before
    *                                            enqueuing
    * @param {import("../instrumentation/emitter")} [options.instrumentationEmitter=null]
-   * @param {() => void)} [options.onDisconnect=null] A callback function that is called on disconnect
    */
   constructor({
     host,
@@ -63,7 +62,6 @@ module.exports = class Connection {
 
     this.requestTimeout = requestTimeout
     this.connectionTimeout = connectionTimeout
-    this.onDisconnect = onDisconnect
 
     this.bytesBuffered = 0
     this.bytesNeeded = Decoder.int32Size()
@@ -220,9 +218,6 @@ module.exports = class Connection {
     this.connectionStatus = CONNECTION_STATUS.DISCONNECTED
     this.logDebug('disconnected')
 
-    if (this.onDisconnect) {
-      this.onDisconnect()
-    }
     return true
   }
 

--- a/src/producer/sendMessages.js
+++ b/src/producer/sendMessages.js
@@ -128,10 +128,6 @@ module.exports = ({ logger, cluster, partitioner, eosManager, retrier }) => {
         const responses = Array.from(responsePerBroker.values())
         return flatten(responses)
       } catch (e) {
-        if (e.name === 'KafkaJSConnectionClosedError') {
-          cluster.removeBroker({ host: e.host, port: e.port })
-        }
-
         if (!cluster.isConnected()) {
           logger.debug(`Cluster has disconnected, reconnecting: ${e.message}`, {
             retryCount,


### PR DESCRIPTION
This fixes #1190

The problem was caused by brokers getting overridden by the seed broker, because all nodes share the same host and port in Oracle Cloud's Streaming service. I changed it to update the nodeId and rack (if necessary) before making the list of brokers, which allows us to use a more specific check when returning the seed broker itself.