### PR TITLE
Increase default authentication timeout

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -94,7 +94,7 @@ Note that the broker may be configured to reject your authentication attempt if 
 
 | option                    | description                                                                                                                                                                             | default |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| authenticationTimeout     | Timeout in ms for authentication requests                                                                                                                                               | `1000`  |
+| authenticationTimeout     | Timeout in ms for authentication requests                                                                                                                                               | `10000`  |
 | reauthenticationThreshold | When periodic reauthentication (`connections.max.reauth.ms`) is configured on the broker side, reauthenticate when `reauthenticationThreshold` milliseconds remain of session lifetime. | `10000` |
 
 ### PLAIN/SCRAM Example
@@ -103,7 +103,7 @@ Note that the broker may be configured to reject your authentication attempt if 
 new Kafka({
   clientId: 'my-app',
   brokers: ['kafka1:9092', 'kafka2:9092'],
-  // authenticationTimeout: 1000,
+  // authenticationTimeout: 10000,
   // reauthenticationThreshold: 10000,
   ssl: true,
   sasl: {
@@ -120,7 +120,7 @@ new Kafka({
 new Kafka({
   clientId: 'my-app',
   brokers: ['kafka1:9092', 'kafka2:9092'],
-  // authenticationTimeout: 1000,
+  // authenticationTimeout: 10000,
   // reauthenticationThreshold: 10000,
   ssl: true,
   sasl: {
@@ -229,7 +229,7 @@ const kafka = new Kafka({
 new Kafka({
   clientId: 'my-app',
   brokers: ['kafka1:9092', 'kafka2:9092'],
-  // authenticationTimeout: 1000,
+  // authenticationTimeout: 10000,
   // reauthenticationThreshold: 10000,
   ssl: true,
   sasl: {

--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -28,7 +28,7 @@ module.exports = class Broker {
    * @param {number} [options.nodeId]
    * @param {import("../../types").ApiVersions} [options.versions=null] The object with all available versions and APIs
    *                                 supported by this cluster. The output of broker#apiVersions
-   * @param {number} [options.authenticationTimeout=1000]
+   * @param {number} [options.authenticationTimeout=10000]
    * @param {boolean} [options.allowAutoTopicCreation=true] If this and the broker config 'auto.create.topics.enable'
    *                                                are true, topics that don't exist will be created when
    *                                                fetching metadata.
@@ -38,7 +38,7 @@ module.exports = class Broker {
     logger,
     nodeId = null,
     versions = null,
-    authenticationTimeout = 1000,
+    authenticationTimeout = 10000,
     allowAutoTopicCreation = true,
   }) {
     this.connectionPool = connectionPool


### PR DESCRIPTION
The Java client and librdkafka have a single timeout configuration value for connection establishment, which includes the entire operation of TCP socket connection, protocol negotiation and authentication. However, they work slightly differently:

* Java client - initial timeout is 10s, but it has a retry mechanism with exponential backoff with another max value of 30s
* librdkafka - default timeout of 30s. No backoff mechanism.
* kafkajs - has a TCP socket connection timeout of 1s, also has an overall connection establishment timeout of `2 * connectionTimeout + authenticationTimeout`, where `authenticationTimeout` is 1s. This means that in practice our equivalent timeout is 3 seconds. This PR changes that to effectively be 12 seconds, bringing it more in line with the other clients.

I considered going full librdkafka and setting it to 30 seconds, but it's much easier to increase defaults than to decrease them if we want to change things in the future. Just setting the authentication timeout to 10s is probably going to solve most people's issues regardless.