### PR TITLE
Remove deprecated error property originalError

### DIFF
--- a/src/consumer/__tests__/errorRecovery.spec.js
+++ b/src/consumer/__tests__/errorRecovery.spec.js
@@ -224,13 +224,13 @@ describe('Consumer', () => {
     const crashListener = jest.fn()
     consumer2.on(consumer.events.CRASH, crashListener)
 
-    const originalError = new KafkaJSError(new Error('💣'), { retriable: true })
-    const retryError = new KafkaJSNumberOfRetriesExceeded(originalError, {
+    const cause = new KafkaJSError(new Error('💣'), { retriable: true })
+    const retryError = new KafkaJSNumberOfRetriesExceeded(cause, {
       retryCount: 5,
       retryTime: 10000,
-      cause: originalError,
+      cause,
     })
-    const error = new KafkaJSNonRetriableError(retryError, { cause: originalError })
+    const error = new KafkaJSNonRetriableError(retryError, { cause })
 
     await consumer2.connect()
     await consumer2.subscribe({ topic: topicName, fromBeginning: true })

--- a/src/errors.js
+++ b/src/errors.js
@@ -17,8 +17,6 @@ class KafkaJSNonRetriableError extends KafkaJSError {
   constructor(e, { cause } = {}) {
     super(e, { retriable: false, cause })
     this.name = 'KafkaJSNonRetriableError'
-    // Kept for backwards compatibility. Introduced in v1.16.0
-    this.originalError = e
   }
 }
 
@@ -52,8 +50,6 @@ class KafkaJSNumberOfRetriesExceeded extends KafkaJSNonRetriableError {
   constructor(e, { retryCount, retryTime }) {
     super(e, { cause: e })
     this.stack = `${this.name}\n  Caused by: ${e.stack}`
-    // Kept for backwards compatibility. Introduced in v1.16.0
-    this.originalError = e
     this.retryCount = retryCount
     this.retryTime = retryTime
     this.name = 'KafkaJSNumberOfRetriesExceeded'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1062,10 +1062,6 @@ export class KafkaJSOffsetOutOfRange extends KafkaJSProtocolError {
 
 export class KafkaJSNumberOfRetriesExceeded extends KafkaJSNonRetriableError {
   readonly stack: string
-  /**
-   * @deprecated Use `cause` instead
-   */
-  readonly originalError: Error
   readonly retryCount: number
   readonly retryTime: number
   constructor(e: Error | string, metadata?: KafkaJSNumberOfRetriesExceededMetadata)


### PR DESCRIPTION
Replaced by `cause`