### PR TITLE
Include the offending topic when metadata request returns unknown or unauthorized

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -38,6 +38,21 @@ class KafkaJSOffsetOutOfRange extends KafkaJSProtocolError {
   }
 }
 
+class KafkaJSUnknownTopic extends KafkaJSProtocolError {
+  constructor(e, { topic }) {
+    super(e, { retriable: false })
+    this.topic = topic
+    this.name = 'KafkaJSUnknownTopic'
+  }
+}
+
+class KafkaJSTopicAuthorizationFailed extends KafkaJSProtocolError {
+  constructor(e, { topic }) {
+    super(e, { retriable: false })
+    this.topic = topic
+    this.name = 'KafkaJSTopicAuthorizationFailed'
+  }
+}
 class KafkaJSMemberIdRequired extends KafkaJSProtocolError {
   constructor(e, { memberId }) {
     super(e)
@@ -304,6 +319,8 @@ module.exports = {
   KafkaJSFetcherRebalanceError,
   KafkaJSNoBrokerAvailableError,
   KafkaJSAlterPartitionReassignmentsError,
+  KafkaJSUnknownTopic,
+  KafkaJSTopicAuthorizationFailed,
   isRebalancing,
   isKafkaJSError,
 }

--- a/src/network/connection.js
+++ b/src/network/connection.js
@@ -445,6 +445,7 @@ module.exports = class Connection {
           error: e.message,
           correlationId,
           size,
+          topic: e.topic,
         })
       }
 

--- a/src/protocol/error.js
+++ b/src/protocol/error.js
@@ -592,10 +592,16 @@ const staleMetadata = e =>
     e.type
   )
 
+const errorCodesByType = errorCodes.reduce((codesByType, error) => {
+  codesByType[error.type] = error.code
+  return codesByType
+}, {})
+
 module.exports = {
   failure,
   errorCodes,
   createErrorFromCode,
   failIfVersionNotSupported,
   staleMetadata,
+  errorCodesByType,
 }

--- a/src/protocol/requests/metadata/v0/response.spec.js
+++ b/src/protocol/requests/metadata/v0/response.spec.js
@@ -67,5 +67,29 @@ describe('Protocol > Requests > Metadata > v0', () => {
         createErrorFromCode(5).message
       )
     })
+
+    test('when topicErrorCode is UNKNOWN_TOPIC_OR_PARTITION', async () => {
+      decoded.topicMetadata[0].topicErrorCode = 3
+      await expect(response.parse(decoded)).rejects.toMatchObject({
+        message: createErrorFromCode(3).message,
+        retriable: false,
+        type: 'UNKNOWN_TOPIC_OR_PARTITION',
+        code: 3,
+        name: 'KafkaJSUnknownTopic',
+        topic: 'test-topic-1',
+      })
+    })
+
+    test('when topicErrorCode is TOPIC_AUTHORIZATION_FAILED', async () => {
+      decoded.topicMetadata[0].topicErrorCode = 29
+      await expect(response.parse(decoded)).rejects.toMatchObject({
+        message: createErrorFromCode(29).message,
+        retriable: false,
+        type: 'TOPIC_AUTHORIZATION_FAILED',
+        code: 29,
+        name: 'KafkaJSTopicAuthorizationFailed',
+        topic: 'test-topic-1',
+      })
+    })
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1159,6 +1159,16 @@ export class KafkaJSOffsetOutOfRange extends KafkaJSProtocolError {
   constructor(e: Error | string, metadata?: KafkaJSOffsetOutOfRangeMetadata)
 }
 
+export class KafkaJSUnknownTopic extends KafkaJSProtocolError {
+  constructor(e: Error | string, metadata?: KafkaJSUnknownTopicMetadata)
+  readonly topic: string
+}
+
+export class KafkaJSTopicAuthorizationFailed extends KafkaJSProtocolError {
+  constructor(e: Error | string, metadata?: KafkaJSTopicAuthorizationFailedMetadata)
+  readonly topic: string
+}
+
 export class KafkaJSAlterPartitionReassignmentsError extends KafkaJSProtocolError {
   readonly topic?: string
   readonly partition?: number
@@ -1275,6 +1285,13 @@ export interface KafkaJSErrorMetadata {
 export interface KafkaJSOffsetOutOfRangeMetadata {
   topic: string
   partition: number
+}
+
+export interface KafkaJSUnknownTopicMetadata {
+  topic: string
+}
+export interface KafkaJSTopicAuthorizationFailedMetadata {
+  topic: string
 }
 
 export interface KafkaJSNumberOfRetriesExceededMetadata {

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -21,6 +21,8 @@ import {
   KafkaJSStaleTopicMetadataAssignment,
   PartitionMetadata,
   KafkaJSServerDoesNotSupportApiKey,
+  KafkaJSUnknownTopic,
+  KafkaJSTopicAuthorizationFailed
 } from './index'
 
 const { roundRobin } = PartitionAssigners
@@ -338,3 +340,6 @@ new KafkaJSServerDoesNotSupportApiKey(
     apiName: 'Produce',
   }
 )
+
+new KafkaJSUnknownTopic('This server does not host this topic-partition', { topic: 'my_topic' })
+new KafkaJSTopicAuthorizationFailed('Not authorized to access topics: [Topic authorization failed]', { topic: 'my_topic' })


### PR DESCRIPTION
This fixes  https://github.com/tulios/kafkajs/issues/957 and https://github.com/tulios/kafkajs/issues/129

A generic `KafkaJSProtocolError` is thrown when a kafka client tries to use a topic that is unknown to the broker or unauthorized for the client. Including the topic name in these cases is very useful for debugging because it allows the engineer to more rapidly know what needs to change with their cluster.

This PR includes the following:
1. A new `KafkaJSUnknownTopic` error which includes a `topic` property
2. A new `KafkaJSTopicAuthorizationFailed` error which includes a `topic property
3. When logging is enabled, the `error.topic` value is included in the log context with the log line.