### PR TITLE
Fix(producer): sending messages as string occurs error

### DIFF
--- a/src/producer/messageProducer.js
+++ b/src/producer/messageProducer.js
@@ -63,7 +63,7 @@ module.exports = ({
     }
 
     for (const { topic, messages } of topicMessages) {
-      if (!messages) {
+      if (!messages || !Array.isArray(messages)) {
         throw new KafkaJSNonRetriableError(
           `Invalid messages array [${messages}] for topic "${topic}"`
         )


### PR DESCRIPTION
If messages send as string it occurs error line:72 messages.find.