### PR TITLE
Allow disconnect on rebalance, currently if trying to rebalance kafka…

### DIFF
--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -86,15 +86,18 @@ module.exports = ({
     )
   }
 
+  let allowCrashReconnect = true
   /** @type {import("../../types").Consumer["connect"]} */
   const connect = async () => {
+    allowCrashReconnect = true
     await cluster.connect()
     instrumentationEmitter.emit(CONNECT)
   }
 
   /** @type {import("../../types").Consumer["disconnect"]} */
-  const disconnect = async () => {
+  const disconnect = async (lAllowCrashReconnect = false) => {
     try {
+      allowCrashReconnect = lAllowCrashReconnect
       await stop()
       logger.debug('consumer has stopped, disconnecting', { groupId })
       await cluster.disconnect()
@@ -201,6 +204,10 @@ module.exports = ({
     }
 
     const start = async onCrash => {
+      if (!allowCrashReconnect) {
+        return
+      }
+
       logger.info('Starting', { groupId })
 
       consumerGroup = new ConsumerGroup({
@@ -254,7 +261,7 @@ module.exports = ({
         cluster.removeBroker({ host: e.host, port: e.port })
       }
 
-      await disconnect()
+      await disconnect(allowCrashReconnect)
 
       const getOriginalCause = error => {
         if (error.cause) {
@@ -286,8 +293,12 @@ module.exports = ({
       instrumentationEmitter.emit(CRASH, {
         error: e,
         groupId,
-        restart: shouldRestart,
+        restart: shouldRestart && allowCrashReconnect,
       })
+
+      if (!allowCrashReconnect) {
+        return
+      }
 
       if (shouldRestart) {
         const retryTime = e.retryTime || (retry && retry.initialRetryTime) || initialRetryTime


### PR DESCRIPTION
Trying to fix the bug where if we call disconnect on kafka consumer and a rebalance is  in process then the disconnect does not work.
