### PR TITLE
Fix TypeError on logging BigInt

### DIFF
--- a/src/utils/long.js
+++ b/src/utils/long.js
@@ -94,7 +94,7 @@ class Long {
   }
 
   /**
-   * Converts the Long to a string written in the specified radix.
+   * Converts the Long to a string.
    * @returns {string}
    * @override
    */
@@ -117,6 +117,15 @@ class Long {
    */
   toInt() {
     return Number(BigInt.asIntN(32, this.value))
+  }
+
+  /**
+   * Converts the Long to JSON
+   * @returns {string}
+   * @override
+   */
+  toJSON() {
+    return this.toString()
   }
 
   /**

--- a/src/utils/long.spec.js
+++ b/src/utils/long.spec.js
@@ -67,6 +67,14 @@ describe('Utils > Long', () => {
       expect(expectedNumber).toEqual(9223372036854776000)
       expect(typeof expectedNumber).toEqual('number')
     })
+
+    describe('toJSON()', () => {
+      it('should return a string', () => {
+        const serialized = max.toJSON()
+
+        expect(serialized).toEqual('9223372036854775807')
+      })
+    })
   })
 
   describe('Operators', () => {


### PR DESCRIPTION
Fixes #1233

BigInt doesn't have a `toJSON` method, because it can't be serialized and then deserialized using the default JSON serializer in Javascript, so tossing a Long into the logger will throw a TypeError.

It's very difficult to trigger this in the application itself. The only way I've seen it happen is by doing manual committing in a weird timing during consumer startup, but in theory it can happen any time we log a Long.