### PR TITLE
[KIP-601] Increase connection timeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ module.exports = class Client {
    * @param {Object} options.ssl
    * @param {Object} options.sasl
    * @param {string} options.clientId
-   * @param {number} [options.connectionTimeout=1000] - in milliseconds
+   * @param {number} [options.connectionTimeout=10000] - in milliseconds
    * @param {number} options.authenticationTimeout - in milliseconds
    * @param {number} options.reauthenticationThreshold - in milliseconds
    * @param {number} [options.requestTimeout=30000] - in milliseconds
@@ -53,7 +53,7 @@ module.exports = class Client {
     ssl,
     sasl,
     clientId,
-    connectionTimeout = 1000,
+    connectionTimeout = 10000,
     authenticationTimeout,
     reauthenticationThreshold,
     requestTimeout,


### PR DESCRIPTION
being closer to the defaults in KIP-601.

In KafkaJS the connection establishment limit corresponds to the `connectionTimeout` + `authenticationTimeout`.

`authenticationTimeout` has been increased to 10s, but `connectionTimeout` is 1s.

KIP-601 `socket.connection.setup.timeout.ms` is about connection and in librdkafka corresponds to 30s, while in kafka-clients is exponential from a minimum of `socket.connection.setup.timeout.ms` (10s) to a maximum of `socket.connection.setup.timeout.max.ms` (30s).

This reduces the gap by setting the minimum to 10s and the sum of them to 20s.