### PR TITLE
Fix SeekOffsets data structure

### DIFF
--- a/src/consumer/seekOffsets.js
+++ b/src/consumer/seekOffsets.js
@@ -1,6 +1,6 @@
 module.exports = class SeekOffsets extends Map {
   getKey(topic, partition) {
-    return JSON.stringify(topic, partition)
+    return JSON.stringify([topic, partition])
   }
 
   set(topic, partition, offset) {
@@ -14,7 +14,7 @@ module.exports = class SeekOffsets extends Map {
   }
 
   pop(topic, partition) {
-    if (this.size === 0) {
+    if (this.size === 0 || !this.has(topic, partition)) {
       return
     }
 


### PR DESCRIPTION
After upgrading kafkajs to version 2.0.1 in our application, a test suddenly failed to pass.

Initially, this test does the following:
* Start Kafka and create a random topic with three partitions
* Produce two messages to partition 1
* Set consumer offset in partition 1 to 1 (i.e., skip the first message) using the admin client method `setOffsets(...)`
* Start a consumer and do some follow-up work

However, this fails (in a reproducible way) because the third operation sets the offset not for partition 1, but partition 0 instead. Further investigations of the bug lead me to the conclusion that the issue must lie somewhere within the consumer seek logic, as the internal `consumer.seek()` call within `setOffsets` passed the correct partition information. I encountered the updated `SeekOffsets` data structure eventually and found two issues:
* The keys are not partition-specific, it stores only one element per topic, because the keys for each partition map to the same. I fixed this by packing the required information into an array in line 3. This directly caused above issue, because `pop(TOPIC, 0)`, which happened before `pop(TOPIC, 1)`, returned the offset for partition 1 instead of 0, and removed it.
* `pop(topic, partition)` returns a non-undefined object (with undefined topic and partition) as soon as ANY topic or partition offset information is stored. I didn't investigate in how far this would affect the seek call in `consumerGroup.js` line 662, but I guess it is not how it should be called.