### PR TITLE
KafkaJSNumberOfRetriesExceeded should reflect the original retry-ability

### DIFF
--- a/src/admin/__tests__/deleteTopicRecords.spec.js
+++ b/src/admin/__tests__/deleteTopicRecords.spec.js
@@ -338,7 +338,7 @@ describe('Admin > deleteTopicRecords', () => {
     }
 
     expect(error).toBeDefined()
-    expect(error.name).toBe('KafkaJSNumberOfRetriesExceeded')
+    expect(error.name).toBe('KafkaJSNonRetriableError')
     expect(error.originalError.name).toBe('KafkaJSDeleteTopicRecordsError')
     expect(error.originalError.retriable).toBe(false)
     expect(error.originalError.partitions).toEqual([
@@ -402,7 +402,7 @@ describe('Admin > deleteTopicRecords', () => {
     }
 
     expect(error).toBeDefined()
-    expect(error.name).toBe('KafkaJSNumberOfRetriesExceeded')
+    expect(error.name).toBe('KafkaJSNonRetriableError')
     expect(error.originalError.name).toBe('KafkaJSDeleteTopicRecordsError')
     expect(error.originalError.retriable).toBe(false)
     expect(error.originalError.partitions).toEqual(

--- a/src/consumer/__tests__/errorRecovery.spec.js
+++ b/src/consumer/__tests__/errorRecovery.spec.js
@@ -160,6 +160,50 @@ describe('Consumer', () => {
     await expect(waitFor(() => eachMessage.mock.calls.length)).resolves.toBe(1)
   })
 
+  it('does not recover from crashes due to not retriable errors', async () => {
+    const groupId = `consumer-group-id-${secureRandom()}`
+    consumer2 = createConsumer({
+      cluster,
+      groupId,
+      logger: newLogger(),
+      heartbeatInterval: 100,
+      maxWaitTimeInMs: 1,
+      maxBytesPerPartition: 180,
+      retry: {
+        retries: 0,
+      },
+    })
+    const crashListener = jest.fn()
+    consumer2.on(consumer.events.CRASH, crashListener)
+
+    const error = new KafkaJSError(new Error('💣'), { retriable: false })
+
+    await consumer2.connect()
+    await consumer2.subscribe({ topic: topicName, fromBeginning: true })
+
+    const coordinator = await cluster.findGroupCoordinator({ groupId })
+    const original = coordinator.joinGroup
+    coordinator.joinGroup = async () => {
+      coordinator.joinGroup = original
+      throw error
+    }
+
+    const eachMessage = jest.fn()
+    await consumer2.run({ eachMessage })
+
+    const key = secureRandom()
+    const message = { key: `key-${key}`, value: `value-${key}` }
+    await producer.send({ acks: 1, topic: topicName, messages: [message] })
+
+    await waitFor(() => crashListener.mock.calls.length > 0)
+    expect(crashListener).toHaveBeenCalledWith({
+      id: expect.any(Number),
+      timestamp: expect.any(Number),
+      type: 'consumer.crash',
+      payload: { error, groupId, restart: false },
+    })
+  })
+
   it('recovers from retriable failures when "restartOnFailure" returns true', async () => {
     const errorMessage = '💣'
     let receivedErrorMessage

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,6 +16,7 @@ class KafkaJSNonRetriableError extends KafkaJSError {
   constructor(e) {
     super(e, { retriable: false })
     this.name = 'KafkaJSNonRetriableError'
+    this.originalError = e
   }
 }
 


### PR DESCRIPTION
The KafkaJSNumberOfRetriesExceed now reflects if the original error was retryable.
If so: The onCrash will restart the consumer (regarding shouldRestartOnFailure)
If not: The onCrash will not.

closes #1271