### PR TITLE
fix: refreshMetadata should retry if topic does not exist and allowAu…

### DIFF
--- a/src/cluster/brokerPool.js
+++ b/src/cluster/brokerPool.js
@@ -206,7 +206,10 @@ module.exports = class BrokerPool {
         const replacedBrokersDisconnects = replacedBrokers.map(broker => broker.disconnect())
         await Promise.all([...brokerDisconnects, ...replacedBrokersDisconnects])
       } catch (e) {
-        if (e.type === 'LEADER_NOT_AVAILABLE') {
+        if (
+          e.type === 'LEADER_NOT_AVAILABLE' ||
+          (broker.allowAutoTopicCreation && e.type === 'UNKNOWN_TOPIC_OR_PARTITION')
+        ) {
           throw e
         }
 


### PR DESCRIPTION
…toTopicCreation is set

fix: #815

Not sure why it happens but it happens randomly. Seems like a race condition when 2 client try to create the same topic at the same time. This fix is tested and working