### PR TITLE
Update Consuming.md seek documentation

### DIFF
--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -349,7 +349,7 @@ await consumer.subscribe({ topics: ['example'] })
 
 // you don't need to await consumer#run
 consumer.run({ eachMessage: async ({ topic, message }) => true })
-consumer.seek({ topic: 'example', partition: 0, offset: 12384 })
+consumer.seek({ topic: 'example', partition: 0, offset: "12384" })
 ```
 
 Upon seeking to an offset, any messages in active batches are marked as stale and discarded, making sure the next message read for the partition is from the offset sought to. Make sure to check `isStale()` before processing a message using [the `eachBatch` interface](#each-batch) of `consumer.run`.


### PR DESCRIPTION
The type offset is expecting is a string, but in the documentation it is a number. Funny enough, it is provided as a string afterwards. I changed it be a string both times for consistency and to make the sample runnable in typescript.

<img width="1445" alt="Screenshot 2024-02-01 at 2 28 36 PM" src="https://github.com/tulios/kafkajs/assets/15067287/96c409d9-42c0-447d-a574-c347acdbac07">
