### PR TITLE
Let consumer crash when no brokers are available

### DIFF
--- a/src/consumer/fetchManager.js
+++ b/src/consumer/fetchManager.js
@@ -38,7 +38,7 @@ const createFetchManager = ({
       const current = getNodeIds()
       const hasChanged =
         nodeIds.length !== current.length || nodeIds.some(nodeId => !current.includes(nodeId))
-      if (hasChanged) {
+      if (hasChanged && current.length !== 0) {
         throw new KafkaJSFetcherRebalanceError()
       }
     }


### PR DESCRIPTION
The fetch manager rebalancing mechanism caused an infinite loop when there were no brokers available, causing the consumer to never become aware of any connection issues.

With 2.0.1, if you ran a consumer against a single broker, and then shut that broker down, the consumer would just freeze with no output and use 100% of a CPU core. With this change, the fetcher will try to fetch against one of the now unavailable brokers and have a KafkaJSConnectionError bubble up and eventually crash the consumer, as was the case with <2.0.0.

Fixes #1384