### PR TITLE
exposed `assigned` method from consumer.

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -494,11 +494,24 @@ module.exports = ({
   }
 
   /**
+   * Returns the list assignment for the consumer
+   *
+   * @type {import("../../types").Consumer["assigned"]}
+   */
+  const assigned = () => {
+    if (!consumerGroup) {
+      return []
+    }
+    return consumerGroup.assigned()
+  }
+
+  /**
    * @return {Object} logger
    */
   const getLogger = () => logger
 
   return {
+    assigned,
     connect,
     disconnect,
     subscribe,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -899,6 +899,7 @@ export type ConsumerRunConfig = {
 export type ConsumerSubscribeTopic = { topic: string | RegExp; fromBeginning?: boolean }
 
 export type Consumer = {
+  assigned(): Promise<Assignment[]>
   connect(): Promise<void>
   disconnect(): Promise<void>
   subscribe(topic: ConsumerSubscribeTopic): Promise<void>


### PR DESCRIPTION
**ISSUE**
The issue was as of now `consumer` can not know which partitions has been assigned to it.

**SOLUTION**
`ConsumerGroup` class already had `assigned` method which was not exposed from `consumer` exposed methods. 
- Created a method `assigned` in consumer
- Used `ConsumerGroup.assigned` method
- exported `assigned` method from consumer 