### PR TITLE
Log warn instead of error when rebalancing

### DIFF
--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -404,7 +404,7 @@ module.exports = class Runner extends EventEmitter {
         }
 
         if (isRebalancing(e)) {
-          this.logger.error('The group is rebalancing, re-joining', {
+          this.logger.warn('The group is rebalancing, re-joining', {
             groupId: this.consumerGroup.groupId,
             memberId: this.consumerGroup.memberId,
             error: e.message,
@@ -499,7 +499,7 @@ module.exports = class Runner extends EventEmitter {
         }
 
         if (isRebalancing(e)) {
-          this.logger.error('The group is rebalancing, re-joining', {
+          this.logger.warn('The group is rebalancing, re-joining', {
             groupId: this.consumerGroup.groupId,
             memberId: this.consumerGroup.memberId,
             error: e.message,


### PR DESCRIPTION
This PR addresses an old issue (https://github.com/tulios/kafkajs/issues/691)

I would suggest that it is easier for devops teams to add extra monitoring for this `warn` then it would be to ignore `error` entries.

If you are open to extending the KafkaConfig, we could also enable this to be set as config setting. Then we could let error be the default, and let users Opt-In to a `warn`.