### PR TITLE
Fix issue #987 Unnecessary warning when calling Admin.deleteTopicRecords with offset -1

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1078,7 +1078,7 @@ module.exports = ({
         low: undefined,
       }
       // warn in case of offset below low watermark
-      if (parseInt(offset) < parseInt(low)) {
+      if (parseInt(offset) < parseInt(low) && parseInt(offset)!==-1) {
         logger.warn(
           'The requested offset is before the earliest offset maintained on the partition - no records will be deleted from this partition',
           {

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1078,7 +1078,7 @@ module.exports = ({
         low: undefined,
       }
       // warn in case of offset below low watermark
-      if (parseInt(offset) < parseInt(low) && parseInt(offset)!==-1) {
+      if (parseInt(offset) < parseInt(low) && parseInt(offset) !== -1) {
         logger.warn(
           'The requested offset is before the earliest offset maintained on the partition - no records will be deleted from this partition',
           {


### PR DESCRIPTION
This fixes issue #987 Unnecessary warning when calling Admin.deleteTopicRecords with offset -1

When using offset -1 all records was, and still is, deleted from partition but behavior is changed so that the warning message "The requested offset is before the earliest offset maintained on the partition - no records will be deleted from this partition" is not logged when calling Admin.deleteTopicRecords with offset -1 to delete.

Functionality of deleteTopicRecords is not changed. No tests are influenced by this change.