### PR TITLE
Wrap sequence number and correlation id on max signed int32

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 const EARLIEST_OFFSET = -2
 const LATEST_OFFSET = -1
-const INT_32_MAX_VALUE = Math.pow(2, 32)
+const INT_32_MAX_VALUE = Math.pow(2, 31) - 1
 
 module.exports = {
   EARLIEST_OFFSET,

--- a/src/network/connection.spec.js
+++ b/src/network/connection.spec.js
@@ -320,14 +320,14 @@ describe('Network > Connection', () => {
       expect(connection.correlationId).toEqual(2)
     })
 
-    test('resets to 0 when correlationId is equal to Number.MAX_VALUE', () => {
+    test('resets to 0 when correlationId is equal to max signed int32', () => {
       expect(connection.correlationId).toEqual(0)
 
       connection.nextCorrelationId()
       connection.nextCorrelationId()
       expect(connection.correlationId).toEqual(2)
 
-      connection.correlationId = Number.MAX_VALUE
+      connection.correlationId = Math.pow(2, 31) - 1
       const id1 = connection.nextCorrelationId()
       expect(id1).toEqual(0)
       expect(connection.correlationId).toEqual(1)

--- a/src/producer/eosManager/index.js
+++ b/src/producer/eosManager/index.js
@@ -3,12 +3,12 @@ const Lock = require('../../utils/lock')
 const { KafkaJSNonRetriableError } = require('../../errors')
 const COORDINATOR_TYPES = require('../../protocol/coordinatorTypes')
 const createStateMachine = require('./transactionStateMachine')
+const { INT_32_MAX_VALUE } = require('../../constants')
 const assert = require('assert')
 
 const STATES = require('./transactionStates')
 const NO_PRODUCER_ID = -1
 const SEQUENCE_START = 0
-const INT_32_MAX_VALUE = Math.pow(2, 32)
 const INIT_PRODUCER_RETRIABLE_PROTOCOL_ERRORS = [
   'NOT_COORDINATOR_FOR_GROUP',
   'GROUP_COORDINATOR_NOT_AVAILABLE',

--- a/src/producer/eosManager/index.spec.js
+++ b/src/producer/eosManager/index.spec.js
@@ -68,10 +68,10 @@ describe('Producer > eosManager', () => {
     expect(eosManager.getSequence(topic, 2)).toEqual(0) // Different partition
     expect(eosManager.getSequence('foobar', 1)).toEqual(0) // Different topic
 
-    eosManager.updateSequence(topic, 3, Math.pow(2, 32) - 100)
-    expect(eosManager.getSequence(topic, 3)).toEqual(Math.pow(2, 32) - 100) // Rotates once we reach 2 ^ 32 (max Int32)
+    eosManager.updateSequence(topic, 3, Math.pow(2, 31) - 100)
+    expect(eosManager.getSequence(topic, 3)).toEqual(Math.pow(2, 31) - 100) // Rotates once we reach 2 ^ 31 (max Int32)
     eosManager.updateSequence(topic, 3, 100)
-    expect(eosManager.getSequence(topic, 3)).toEqual(0) // Rotates once we reach 2 ^ 32 (max Int32)
+    expect(eosManager.getSequence(topic, 3)).toEqual(0) // Rotates once we reach 2 ^ 31 (max Int32)
 
     await eosManager.initProducerId()
     expect(eosManager.getSequence(topic, 1)).toEqual(0) // Sequences reset by initProducerId


### PR DESCRIPTION
Previously it was based on an unsigned int32 max value, but the value is encoded in a signed int32 in the protocol.

Fixes #1180