### PR TITLE
Remove deprecated "topic" argument from admin.fetchOffsets

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -210,7 +210,7 @@ Include the optional `resolveOffsets` flag to resolve the offsets without having
 
 ```javascript
 await admin.resetOffsets({ groupId, topic })
-await admin.fetchOffsets({ groupId, topic, resolveOffsets: false })
+await admin.fetchOffsets({ groupId, topics: [topic], resolveOffsets: false })
 // [
 //   { partition: 0, offset: '-1' },
 //   { partition: 1, offset: '-1' },
@@ -219,7 +219,7 @@ await admin.fetchOffsets({ groupId, topic, resolveOffsets: false })
 // ]
 
 await admin.resetOffsets({ groupId, topic })
-await admin.fetchOffsets({ groupId, topic, resolveOffsets: true })
+await admin.fetchOffsets({ groupId, topics: [topic], resolveOffsets: true })
 // [
 //   { partition: 0, offset: '31004' },
 //   { partition: 1, offset: '54312' },

--- a/src/admin/__tests__/fetchOffsets.spec.js
+++ b/src/admin/__tests__/fetchOffsets.spec.js
@@ -54,19 +54,15 @@ describe('Admin', () => {
       )
     })
 
-    test('throws an error if both topic and topics are set', async () => {
-      await expect(
-        admin.fetchOffsets({ groupId: 'groupId', topic: topicName, topics: [topicName] })
-      ).rejects.toThrow(KafkaJSNonRetriableError, 'Either topic or topics must be set, not both')
-    })
-
     test('returns unresolved consumer group offsets', async () => {
       const offsets = await admin.fetchOffsets({
         groupId,
-        topic: topicName,
+        topics: [topicName],
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '-1', metadata: null }])
+      expect(offsets).toEqual([
+        { topic: topicName, partitions: [{ partition: 0, offset: '-1', metadata: null }] },
+      ])
     })
 
     test('returns the current consumer group offset', async () => {
@@ -78,10 +74,12 @@ describe('Admin', () => {
 
       const offsets = await admin.fetchOffsets({
         groupId,
-        topic: topicName,
+        topics: [topicName],
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '13', metadata: null }])
+      expect(offsets).toEqual([
+        { topic: topicName, partitions: [{ partition: 0, offset: '13', metadata: null }] },
+      ])
     })
 
     test('returns consumer group offsets for all topics', async () => {
@@ -194,17 +192,23 @@ describe('Admin', () => {
         })
         const offsetsUponResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
           resolveOffsets: true,
         })
         const offsetsAfterResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
         })
 
-        expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '5', metadata: null }])
-        expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '5', metadata: null }])
-        expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '5', metadata: null }])
+        expect(offsetsBeforeResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '5', metadata: null }] },
+        ])
+        expect(offsetsUponResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '5', metadata: null }] },
+        ])
+        expect(offsetsAfterResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '5', metadata: null }] },
+        ])
       })
 
       test('reset to latest: returns latest *topic* offsets after resolving', async () => {
@@ -212,21 +216,27 @@ describe('Admin', () => {
 
         const offsetsBeforeResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
         })
         const offsetsUponResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
           resolveOffsets: true,
         })
         const offsetsAfterResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
         })
 
-        expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '-1', metadata: null }])
-        expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '10', metadata: null }])
-        expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '10', metadata: null }])
+        expect(offsetsBeforeResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '-1', metadata: null }] },
+        ])
+        expect(offsetsUponResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '10', metadata: null }] },
+        ])
+        expect(offsetsAfterResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '10', metadata: null }] },
+        ])
       })
 
       test('reset to earliest: returns earliest *topic* offsets after resolving', async () => {
@@ -234,21 +244,27 @@ describe('Admin', () => {
 
         const offsetsBeforeResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
         })
         const offsetsUponResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
           resolveOffsets: true,
         })
         const offsetsAfterResolving = await admin.fetchOffsets({
           groupId,
-          topic: topicName,
+          topics: [topicName],
         })
 
-        expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '-2', metadata: null }])
-        expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '0', metadata: null }])
-        expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '0', metadata: null }])
+        expect(offsetsBeforeResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '-2', metadata: null }] },
+        ])
+        expect(offsetsUponResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '0', metadata: null }] },
+        ])
+        expect(offsetsAfterResolving).toEqual([
+          { topic: topicName, partitions: [{ partition: 0, offset: '0', metadata: null }] },
+        ])
       })
 
       testIfKafkaAtLeast_0_11(
@@ -267,21 +283,27 @@ describe('Admin', () => {
 
           const offsetsBeforeResolving = await admin.fetchOffsets({
             groupId,
-            topic: topicName,
+            topics: [topicName],
           })
           const offsetsUponResolving = await admin.fetchOffsets({
             groupId,
-            topic: topicName,
+            topics: [topicName],
             resolveOffsets: true,
           })
           const offsetsAfterResolving = await admin.fetchOffsets({
             groupId,
-            topic: topicName,
+            topics: [topicName],
           })
 
-          expect(offsetsBeforeResolving).toEqual([{ partition: 0, offset: '-2', metadata: null }])
-          expect(offsetsUponResolving).toEqual([{ partition: 0, offset: '7', metadata: null }])
-          expect(offsetsAfterResolving).toEqual([{ partition: 0, offset: '7', metadata: null }])
+          expect(offsetsBeforeResolving).toEqual([
+            { topic: topicName, partitions: [{ partition: 0, offset: '-2', metadata: null }] },
+          ])
+          expect(offsetsUponResolving).toEqual([
+            { topic: topicName, partitions: [{ partition: 0, offset: '7', metadata: null }] },
+          ])
+          expect(offsetsAfterResolving).toEqual([
+            { topic: topicName, partitions: [{ partition: 0, offset: '7', metadata: null }] },
+          ])
         }
       )
     })

--- a/src/admin/__tests__/resetOffsets.spec.js
+++ b/src/admin/__tests__/resetOffsets.spec.js
@@ -59,10 +59,12 @@ describe('Admin', () => {
 
       const offsets = await admin.fetchOffsets({
         groupId,
-        topic: topicName,
+        topics: [topicName],
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '-1', metadata: null }])
+      expect(offsets).toEqual([
+        { topic: topicName, partitions: [{ partition: 0, offset: '-1', metadata: null }] },
+      ])
     })
 
     test('set the consumer group offsets to the earliest offsets', async () => {
@@ -84,10 +86,12 @@ describe('Admin', () => {
 
       const offsets = await admin.fetchOffsets({
         groupId,
-        topic: topicName,
+        topics: [topicName],
       })
 
-      expect(offsets).toEqual([{ partition: 0, offset: '-2', metadata: null }])
+      expect(offsets).toEqual([
+        { topic: topicName, partitions: [{ partition: 0, offset: '-2', metadata: null }] },
+      ])
     })
 
     test('throws an error if the consumer group is running', async () => {

--- a/src/admin/__tests__/setOffsets.spec.js
+++ b/src/admin/__tests__/setOffsets.spec.js
@@ -57,8 +57,13 @@ describe('Admin', () => {
         partitions: [{ partition: 0, offset: 13 }],
       })
 
-      const offsets = await admin.fetchOffsets({ groupId, topic: topicName })
-      expect(offsets).toEqual([{ partition: 0, offset: '13', metadata: null }])
+      const offsets = await admin.fetchOffsets({ groupId, topics: [topicName] })
+      expect(offsets).toEqual([
+        {
+          topic: topicName,
+          partitions: [{ partition: 0, offset: '13', metadata: null }],
+        },
+      ])
     })
 
     test('throws an error if the consumer group is running', async () => {

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -408,30 +408,21 @@ module.exports = ({
    * Note: set either topic or topics but not both.
    *
    * @param {string} groupId
-   * @param {string} topic - deprecated, use the `topics` parameter. Topic to fetch offsets for.
    * @param {string[]} topics - list of topics to fetch offsets for, defaults to `[]` which fetches all topics for `groupId`.
    * @param {boolean} [resolveOffsets=false]
    * @return {Promise}
    */
-  const fetchOffsets = async ({ groupId, topic, topics, resolveOffsets = false }) => {
+  const fetchOffsets = async ({ groupId, topics, resolveOffsets = false }) => {
     if (!groupId) {
       throw new KafkaJSNonRetriableError(`Invalid groupId ${groupId}`)
     }
 
-    if (!topic && !topics) {
+    if (!topics) {
       topics = []
     }
 
-    if (!topic && !Array.isArray(topics)) {
-      throw new KafkaJSNonRetriableError(`Expected topic or topics array to be set`)
-    }
-
-    if (topic && topics) {
-      throw new KafkaJSNonRetriableError(`Either topic or topics must be set, not both`)
-    }
-
-    if (topic) {
-      topics = [topic]
+    if (!Array.isArray(topics)) {
+      throw new KafkaJSNonRetriableError('Expected topics array to be set')
     }
 
     const coordinator = await cluster.findGroupCoordinator({ groupId })
@@ -476,7 +467,7 @@ module.exports = ({
       )
     }
 
-    const result = consumerOffsets.map(({ topic, partitions }) => {
+    return consumerOffsets.map(({ topic, partitions }) => {
       const completePartitions = partitions.map(({ partition, offset, metadata }) => ({
         partition,
         offset,
@@ -485,12 +476,6 @@ module.exports = ({
 
       return { topic, partitions: completePartitions }
     })
-
-    if (topic) {
-      return result.pop().partitions
-    } else {
-      return result
-    }
   }
 
   /**

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -415,7 +415,7 @@ describe('Consumer', () => {
     expect(messagesConsumed.map(m => m.message.offset)).toEqual(messages.map((_, i) => `${i}`))
     const response = await admin.fetchOffsets({ groupId, topics: [topicName] })
     const { partitions } = response.find(({ topic }) => topic === topicName)
-    const partition = partitions.find(({ partition }) => partition === '0')
+    const partition = partitions.find(({ partition }) => partition === 0)
     expect(partition.offset).toEqual('100') // check if offsets were committed
   })
 

--- a/src/consumer/__tests__/consumeMessages.spec.js
+++ b/src/consumer/__tests__/consumeMessages.spec.js
@@ -413,7 +413,9 @@ describe('Consumer', () => {
 
     // check if all offsets are present
     expect(messagesConsumed.map(m => m.message.offset)).toEqual(messages.map((_, i) => `${i}`))
-    const [partition] = await admin.fetchOffsets({ groupId, topic: topicName })
+    const response = await admin.fetchOffsets({ groupId, topics: [topicName] })
+    const { partitions } = response.find(({ topic }) => topic === topicName)
+    const partition = partitions.find(({ partition }) => partition === '0')
     expect(partition.offset).toEqual('100') // check if offsets were committed
   })
 

--- a/src/consumer/__tests__/seek.spec.js
+++ b/src/consumer/__tests__/seek.spec.js
@@ -202,11 +202,16 @@ describe('Consumer', () => {
           }),
         ])
 
-        await expect(admin.fetchOffsets({ groupId, topic: topicName })).resolves.toEqual([
-          expect.objectContaining({
-            partition: 0,
-            offset: '-1',
-          }),
+        await expect(admin.fetchOffsets({ groupId, topics: [topicName] })).resolves.toEqual([
+          {
+            topic: topicName,
+            partitions: expect.arrayContaining([
+              expect.objectContaining({
+                partition: 0,
+                offset: '-1',
+              }),
+            ]),
+          },
         ])
 
         messagesConsumed = []

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -451,14 +451,6 @@ export type Admin = {
     topicPartitions: ITopicPartitionConfig[]
   }): Promise<boolean>
   fetchTopicMetadata(options?: { topics: string[] }): Promise<{ topics: Array<ITopicMetadata> }>
-  /**
-   * @deprecated "topic: string" replaced by "topics: string[]"
-   */
-  fetchOffsets(options: {
-    groupId: string
-    topic: string
-    resolveOffsets?: boolean
-  }): Promise<FetchOffsetsPartition[]>
   fetchOffsets(options: {
     groupId: string
     topics?: string[]

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -182,7 +182,6 @@ const runAdmin = async () => {
   await admin.listTopics()
 
   await admin.fetchOffsets({ groupId: 'test-group' })
-  await admin.fetchOffsets({ groupId: 'test-group', topic: 'topic1' })
   await admin.fetchOffsets({ groupId: 'test-group', topics: ['topic1', 'topic2'] })
 
   await admin.createTopics({


### PR DESCRIPTION
Was replaced by `topics: string[]` in #992