### PR TITLE
Ensure checkPendingRequests is run when the throttle delay is marginal

### DIFF
--- a/src/broker/index.js
+++ b/src/broker/index.js
@@ -77,8 +77,8 @@ module.exports = class Broker {
    * @returns {Promise}
    */
   async connect() {
+    await this.lock.acquire()
     try {
-      await this.lock.acquire()
       if (this.isConnected()) {
         return
       }

--- a/src/network/requestQueue/index.spec.js
+++ b/src/network/requestQueue/index.spec.js
@@ -211,6 +211,28 @@ describe('Network > RequestQueue', () => {
       expect(sentAt).toBeGreaterThanOrEqual(before + clientSideThrottleTime)
     })
 
+    it('ensure request is sent when client-side throttling delay is marginal', async () => {
+      const sendDone = new Promise(resolve => {
+        request.sendRequest = () => {
+          resolve(Date.now())
+        }
+      })
+
+      expect(requestQueue.canSendSocketRequestImmediately()).toBe(true)
+      const socketRequest = requestQueue.createSocketRequest(request)
+      requestQueue.pending.push(socketRequest)
+
+      const before = Date.now()
+      const clientSideThrottleTime = 1
+      requestQueue.maybeThrottle(clientSideThrottleTime)
+      // Sleep until the marginal delay is passed before calling scheduleCheckPendingRequests()
+      await sleep(clientSideThrottleTime)
+      requestQueue.scheduleCheckPendingRequests()
+
+      const sentAt = await sendDone
+      expect(sentAt).toBeGreaterThanOrEqual(before + clientSideThrottleTime)
+    })
+
     it('does not allow for a inflight correlation ids collision', async () => {
       requestQueue.inflight.set(request.entry.correlationId, 'already existing inflight')
       expect(() => {


### PR DESCRIPTION
We have observed 10 minute pauses on consumers on fetch and it recovers after the Kafka broker resets the connection. Here are the logs from the client:
```
1:12:48.629 PM	
     correlationId: 67644
     expectResponse: true
     logger: kafkajs
     message: Request Fetch(key: 1, version: 11)
     namespace: Connection
     size: 143
```
```
1:12:48.630 PM	
     correlationId: 67644
     logger: kafkajs
     message: Request enqueued
     namespace: RequestQueue
```
```
1:22:48.632 PM	
     logger: kafkajs
     message: Kafka server has closed connection
     namespace: Connection
```
On debugging this further and reading the code, we observed that if the throttle delay is marginal (say in this case 1ms), in `push`, the request will not be sent immediately. When scheduleCheckPendingRequests is called, it computes `this.throttleUntil - Date.now()` again. When Data.now() progresses 1ms (race condition), `this.throttleUntil - Date.now()` is zero and checkPendingRequests() is not scheduled at all. Now this connection goes into a limbo until the brokers kills it based on `connections.max.idle.ms` configuration on broker (which defaults to 10 minutes).

This fixes the root cause of the same issue called out in #660.

The code changes:
- Ensure checkPendingRequests is run even when the throttle delay is marginal. When there are pending requests, we keep scheduling checkPendingRequests() periodically. I am open to changing the default interval if there are concerns.
- Ensure maybeThrottle accounts for negative values. This is extra protective and Java [client](https://github.com/apache/kafka/blob/1ed61e4090353bc9e4802ee09366f512dc60884f/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L854) does the same.
- (not specifically related to this bug but noticed it) Move the lock acquisition code out of try block to ensure we only release (in the finally) the lock after it is taken successfully
- Add a test that exposes the problem which passes with the fix.