### PR TITLE
Provide a `pause()` helper to eachMessage/eachBatch

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -102,7 +102,7 @@ await consumer.run({
 * `uncommittedOffsets()` returns all offsets by topic-partition which have not yet been committed.
 * `isRunning()` returns true if consumer is in running state, else it returns false.
 * `isStale()` returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling [`consumer.seek`](#seek) the messages in the batch should be discarded, as they are not at the offset we seeked to.
-* `pause()` can be used to pause the consumer for the current topic/partition. All offsets resolved up to that point will be committed (subject to `eachBatchAutoResolve` and [autoCommit](#auto-commit) settings). If you want to pause in the middle of the batch, you should throw an exception if you do not wish to resolve the current batch's offset or, alternatively, make sure that `eachBatchAutoResolve` is turned off. You can used the returned callback function to resume processing of the relevant partition and topic (i.e. using `setTimeout` or some other asynchronous trigger). See [Pause & Resume](#pause-resume) for more information about this feature.
+* `pause()` can be used to pause the consumer for the current topic/partition. All offsets resolved up to that point will be committed (subject to `eachBatchAutoResolve` and [autoCommit](#auto-commit) settings). If you want to pause in the middle of the batch, you should throw an exception after pausing if you do not wish to resolve the current batch's offset or, alternatively, make sure that `eachBatchAutoResolve` is turned off. You can used the returned callback function to resume processing of the relevant partition and topic (i.e. using `setTimeout` or some other asynchronous trigger). See [Pause & Resume](#pause-resume) for more information about this feature.
 
 ### Example
 
@@ -253,7 +253,7 @@ kafka.consumer({
 
 ## <a name="pause-resume"></a> Pause & Resume
 
-In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`. It also provides the `paused` method to get the list of all paused topics. Note that pausing a topic means that it won't be fetched in the next cycle. You may still receive messages for the topic within the current batch.
+In order to pause and resume consuming from one or more topics, the `Consumer` provides the methods `pause` and `resume`. It also provides the `paused` method to get the list of all paused topics. Note that pausing a topic means that it won't be fetched in the next cycle and subsequent messages within the current batch won't be passed to an `eachMessage` handler.
 
 Calling `pause` with a topic that the consumer is not subscribed to is a no-op, calling `resume` with a topic that is not paused is also a no-op.
 
@@ -330,7 +330,7 @@ await consumer.run({ eachMessage: async ({ topic, message, pause }) => {
 
 Depending on your use case, be sure to throw an exception after `pause()` is called (as shown above) or the current message's offset will be resolved and committed.
 Alternatively, if you want to pause processing of a topic's partition without retrying the current message, no exception needs to be thrown.
-In either case, the `eachMessage` callback will not be called for the current topic/partition until the consumer is resumed. 
+In either case, the `eachMessage` callback will not be called again for the current topic/partition until the consumer is resumed for this topic/partition.
 
 It's possible to access the list of paused topic partitions using the `paused` method.
 

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -56,7 +56,7 @@ Be aware that the `eachMessage` handler should not block for longer than the con
 
 ## <a name="each-batch"></a> eachBatch
 
-Some use cases require dealing with batches directly. This handler will feed your function batches and provide some utility functions to give your code more flexibility: `resolveOffset`, `heartbeat`, `commitOffsetsIfNecessary`, `uncommittedOffsets`, `isRunning`, and `isStale`. All resolved offsets will be automatically committed after the function is executed.
+Some use cases require dealing with batches directly. This handler will feed your function batches and provide some utility functions to give your code more flexibility: `resolveOffset`, `heartbeat`, `commitOffsetsIfNecessary`, `uncommittedOffsets`, `isRunning`, `isStale`, and `pause`. All resolved offsets will be automatically committed after the function is executed.
 
 > Note: Be aware that using `eachBatch` directly is considered a more advanced use case as compared to using `eachMessage`, since you will have to understand how session timeouts and heartbeats are connected.
 

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -53,7 +53,7 @@ await consumer.run({
 ```
 
 Be aware that the `eachMessage` handler should not block for longer than the configured [session timeout](#options) or else the consumer will be removed from the group. If your workload involves very slow processing times for individual messages then you should either increase the session timeout or make periodic use of the `heartbeat` function exposed in the handler payload.
-The `pause` callback function is a convenience for `consumer.pause({ topic, partitions: [partition] })`. Depending on your use case, take care to throw an exception after pausing if you do not want the current message's offset resolved and committed (i.e. if you want to retry the message later).
+The `pause` function is a convenience for `consumer.pause({ topic, partitions: [partition] })`. It will pause the current topic-partition and returns a function that allows you to resume consuming later.
 
 ## <a name="each-batch"></a> eachBatch
 
@@ -102,7 +102,7 @@ await consumer.run({
 * `uncommittedOffsets()` returns all offsets by topic-partition which have not yet been committed.
 * `isRunning()` returns true if consumer is in running state, else it returns false.
 * `isStale()` returns whether the messages in the batch have been rendered stale through some other operation and should be discarded. For example, when calling [`consumer.seek`](#seek) the messages in the batch should be discarded, as they are not at the offset we seeked to.
-* `pause()` can be used to pause the consumer for the current topic/partition. All offsets resolved up to that point will be committed (subject to `eachBatchAutoResolve` and [autoCommit](#auto-commit) settings). If you want to pause in the middle of the batch, you should throw an exception after pausing if you do not wish to resolve the current batch's offset or, alternatively, make sure that `eachBatchAutoResolve` is turned off. You can used the returned callback function to resume processing of the relevant partition and topic (i.e. using `setTimeout` or some other asynchronous trigger). See [Pause & Resume](#pause-resume) for more information about this feature.
+* `pause()` can be used to pause the consumer for the current topic-partition. All offsets resolved up to that point will be committed (subject to `eachBatchAutoResolve` and [autoCommit](#auto-commit)). Throw an error to pause in the middle of the batch without resolving the current offset. Alternatively, disable `eachBatchAutoResolve`. The returned function can be used to resume processing of the topic-partition. See [Pause & Resume](#pause-resume) for more information about this feature.
 
 ### Example
 
@@ -307,7 +307,7 @@ consumer.run({
 })
 ```
 
-As a convenience, the `eachMessage` callback provides a simple callback function to pause the specific topic/partition for the message currently being processed. You can also specify a timeout for when that topic/partition will automatically be resumed:
+As a convenience, the `eachMessage` callback provides a `pause` function to pause the specific topic-partition of the message currently being processed.
 
 ```javascript
 await consumer.connect()
@@ -327,10 +327,6 @@ await consumer.run({ eachMessage: async ({ topic, message, pause }) => {
     }
 }})
 ```
-
-Depending on your use case, be sure to throw an exception after `pause()` is called (as shown above) or the current message's offset will be resolved and committed.
-Alternatively, if you want to pause processing of a topic's partition without retrying the current message, no exception needs to be thrown.
-In either case, the `eachMessage` callback will not be called again for the current topic/partition until the consumer is resumed for this topic/partition.
 
 It's possible to access the list of paused topic partitions using the `paused` method.
 

--- a/src/consumer/__tests__/runner.spec.js
+++ b/src/consumer/__tests__/runner.spec.js
@@ -62,6 +62,7 @@ describe('Consumer > Runner', () => {
       heartbeat: jest.fn(),
       assigned: jest.fn(() => []),
       isLeader: jest.fn(() => true),
+      isPaused: jest.fn().mockReturnValue(false),
     }
     instrumentationEmitter = new InstrumentationEventEmitter()
 

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -421,7 +421,7 @@ module.exports = class ConsumerGroup {
   /**
    * @param {string} topic
    * @param {string} partition
-   * @returns {boolean} whether the specified topic/partition are paused or not
+   * @returns {boolean} whether the specified topic-partition are paused or not
    */
   isPaused(topic, partition) {
     return this.subscriptionState.isPaused(topic, partition)

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -418,6 +418,15 @@ module.exports = class ConsumerGroup {
     return this.subscriptionState.paused()
   }
 
+  /**
+   * @param {string} topic
+   * @param {string} partition
+   * @returns {boolean} whether the specified topic/partition are paused or not
+   */
+  isPaused(topic, partition) {
+    return this.subscriptionState.isPaused(topic, partition)
+  }
+
   async commitOffsetsIfNecessary() {
     await this.offsetManager.commitOffsetsIfNecessary()
   }

--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -260,7 +260,7 @@ module.exports = class Runner extends EventEmitter {
         },
         heartbeat: () => this.heartbeat(),
         /**
-         * Pause consumption for the current topic/partition being processed
+         * Pause consumption for the current topic-partition being processed
          */
         pause,
         /**
@@ -434,16 +434,6 @@ module.exports = class Runner extends EventEmitter {
           })
           return
         }
-        if (this.consumerGroup.isPaused(batch.topic, batch.partition)) {
-          this.logger.debug('topic/partition paused, will not retry', {
-            error: e.message,
-            groupId: this.consumerGroup.groupId,
-            memberId: this.consumerGroup.memberId,
-            topic: batch.topic,
-            partition: batch.partition,
-          })
-          return
-        }
 
         if (
           isRebalancing(e) ||
@@ -451,6 +441,17 @@ module.exports = class Runner extends EventEmitter {
           e.name === 'KafkaJSNotImplemented'
         ) {
           return bail(e)
+        }
+
+        if (this.consumerGroup.isPaused(batch.topic, batch.partition)) {
+          this.logger.debug('topic-partition paused, will not retry', {
+            error: e.message,
+            groupId: this.consumerGroup.groupId,
+            memberId: this.consumerGroup.memberId,
+            topic: batch.topic,
+            partition: batch.partition,
+          })
+          return
         }
 
         this.logger.debug('Error while fetching data, trying again...', {

--- a/src/errors.js
+++ b/src/errors.js
@@ -248,13 +248,6 @@ class KafkaJSAggregateError extends Error {
 
 class KafkaJSFetcherRebalanceError extends Error {}
 
-class KafkaJSPauseConsumerError extends Error {
-  constructor(timeout) {
-    super('Consumer paused on current topic/partition' + (timeout ? ` for ${timeout}ms` : ''))
-    this.timeout = timeout
-  }
-}
-
 const isRebalancing = e =>
   e.type === 'REBALANCE_IN_PROGRESS' || e.type === 'NOT_COORDINATOR_FOR_GROUP'
 
@@ -290,7 +283,6 @@ module.exports = {
   KafkaJSCreateTopicError,
   KafkaJSAggregateError,
   KafkaJSFetcherRebalanceError,
-  KafkaJSPauseConsumerError,
   isRebalancing,
   isKafkaJSError,
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -248,6 +248,13 @@ class KafkaJSAggregateError extends Error {
 
 class KafkaJSFetcherRebalanceError extends Error {}
 
+class KafkaJSPauseConsumerError extends Error {
+  constructor(timeout) {
+    super('Consumer paused on current topic/partition' + (timeout ? ` for ${timeout}ms` : ''))
+    this.timeout = timeout
+  }
+}
+
 const isRebalancing = e =>
   e.type === 'REBALANCE_IN_PROGRESS' || e.type === 'NOT_COORDINATOR_FOR_GROUP'
 
@@ -283,6 +290,7 @@ module.exports = {
   KafkaJSCreateTopicError,
   KafkaJSAggregateError,
   KafkaJSFetcherRebalanceError,
+  KafkaJSPauseConsumerError,
   isRebalancing,
   isKafkaJSError,
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -899,14 +899,14 @@ export interface EachMessagePayload {
   partition: number
   message: KafkaMessage
   heartbeat(): Promise<void>
-  pause(timeout?: number): never
+  pause(): () => void
 }
 
 export interface EachBatchPayload {
   batch: Batch
   resolveOffset(offset: string): void
   heartbeat(): Promise<void>
-  pause(timeout?: number): never
+  pause(): () => void
   commitOffsetsIfNecessary(offsets?: Offsets): Promise<void>
   uncommittedOffsets(): OffsetsByTopicPartition
   isRunning(): boolean

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -899,12 +899,14 @@ export interface EachMessagePayload {
   partition: number
   message: KafkaMessage
   heartbeat(): Promise<void>
+  pause(timeout?: number): never
 }
 
 export interface EachBatchPayload {
   batch: Batch
   resolveOffset(offset: string): void
   heartbeat(): Promise<void>
+  pause(timeout?: number): never
   commitOffsetsIfNecessary(offsets?: Offsets): Promise<void>
   uncommittedOffsets(): OffsetsByTopicPartition
   isRunning(): boolean


### PR DESCRIPTION
This function will take care of pausing (and optionally, resuming) message consumption on the current topic/partition when processing messages either within the `eachMessage` or `eachBatch` handler functions.
