### PR TITLE
Ensure error classes are exported

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const AclResourceTypes = require('./src/protocol/aclResourceTypes')
 const AclOperationTypes = require('./src/protocol/aclOperationTypes')
 const AclPermissionTypes = require('./src/protocol/aclPermissionTypes')
 const ResourcePatternTypes = require('./src/protocol/resourcePatternTypes')
+const Errors = require('./src/errors')
 const { LEVELS } = require('./src/loggers')
 
 module.exports = {
@@ -33,4 +34,5 @@ module.exports = {
   AclPermissionTypes,
   ResourcePatternTypes,
   ConfigSource,
+  ...Errors,
 }


### PR DESCRIPTION
Fixes #982 

The KafkaJS error classes currently aren't exported which makes it hard to distinguish between application errors and kafka errors, especially while developing utils/libraries on top of KafkaJS.

This is especially confusing as the TS types included _do_ export the error classes meaning these errors are only discovered at runtime.