### PR TITLE
Validate brokers

### DIFF
--- a/src/cluster/__tests__/connectionBuilder.spec.js
+++ b/src/cluster/__tests__/connectionBuilder.spec.js
@@ -85,8 +85,22 @@ describe('Cluster > ConnectionBuilder', () => {
         connectionTimeout,
         logger,
       }).build()
+    ).rejects.toEqual(new KafkaJSNonRetriableError('Failed to connect: brokers should not be null'))
+  })
+
+  it('throws an exception if one of the brokers is not a string', async () => {
+    await expect(
+      connectionBuilder({
+        socketFactory,
+        brokers: ['localhost:1234', undefined],
+        ssl,
+        sasl,
+        clientId,
+        connectionTimeout,
+        logger,
+      }).build()
     ).rejects.toEqual(
-      new KafkaJSNonRetriableError('Failed to connect: brokers parameter should not be null')
+      new KafkaJSNonRetriableError('Failed to connect: broker at index 1 is invalid "undefined"')
     )
   })
 
@@ -101,9 +115,7 @@ describe('Cluster > ConnectionBuilder', () => {
         connectionTimeout,
         logger,
       }).build()
-    ).rejects.toEqual(
-      new KafkaJSConnectionError('Failed to connect: "config.brokers" returned void or empty array')
-    )
+    ).rejects.toEqual(new KafkaJSConnectionError('Failed to connect: brokers should not be null'))
   })
 
   it('throws an KafkaJSConnectionError if brokers is function crashes', async () => {

--- a/src/cluster/connectionBuilder.js
+++ b/src/cluster/connectionBuilder.js
@@ -37,36 +37,49 @@ module.exports = ({
 }) => {
   let index = 0
 
-  const getBrokers = async () => {
+  const isValidBroker = broker => {
+    return broker && typeof broker === 'string' && broker.length > 0
+  }
+
+  const validateBrokers = brokers => {
     if (!brokers) {
-      throw new KafkaJSNonRetriableError(`Failed to connect: brokers parameter should not be null`)
+      throw new KafkaJSNonRetriableError(`Failed to connect: brokers should not be null`)
     }
 
-    // static list
     if (Array.isArray(brokers)) {
       if (!brokers.length) {
         throw new KafkaJSNonRetriableError(`Failed to connect: brokers array is empty`)
       }
-      return brokers
-    }
 
-    // dynamic brokers
+      brokers.forEach((broker, index) => {
+        if (!isValidBroker(broker)) {
+          throw new KafkaJSNonRetriableError(
+            `Failed to connect: broker at index ${index} is invalid "${typeof broker}"`
+          )
+        }
+      })
+    }
+  }
+
+  const getBrokers = async () => {
     let list
-    try {
-      list = await brokers()
-    } catch (e) {
-      const wrappedError = new KafkaJSConnectionError(
-        `Failed to connect: "config.brokers" threw: ${e.message}`
-      )
-      wrappedError.stack = `${wrappedError.name}\n  Caused by: ${e.stack}`
-      throw wrappedError
+
+    if (typeof brokers === 'function') {
+      try {
+        list = await brokers()
+      } catch (e) {
+        const wrappedError = new KafkaJSConnectionError(
+          `Failed to connect: "config.brokers" threw: ${e.message}`
+        )
+        wrappedError.stack = `${wrappedError.name}\n  Caused by: ${e.stack}`
+        throw wrappedError
+      }
+    } else {
+      list = brokers
     }
 
-    if (!list || list.length === 0) {
-      throw new KafkaJSConnectionError(
-        `Failed to connect: "config.brokers" returned void or empty array`
-      )
-    }
+    validateBrokers(list)
+
     return list
   }
 


### PR DESCRIPTION
Unifies the validation between broker function return values and static lists, and will now throw an error if one of the brokers is not a non-zero length string. We could do better to validate that it's a real hostname or ip, but it seems like overkill to catch simple mistakes like having an undefined value in a config or something like that.

Fixes #1229