### PR TITLE
Update ConsumerExample.md

### DIFF
--- a/docs/ConsumerExample.md
+++ b/docs/ConsumerExample.md
@@ -69,7 +69,7 @@ signalTraps.forEach(type => {
 A similar example in TypeScript
 
 ```typescript
-import { Consumer, ConsumerSubscribeTopic, EachBatchPayload, Kafka, EachMessagePayload } from 'kafkajs'
+import { Consumer, ConsumerSubscribeTopics, EachBatchPayload, Kafka, EachMessagePayload } from 'kafkajs'
 
 export default class ExampleConsumer {
   private kafkaConsumer: Consumer
@@ -81,8 +81,8 @@ export default class ExampleConsumer {
   }
 
   public async startConsumer(): Promise<void> {
-    const topic: ConsumerSubscribeTopic = {
-      topic: 'example-topic',
+    const topic: ConsumerSubscribeTopics = {
+      topics: ['example-topic'],
       fromBeginning: false
     }
 
@@ -103,8 +103,8 @@ export default class ExampleConsumer {
   }
 
   public async startBatchConsumer(): Promise<void> {
-    const topic: ConsumerSubscribeTopic = {
-      topic: 'example-topic',
+    const topic: ConsumerSubscribeTopics = {
+      topics: ['example-topic'],
       fromBeginning: false
     }
 
@@ -112,10 +112,10 @@ export default class ExampleConsumer {
       await this.kafkaConsumer.connect()
       await this.kafkaConsumer.subscribe(topic)
       await this.kafkaConsumer.run({
-        eachBatch: async (eatchBatchPayload: EachBatchPayload) => {
-          const { topic, partition, batch } = eachBatchPayload
+        eachBatch: async (eachBatchPayload: EachBatchPayload) => {
+          const { batch } = eachBatchPayload
           for (const message of batch.messages) {
-            const prefix = `${topic}[${partition} | ${message.offset}] / ${message.timestamp}`
+            const prefix = `${batch.topic}[${batch.partition} | ${message.offset}] / ${message.timestamp}`
             console.log(`- ${prefix} ${message.key}#${message.value}`) 
           }
         }


### PR DESCRIPTION
**ConsumerSubscribeTopic** is deprecated and has been replaced with **ConsumerSubscribeTopics**.
**eachBatchPayload** was spelled wrong as **eatchBatchPayload**.
**eachBatchPayload** does not directly have `{topic, partition}` as properties. These properties can be directly be found on the `{batch}` property rather.