### PR TITLE
Fix website versioning in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -263,7 +263,7 @@ jobs:
           git add .
           DOC_VERSION=$(echo "$VERSION" | sed -e "s/^refs\/tags\/v//")
           git commit -m "Versioned docs for $DOC_VERSION"
-          git push origin master
+          git push origin HEAD:master
         displayName: commit
         env:
           VERSION: $(Build.SourceBranch)


### PR DESCRIPTION
Pushes local HEAD to the remote master, instead of trying to push to local master, which may not exist.