### PR TITLE
Fix saslAuthenticate parameter type definitions

### DIFF
--- a/docs/CustomAuthenticationMechanism.md
+++ b/docs/CustomAuthenticationMechanism.md
@@ -24,13 +24,17 @@ configure your brokers.
 A custom authentication mechanism needs to fulfill the following interface:
 
 ```ts
+type SaslAuthenticateArgs<ParseResult> = {
+  request: SaslAuthenticationRequest
+  response?: SaslAuthenticationResponse<ParseResult>
+}
+
 type AuthenticationProviderArgs = {
   host: string
   port: number
   logger: Logger
   saslAuthenticate: <ParseResult>(
-    request: SaslAuthenticationRequest,
-    response?: SaslAuthenticationResponse<ParseResult>
+    args: SaslAuthenticateArgs<ParseResult>
   ) => Promise<ParseResult | void>
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,13 +28,17 @@ export type Authenticator = {
   authenticate: () => Promise<void>
 }
 
+export type SaslAuthenticateArgs<ParseResult> = {
+  request: SaslAuthenticationRequest
+  response?: SaslAuthenticationResponse<ParseResult>
+}
+
 export type AuthenticationProviderArgs = {
   host: string
   port: number
   logger: Logger
   saslAuthenticate: <ParseResult>(
-    request: SaslAuthenticationRequest,
-    response?: SaslAuthenticationResponse<ParseResult>
+    args: SaslAuthenticateArgs<ParseResult>
   ) => Promise<ParseResult | void>
 }
 
@@ -259,7 +263,7 @@ export interface ReplicaAssignment {
 }
 
 export interface PartitionReassignment {
-  topic: string,
+  topic: string
   partitionAssignment: Array<ReplicaAssignment>
 }
 
@@ -694,7 +698,10 @@ export type Broker = {
     topics: PartitionReassignment[]
     timeout?: number
   }): Promise<any>
-  listPartitionReassignments(request: { topics?: TopicPartitions[]; timeout?: number }): Promise<ListPartitionReassignmentsResponse>
+  listPartitionReassignments(request: {
+    topics?: TopicPartitions[]
+    timeout?: number
+  }): Promise<ListPartitionReassignmentsResponse>
 }
 
 interface MessageSetEntry {


### PR DESCRIPTION
These got missed in the original PR when the interface changed at the end. 

Fixes #1458