### PR TITLE
sasl config must be unfrozen object - issues/1546

### DIFF
--- a/src/cluster/connectionPoolBuilder.js
+++ b/src/cluster/connectionPoolBuilder.js
@@ -63,6 +63,14 @@ module.exports = ({
     }
   }
 
+  const validateSasl = sasl => {
+    if (Object.isFrozen(sasl)) {
+      throw new KafkaJSNonRetriableError(
+        `Failed to connect: sasl object must be unfrozen`
+      )
+    }
+  }
+
   const getBrokers = async () => {
     let list
 
@@ -81,6 +89,7 @@ module.exports = ({
     }
 
     validateBrokers(list)
+    validateSasl(sasl)
 
     return list
   }


### PR DESCRIPTION
added restrictions of type of object of sasl config during initiating kafka