### PR TITLE
Correct parameter name in documentation for describeAcls.

### DIFF
--- a/docs/Admin.md
+++ b/docs/Admin.md
@@ -654,7 +654,7 @@ await admin.describeAcls({
   host: '*',
   permissionType: AclPermissionTypes.ALLOW,
   operation: AclOperationTypes.ANY,
-  resourcePatternTypeFilter: ResourcePatternTypes.LITERAL,
+  resourcePatternType: ResourcePatternTypes.LITERAL,
 })
 // {
 //   resources: [

--- a/website/versioned_docs/version-1.15.0/Admin.md
+++ b/website/versioned_docs/version-1.15.0/Admin.md
@@ -640,7 +640,7 @@ await admin.describeAcls({
   host: '*',
   permissionType: AclPermissionTypes.ALLOW,
   operation: AclOperationTypes.ANY,
-  resourcePatternTypeFilter: ResourcePatternTypes.LITERAL,
+  resourcePatternType: ResourcePatternTypes.LITERAL,
 })
 // {
 //   resources: [

--- a/website/versioned_docs/version-1.16.0/Admin.md
+++ b/website/versioned_docs/version-1.16.0/Admin.md
@@ -663,7 +663,7 @@ await admin.describeAcls({
   host: '*',
   permissionType: AclPermissionTypes.ALLOW,
   operation: AclOperationTypes.ANY,
-  resourcePatternTypeFilter: ResourcePatternTypes.LITERAL,
+  resourcePatternType: ResourcePatternTypes.LITERAL,
 })
 // {
 //   resources: [

--- a/website/versioned_docs/version-2.0.0/Admin.md
+++ b/website/versioned_docs/version-2.0.0/Admin.md
@@ -655,7 +655,7 @@ await admin.describeAcls({
   host: '*',
   permissionType: AclPermissionTypes.ALLOW,
   operation: AclOperationTypes.ANY,
-  resourcePatternTypeFilter: ResourcePatternTypes.LITERAL,
+  resourcePatternType: ResourcePatternTypes.LITERAL,
 })
 // {
 //   resources: [

--- a/website/versioned_docs/version-2.2.0/Admin.md
+++ b/website/versioned_docs/version-2.2.0/Admin.md
@@ -655,7 +655,7 @@ await admin.describeAcls({
   host: '*',
   permissionType: AclPermissionTypes.ALLOW,
   operation: AclOperationTypes.ANY,
-  resourcePatternTypeFilter: ResourcePatternTypes.LITERAL,
+  resourcePatternType: ResourcePatternTypes.LITERAL,
 })
 // {
 //   resources: [


### PR DESCRIPTION
Website and docs show `resourcePatternTypeFilter` parameter - which is the incorrect name in all versions back through `1.15.0`