### PR TITLE
Replace slackin with invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Contributions are made to this repo via Issues and Pull Requests (PRs). A few ge
 
 Issues should be used to report problems with the library, request a new feature, or to discuss potential changes before a PR is created. Please follow the issue template that's provided when you first create an issue in order to collect all the necessary information.
 
-Issues are not a support channel. Please use [StackOverflow](https://stackoverflow.com/questions/tagged/kafkajs), [Slack](https://kafkajs-slackin.herokuapp.com/) or other online resources instead. [Limited support from a maintainer](https://github.com/sponsors/Nevon?frequency=one-time&sponsor=Nevon) is available to sponsors.
+Issues are not a support channel. Please use [StackOverflow](https://stackoverflow.com/questions/tagged/kafkajs), [Slack](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) or other online resources instead. [Limited support from a maintainer](https://github.com/sponsors/Nevon?frequency=one-time&sponsor=Nevon) is available to sponsors.
 
 If you find an issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help be indicating to our maintainers that a particular problem is affecting more than just the reporter.
 
@@ -37,4 +37,4 @@ Once a PR is merged and the master build is successful, a pre-release version of
 
 ## Getting Help
 
-Join our [Slack community](https://kafkajs-slackin.herokuapp.com/) if you have questions about the contribution process or otherwise want to get in touch.
+Join our [Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) if you have questions about the contribution process or otherwise want to get in touch.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm version](https://img.shields.io/npm/v/kafkajs?color=%2344cc11&label=stable)](https://www.npmjs.com/package/kafkajs) [![npm pre-release version](https://img.shields.io/npm/v/kafkajs/beta?label=pre-release)](https://www.npmjs.com/package/kafkajs) [![Build Status](https://dev.azure.com/tulios/kafkajs/_apis/build/status/tulios.kafkajs?branchName=master)](https://dev.azure.com/tulios/kafkajs/_build/latest?definitionId=2&branchName=master) [![Slack Channel](https://kafkajs-slackin.herokuapp.com/badge.svg)](https://kafkajs-slackin.herokuapp.com/)
+[![npm version](https://img.shields.io/npm/v/kafkajs?color=%2344cc11&label=stable)](https://www.npmjs.com/package/kafkajs) [![npm pre-release version](https://img.shields.io/npm/v/kafkajs/beta?label=pre-release)](https://www.npmjs.com/package/kafkajs) [![Build Status](https://dev.azure.com/tulios/kafkajs/_apis/build/status/tulios.kafkajs?branchName=master)](https://dev.azure.com/tulios/kafkajs/_build/latest?definitionId=2&branchName=master) [![Slack Channel](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0Abadge.svg)](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)
 <br />
 <p align="center">
   <a href="https://kafka.js.org">
@@ -73,7 +73,7 @@ KafkaJS is a modern [Apache Kafka](https://kafka.apache.org/) client for Node.js
   </table>
 </p>
 
-*To become a sponsor, [reach out in our Slack community](https://kafkajs-slackin.herokuapp.com/) to get in touch with one of the maintainers. Also consider becoming a Github Sponsor by following any of the links under "[Sponsor this project](https://github.com/tulios/kafkajs#sponsors)" in the sidebar.*
+*To become a sponsor, [reach out in our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) to get in touch with one of the maintainers. Also consider becoming a Github Sponsor by following any of the links under "[Sponsor this project](https://github.com/tulios/kafkajs#sponsors)" in the sidebar.*
 
 ### <a name="features"></a> Features
 
@@ -154,7 +154,7 @@ See [Developing KafkaJS](https://kafka.js.org/docs/contribution-guide) for infor
 
 ### <a name="help-wanted"></a> Help wanted 🤝
 
-We welcome contributions to KafkaJS, but we also want to see a thriving third-party ecosystem. If you would like to create an open-source project that builds on top of KafkaJS, [please get in touch](https://kafkajs-slackin.herokuapp.com/) and we'd be happy to provide feedback and support.
+We welcome contributions to KafkaJS, but we also want to see a thriving third-party ecosystem. If you would like to create an open-source project that builds on top of KafkaJS, [please get in touch](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) and we'd be happy to provide feedback and support.
 
 Here are some projects that we would like to build, but haven't yet been able to prioritize:
 
@@ -164,7 +164,7 @@ Here are some projects that we would like to build, but haven't yet been able to
 
 ### <a name="contact"></a> Contact 💬
 
-[Join our Slack community](https://kafkajs-slackin.herokuapp.com/)
+[Join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)
 
 ## <a name="license"></a> License
 

--- a/docs/ContributionGuide.md
+++ b/docs/ContributionGuide.md
@@ -5,7 +5,7 @@ title: Contributing
 
 KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bug fixes, feature development and other contributions.
 
-Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://kafkajs-slackin.herokuapp.com/) is also a good place if you want to discuss your plans before starting your implementation.
+Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) is also a good place if you want to discuss your plans before starting your implementation.
 
 ## TL;DR
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,4 +46,4 @@ For more information, see:
 
 ## Didn't find what you were looking for?
 
-Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)
+Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -41,7 +41,9 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>Community</h5>
-            <a href="https://kafkajs-slackin.herokuapp.com">Slack</a>
+            <a href="https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A">
+              Slack
+            </a>
           </div>
           <div>
             <h5>More</h5>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -9,7 +9,8 @@
 // site configuration options.
 
 const repoUrl = 'https://github.com/tulios/kafkajs'
-const slackUrl = 'https://kafkajs-slackin.herokuapp.com/'
+const slackUrl =
+  'https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A'
 
 const siteConfig = {
   title: 'KafkaJS',

--- a/website/versioned_docs/version-1.10.0/ContributionGuide.md
+++ b/website/versioned_docs/version-1.10.0/ContributionGuide.md
@@ -6,7 +6,7 @@ original_id: contribution-guide
 
 KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bugfixes, feature development and other contributions.
 
-Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://kafkajs-slackin.herokuapp.com/) is also a good place if you want to discuss your plans before starting your implementation.
+Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) is also a good place if you want to discuss your plans before starting your implementation.
 
 ## TL;DR
 

--- a/website/versioned_docs/version-1.10.0/FAQ.md
+++ b/website/versioned_docs/version-1.10.0/FAQ.md
@@ -33,4 +33,4 @@ The rebalancing state is enforced on the broker side. When a consumer tries to c
 
 ## Didn't find what you were looking for?
 
-Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)
+Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)

--- a/website/versioned_docs/version-1.11.0/ContributionGuide.md
+++ b/website/versioned_docs/version-1.11.0/ContributionGuide.md
@@ -6,7 +6,7 @@ original_id: contribution-guide
 
 KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bugfixes, feature development and other contributions.
 
-Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://kafkajs-slackin.herokuapp.com/) is also a good place if you want to discuss your plans before starting your implementation.
+Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) is also a good place if you want to discuss your plans before starting your implementation.
 
 ## TL;DR
 

--- a/website/versioned_docs/version-1.11.0/FAQ.md
+++ b/website/versioned_docs/version-1.11.0/FAQ.md
@@ -33,4 +33,4 @@ The rebalancing state is enforced on the broker side. When a consumer tries to c
 
 ## Didn't find what you were looking for?
 
-Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)
+Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)

--- a/website/versioned_docs/version-1.12.0/ContributionGuide.md
+++ b/website/versioned_docs/version-1.12.0/ContributionGuide.md
@@ -6,7 +6,7 @@ original_id: contribution-guide
 
 KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bugfixes, feature development and other contributions.
 
-Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://kafkajs-slackin.herokuapp.com/) is also a good place if you want to discuss your plans before starting your implementation.
+Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) is also a good place if you want to discuss your plans before starting your implementation.
 
 ## TL;DR
 

--- a/website/versioned_docs/version-1.12.0/FAQ.md
+++ b/website/versioned_docs/version-1.12.0/FAQ.md
@@ -33,4 +33,4 @@ The rebalancing state is enforced on the broker side. When a consumer tries to c
 
 ## Didn't find what you were looking for?
 
-Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)
+Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)

