### PR TITLE
Improve performance by replacing reduce with spread with forEach

### DIFF
--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -747,8 +747,13 @@ module.exports = class ConsumerGroup {
   }
 
   getActiveTopicPartitions() {
-    return this.subscriptionState
-      .active()
-      .reduce((acc, { topic, partitions }) => ({ ...acc, [topic]: new Set(partitions) }), {})
+    const activeSubscriptionState = this.subscriptionState.active()
+
+    const activeTopicPartitions = {}
+    activeSubscriptionState.forEach(({ topic, partitions }) => {
+      activeTopicPartitions[topic] = new Set(partitions)
+    })
+
+    return activeTopicPartitions
   }
 }


### PR DESCRIPTION
We are using KafkaJS with a cluster that has a lot of topics - thousands of them. Now we want to migrate to KafkaJS 2, but, unfortunately, there is a very heavy computation happening in the `getActiveTopicPartitions` function (see screenshot).

The issue is caused by using spread in reduce, which has n^2 complexity. For the case of 12k topics, with the current implementation, it takes **40 seconds** to compute the result of this function. However, the proposed implementation only takes **20 milliseconds**.

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/966690/184674728-6e535862-024a-40de-800c-e0da7a190a7c.png">


See [this article](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern) for more trough explanation.

It is a show stopper for us for an upgrade.

Also, other places in the code have similar behavior. They are less critical for the tested flow but can be changed to forEach. WDYT?

Thank you.