### PR TITLE
Handle retriable throttling errors

### DIFF
--- a/src/protocol/error.js
+++ b/src/protocol/error.js
@@ -564,6 +564,12 @@ const errorCodes = [
     retriable: true,
     message: 'There are unstable offsets that need to be cleared',
   },
+  {
+    type: 'THROTTLING_QUOTA_EXCEEDED',
+    code: 89,
+    retriable: true,
+    message: 'The throttling quota has been exceeded',
+  },
 ]
 
 const unknownErrorCode = errorCode => ({


### PR DESCRIPTION
Throttling errors are used by many of the hosted Kafka providers as a way to implement ratelimiting and should be treated as retriable.

https://kafka.apache.org/protocol.html#protocol_error_codes