### PR TITLE
Prevent typeerror when committing offsets for a topic before initialization

### DIFF
--- a/src/consumer/offsetManager/index.js
+++ b/src/consumer/offsetManager/index.js
@@ -290,7 +290,12 @@ module.exports = class OffsetManager {
           (obj, { partition, offset }) => assign(obj, { [partition]: offset }),
           {}
         )
-        assign(this.committedOffsets()[topic], updatedOffsets)
+
+        this[PRIVATE.COMMITTED_OFFSETS][topic] = assign(
+          {},
+          this.committedOffsets()[topic],
+          updatedOffsets
+        )
       })
 
       this.lastCommit = Date.now()


### PR DESCRIPTION
I cannot reproduce this myself, but I have seen a service somehow triggering this in production. I think it's triggered somehow when trying to commit offsets for a topic before the consumer has gone through the fetch loop, or maybe something to do with them using a different consumer instance to commit than they are using to consume. This application is basically storing references to consumers in a lookup table, and replacing the consumers whenever there's any error, which means that they might be calling `consumer.commitOffsets` while the consumer is somewhere in the middle of joining the group or in the middle of shutting down etc. Clearly they shouldn't do that, but any which way KafkaJS shouldn't throw a TypeError here.

The code is assuming that `committedOffsets()[topic]` will always return an object, but in some weird circumstance that's not the case, so it throws a TypeError from trying to do `Object.assign(undefined, offsets)`.