### PR TITLE
Differentiate KafkaMessage type between Record and Message

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -631,15 +631,25 @@ export type Broker = {
   }): Promise<any>
 }
 
-export type KafkaMessage = {
+interface MessageSetEntry {
   key: Buffer | null
   value: Buffer | null
   timestamp: string
-  size: number
   attributes: number
   offset: string
-  headers?: IHeaders
+  size: number
 }
+
+interface RecordBatchEntry {
+  key: Buffer | null
+  value: Buffer | null
+  timestamp: string
+  attributes: number
+  offset: string
+  headers: IHeaders
+}
+
+export type KafkaMessage = MessageSetEntry | RecordBatchEntry
 
 export interface ProducerRecord {
   topic: string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -638,6 +638,7 @@ interface MessageSetEntry {
   attributes: number
   offset: string
   size: number
+  headers?: never
 }
 
 interface RecordBatchEntry {
@@ -647,6 +648,7 @@ interface RecordBatchEntry {
   attributes: number
   offset: string
   headers: IHeaders
+  size?: never
 }
 
 export type KafkaMessage = MessageSetEntry | RecordBatchEntry


### PR DESCRIPTION
The `size` attribute is only ever present on pre-0.10 `Messages`, and never on the new `Record`. The field was mistakenly defined as being non-optional.