### PR TITLE
fix: dot buffer twice make sasl-auth error

### DIFF
--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -355,7 +355,7 @@ module.exports = class Connection {
         const requestPayload = await request.encode()
 
         this.failIfNotConnected()
-        this.socket.write(requestPayload.buffer, 'binary')
+        this.socket.write(requestPayload, 'binary')
       } catch (e) {
         reject(e)
       }


### PR DESCRIPTION
The method _request.encode()_ has returned a **Buffer** object , [[(PR)[Fix return type of request.encode to actually be a Buffer]](https://github.com/tulios/kafkajs/commit/533db2f155ceb6fcdee39e87acc67e51782b1e68)](https://github.com/tulios/kafkajs/commit/533db2f155ceb6fcdee39e87acc67e51782b1e68) ,but after ```const requestPayload = await request.encode()```，this line ```this.socket.write(requestPayload.buffer, 'binary')``` get buffer again, it will throws an unhandle exception  which makes sasl-auth error. This bug is in v2.2.0 +, maybe need **emergency** fix.