### PR TITLE
handled UncaughtException with Consumer Runner using this.onCrash in catch #1390

### DIFF
--- a/src/consumer/runner.js
+++ b/src/consumer/runner.js
@@ -124,7 +124,11 @@ module.exports = class Runner extends EventEmitter {
             memberId: this.consumerGroup.memberId,
           })
 
-          await this.consumerGroup.joinAndSync()
+          try {
+            await this.consumerGroup.joinAndSync()
+          } catch (e) {
+            return this.onCrash(e)
+          }
           return
         }
 
@@ -136,7 +140,11 @@ module.exports = class Runner extends EventEmitter {
           })
 
           this.consumerGroup.memberId = null
-          await this.consumerGroup.joinAndSync()
+          try {
+            await this.consumerGroup.joinAndSync()
+          } catch (e) {
+            return this.onCrash(e)
+          }
           return
         }
 


### PR DESCRIPTION
by adding this catch error on this.consumerGroup.joinAndSync() in consumer/runner.js
https://github.com/tulios/kafkajs/blob/ff3b1117f316d527ae170b550bc0f772614338e9/src/consumer/runner.js#L127C49-L127C49
the following error get caught
2022-06-10T18:38:26.771Z error: uncaughtException: The coordinator is loading and hence can't process requests for this group
`KafkaJSProtocolError: The coordinator is loading and hence can't process requests for this group
    at createErrorFromCode (/test/node_modules/kafkajs/src/protocol/error.js:581:10)
    at Object.parse (/test/node_modules/kafkajs/src/protocol/requests/joinGroup/v5/response.js:35:11)
    at Connection.send (/test/node_modules/kafkajs/src/network/connection.js:433:35)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Broker.[private:Broker:sendRequest] (/test/node_modules/kafkajs/src/broker/index.js:875:14)
    at async Broker.joinGroup (/test/node_modules/kafkajs/src/broker/index.js:395:14)
    at async ConsumerGroup.[private:ConsumerGroup:join] (/test/node_modules/kafkajs/src/consumer/consumerGroup.js:169:23)
    at async /test/node_modules/kafkajs/src/consumer/consumerGroup.js:335:9
    at async Runner.scheduleFetchManager (/test/node_modules/kafkajs/src/consumer/runner.js:112:11)
`
since this code number 14 is retriable as show in below object in error.js

```
{
  type: 'GROUP_LOAD_IN_PROGRESS',
  code: 14,
  retriable: true,
  message: "The coordinator is loading and hence can't process requests for this group",
}

```
the onCrash fucntion in consumer/index.js will try to restart and it is getting handled further instead of throwing uncaught error

this will solve #1394 

**kindly let me know your thoughts/suggestions**