### PR TITLE
Remain in the consumer group even when not assigned partitions

### DIFF
--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -314,6 +314,10 @@ module.exports = class Runner extends EventEmitter {
       nodeId,
     })
 
+    if (batches.length === 0) {
+      await this.heartbeat()
+    }
+
     return batches
   }
 


### PR DESCRIPTION
Since #683, heartbeating was only being done inside `onBatch`, which is only invoked when you receive a batch to process (even an empty one). However, if a member is not assigned any partitions, it would never actually execute any fetch requests and thus yield no batches to process. As such, the member would get kicked out of the group but never be aware of it, and never rejoin.

The runner now triggers a heartbeat on every iteration of the fetch loop (subject to the heartbeat interval) even if there were no batches returned, which makes it so that even members without any assignments continue to heartbeat and thus remain in the group and will receive new assignments on rebalances.

Fixes #1361