--- a/website/versioned_docs/version-1.13.0/ContributionGuide.md
+++ b/website/versioned_docs/version-1.13.0/ContributionGuide.md
@@ -6,7 +6,7 @@ original_id: contribution-guide
 
 KafkaJS is an open-source project where development takes place in the open on GitHub. Although the project is maintained by a small group of dedicated volunteers, we are grateful to the community for bug fixes, feature development and other contributions.
 
-Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://kafkajs-slackin.herokuapp.com/) is also a good place if you want to discuss your plans before starting your implementation.
+Issues are tracked in [Github](https://github.com/tulios/kafkajs/issues). For first time contributors, we maintain a list of [Good First Issues](https://github.com/tulios/kafkajs/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22). If you are planning to implement a new feature or work on fixing a bug, make sure to [check the issue tracker](https://github.com/tulios/kafkajs/issues) to see if someone is already working on it, or [open an issue](https://github.com/tulios/kafkajs/issues/new) before you start your work. [The Slack channel](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A) is also a good place if you want to discuss your plans before starting your implementation.
 
 ## TL;DR
 

--- a/website/versioned_docs/version-1.15.0/FAQ.md
+++ b/website/versioned_docs/version-1.15.0/FAQ.md
@@ -35,4 +35,4 @@ The rebalancing state is enforced on the broker side. When a consumer tries to c
 
 ## Didn't find what you were looking for?
 
-Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)
+Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)

--- a/website/versioned_docs/version-1.16.0/FAQ.md
+++ b/website/versioned_docs/version-1.16.0/FAQ.md
@@ -47,4 +47,4 @@ For more information, see:
 
 ## Didn't find what you were looking for?
 
-Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://kafkajs-slackin.herokuapp.com)
+Please [open an issue](https://github.com/tulios/kafkajs/issues) or [join our Slack community](https://join.slack.com/t/kafkajs/shared_invite/zt-1ezd5395v-SOpTqYoYfRCyPKOkUggK0A)


### PR DESCRIPTION
Slackin is hosted on Heroku, which is shutting down its free tier, and
the legacy token integration is being discontinued. Slack has been back
and forth about never-expiring invite links, but this one claims to never
be expiring, so let's see what happens.