### PR TITLE
Adds StickyPartitioner

### DIFF
--- a/src/producer/partitioners/default/partitioner.js
+++ b/src/producer/partitioners/default/partitioner.js
@@ -1,15 +1,8 @@
 const randomBytes = require('./randomBytes')
+const toPositive = require('./toPositive')
 
 // Based on the java client 0.10.2
 // https://github.com/apache/kafka/blob/0.10.2/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java
-
-/**
- * A cheap way to deterministically convert a number to a positive value. When the input is
- * positive, the original value is returned. When the input number is negative, the returned
- * positive value is the original value bit AND against 0x7fffffff which is not its absolutely
- * value.
- */
-const toPositive = x => x & 0x7fffffff
 
 /**
  * The default partitioning strategy:

--- a/src/producer/partitioners/default/toPositive.js
+++ b/src/producer/partitioners/default/toPositive.js
@@ -1,0 +1,7 @@
+/**
+ * A cheap way to deterministically convert a number to a positive value. When the input is
+ * positive, the original value is returned. When the input number is negative, the returned
+ * positive value is the original value bit AND against 0x7fffffff which is not its absolutely
+ * value.
+ */
+module.exports = x => x & 0x7fffffff

--- a/src/producer/partitioners/index.js
+++ b/src/producer/partitioners/index.js
@@ -1,7 +1,9 @@
 const DefaultPartitioner = require('./default')
 const JavaCompatiblePartitioner = require('./defaultJava')
+const StickyPartitioner = require('./sticky')
 
 module.exports = {
   DefaultPartitioner,
   JavaCompatiblePartitioner,
+  StickyPartitioner,
 }

--- a/src/producer/partitioners/sticky/index.js
+++ b/src/producer/partitioners/sticky/index.js
@@ -1,0 +1,4 @@
+const murmur2 = require('../default/murmur2')
+const createStickyPartitioner = require('./stickyPartitioner')
+
+module.exports = createStickyPartitioner(murmur2)

