### PR TITLE
Consider ILLEGAL_GENERATION error as rebalancing error

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -259,7 +259,9 @@ class KafkaJSAggregateError extends Error {
 class KafkaJSFetcherRebalanceError extends Error {}
 
 const isRebalancing = e =>
-  e.type === 'REBALANCE_IN_PROGRESS' || e.type === 'NOT_COORDINATOR_FOR_GROUP'
+  e.type === 'REBALANCE_IN_PROGRESS' ||
+  e.type === 'NOT_COORDINATOR_FOR_GROUP' ||
+  e.type === 'ILLEGAL_GENERATION'
 
 const isKafkaJSError = e => e instanceof KafkaJSError
 


### PR DESCRIPTION
This error is indicating that the consumer is trying to commit offsets, but the consumer group has changed to a new generation.

Retrying within the existing session will indeed not work, but rejoining the group and re-trying should be successful.

Fixes #1466