--- a/src/producer/partitioners/sticky/index.spec.js
+++ b/src/producer/partitioners/sticky/index.spec.js
@@ -1,0 +1,118 @@
+const createPartitioner = require('./index')
+
+describe('Producer > Partitioner > Sticky', () => {
+  let topic, partitioner, partitionMetadata
+
+  beforeEach(() => {
+    topic = 'test-topic-1'
+    partitioner = createPartitioner()
+
+    // Intentionally make the partition list not in partition order
+    // to test the edge cases
+    partitionMetadata = [
+      { partitionId: 1, leader: 1 },
+      { partitionId: 2, leader: 2 },
+      { partitionId: 0, leader: 0 },
+    ]
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('same key yields same partition', () => {
+    const partitionA = partitioner({ topic, partitionMetadata, message: { key: 'test-key' } })
+    const partitionB = partitioner({ topic, partitionMetadata, message: { key: 'test-key' } })
+    expect(partitionA).toEqual(partitionB)
+  })
+
+  test('sticky with unavailable partitions', () => {
+    partitionMetadata[0].leader = -1
+    let countForPartition0 = 0
+    let countForPartition2 = 0
+
+    for (let i = 1; i <= 100; i++) {
+      const partition = partitioner({ topic, partitionMetadata, message: {} })
+      expect([0, 2]).toContain(partition)
+      partition === 0 ? countForPartition0++ : countForPartition2++
+    }
+
+    // The distribution between two available partitions should be even
+    expect(countForPartition0 === 100 || countForPartition2 === 100).toBeTrue()
+  })
+
+  test('partitions are sticky', () => {
+    const partitionCount = {}
+
+    for (let i = 0; i < 30; ++i) {
+      const partition = partitioner({ topic, partitionMetadata, message: {} })
+      const count = partitionCount[partition] || 0
+      partitionCount[partition] = count + 1
+    }
+
+    expect(Object.keys(partitionCount).length).toEqual(1)
+    expect(Object.values(partitionCount)[0]).toEqual(30)
+  })
+
+  test('sticky partition changes between batches', () => {
+    jest.useFakeTimers()
+    const partitionCount = {}
+
+    for (let i = 0; i < 30; ++i) {
+      const partition = partitioner({ topic, partitionMetadata, message: {} })
+      const count = partitionCount[partition] || 0
+      partitionCount[partition] = count + 1
+      if (i % 10 === 0) {
+        jest.advanceTimersByTime(1000)
+      }
+    }
+
+    expect(Object.keys(partitionCount).length).toBeGreaterThan(1)
+    expect(Object.values(partitionCount)[0]).toBeLessThan(30)
+    expect(Object.values(partitionCount)[1]).toBeLessThan(30)
+  })
+
+  test('messages are partitioned in a sticky fashion for each topic', () => {
+    const partitionMetadata = [
+      { partitionId: 1, leader: 1 },
+      { partitionId: 2, leader: 2 },
+    ]
+    const topics = [
+      { topic: 'topic-a', partitionMetadata, partitionCount: {} },
+      { topic: 'topic-b', partitionMetadata, partitionCount: {} },
+    ]
+
+    for (let i = 0; i < 30; ++i) {
+      for (const { topic, partitionMetadata, partitionCount } of topics) {
+        const partition = partitioner({ topic, partitionMetadata, message: {} })
+        const count = partitionCount[partition] || 0
+        partitionCount[partition] = count + 1
+      }
+    }
+
+    expect(Object.keys(topics[0].partitionCount).length).toEqual(1)
+    expect(Object.values(topics[0].partitionCount)[0]).toEqual(30)
+    expect(Object.keys(topics[1].partitionCount).length).toEqual(1)
+    expect(Object.values(topics[1].partitionCount)[0]).toEqual(30)
+  })
+
+  test('returns the configured partition if it exists', () => {
+    const partition = partitioner({
+      topic,
+      partitionMetadata,
+      message: { key: '1', partition: 99 },
+    })
+
+    expect(partition).toEqual(99)
+  })
+
+  test('returns the configured partition even if the partition is falsy', () => {
+    const partition = partitioner({
+      topic,
+      partitionMetadata,
+      message: { key: '1', partition: 0 },
+    })
+
+    expect(partition).toEqual(0)
+  })
+})

--- a/src/producer/partitioners/sticky/stickyPartitionCache.js
+++ b/src/producer/partitioners/sticky/stickyPartitionCache.js
@@ -1,0 +1,63 @@
+const randomBytes = require('../default/randomBytes')
+const toPositive = require('../default/toPositive')
+/**
+ * Based on https://github.com/a0x8o/kafka/blob/master/clients/src/main/java/org/apache/kafka/clients/producer/internals/StickyPartitionCache.java
+ */
+module.exports = class StickyPartitionCache {
+  constructor() {
+    /** @type {Record<string, number>} */
+    this.indexCache = {}
+  }
+
+  /**
+   * @param topic {string}
+   * @param partitionMetadata {import("../../../../types").PartitionMetadata[]} partitions for topic
+   * @returns {number}
+   */
+  partition(topic, partitionMetadata) {
+    const partition = this.indexCache[topic]
+    if (typeof partition === 'undefined') {
+      return this.nextPartition(topic, partitionMetadata, -1)
+    }
+    return partition
+  }
+
+  /**
+   * @param topic {string}
+   * @param partitionMetadata {import("../../../../types").PartitionMetadata[]} partitions for topic
+   * @param prevPartition {number}
+   * @returns {number}
+   */
+  nextPartition(topic, partitionMetadata, prevPartition) {
+    const oldPartition = this.indexCache[topic]
+    let newPartition = oldPartition
+
+    /* Check that the current sticky partition for the topic is either not set or that the partition
+     * that triggered the new batch matches the sticky partition that needs to be changed. */
+    if (typeof oldPartition === 'undefined' || oldPartition === prevPartition) {
+      const availablePartitions = partitionMetadata.filter(p => p.leader >= 0)
+      if (!availablePartitions.length) {
+        const random = toPositive(randomBytes(32).readUInt32BE(0))
+        newPartition = random % partitionMetadata.length
+      } else if (availablePartitions.length === 1) {
+        newPartition = availablePartitions[0].partitionId
+      } else {
+        while (typeof newPartition === 'undefined' || newPartition === oldPartition) {
+          const random = toPositive(randomBytes(32).readUInt32BE(0))
+          newPartition = availablePartitions[random % availablePartitions.length].partitionId
+        }
+      }
+
+      // Only change the sticky partition if it is null or previous matches the current sticky partition
+      if (typeof oldPartition === 'undefined') {
+        if (typeof this.indexCache[topic] === 'undefined') {
+          this.indexCache[topic] = newPartition
+        }
+      } else if (this.indexCache[topic] === prevPartition) {
+        this.indexCache[topic] = newPartition
+      }
+    }
+
+    return this.indexCache[topic]
+  }
+}

--- a/src/producer/partitioners/sticky/stickyPartitioner.js
+++ b/src/producer/partitioners/sticky/stickyPartitioner.js
@@ -1,0 +1,52 @@
+const StickyPartitionCache = require('./stickyPartitionCache')
+const toPositive = require('../default/toPositive')
+/**
+ * Tries to batch messages to a single partition as an optimization
+ */
+module.exports = murmur2 => () => {
+  const stickyPartitionCache = new StickyPartitionCache()
+
+  // Used to try to detect batches of messages. Switches sticky partition when expires
+  let lastPartitionTimeoutId = null
+  let changeStickyPartition = true
+  const EXPIRE_AFTER_MS = 500
+
+  /**
+   * @param opts {{
+   *  topic: string;
+   *  partitionMetadata: import("../../../../types").PartitionMetadata[];
+   *  message: import("../../../../types").Message;
+   * }}
+   */
+  return opts => {
+    const { topic, partitionMetadata, message } = opts
+    const numPartitions = partitionMetadata.length
+    if (typeof message.partition === 'number') {
+      return message.partition
+    }
+
+    if (typeof message.key === 'undefined' || message.key === null) {
+      let result = null
+      if (changeStickyPartition) {
+        result = stickyPartitionCache.nextPartition(
+          topic,
+          partitionMetadata,
+          stickyPartitionCache.indexCache[topic]
+        )
+        changeStickyPartition = false
+      } else {
+        result = stickyPartitionCache.partition(topic, partitionMetadata)
+      }
+
+      // If no requests follow this one, use a new sticky partition
+      clearTimeout(lastPartitionTimeoutId)
+      lastPartitionTimeoutId = setTimeout(() => {
+        changeStickyPartition = true
+      }, EXPIRE_AFTER_MS)
+
+      return result
+    }
+
+    return toPositive(murmur2(message.key)) % numPartitions
+  }
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,10 +92,12 @@ export interface PartitionerArgs {
 export type ICustomPartitioner = () => (args: PartitionerArgs) => number
 export type DefaultPartitioner = ICustomPartitioner
 export type JavaCompatiblePartitioner = ICustomPartitioner
+export type StickyPartitioner = ICustomPartitioner
 
 export const Partitioners: {
   DefaultPartitioner: DefaultPartitioner
   JavaCompatiblePartitioner: JavaCompatiblePartitioner
+  StickyPartitioner: StickyPartitioner
 }
 
 export type PartitionMetadata = {


### PR DESCRIPTION
This change adds a new partitioner that works more like [the default partitioner in the java client](https://github.com/a0x8o/kafka/blob/master/clients/src/main/java/org/apache/kafka/clients/producer/internals/StickyPartitionCache.java)

The idea is that it tries to send batches of messages that don't have keys to the same partition as a performance optimization.