### PR TITLE
Fix types: make `validateOnly` optional also in `alterConfigs()`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -533,7 +533,7 @@ export type Admin = {
     resources: ResourceConfigQuery[]
     includeSynonyms: boolean
   }): Promise<DescribeConfigResponse>
-  alterConfigs(configs: { validateOnly: boolean; resources: IResourceConfig[] }): Promise<any>
+  alterConfigs(configs: { validateOnly?: boolean; resources: IResourceConfig[] }): Promise<any>
   listGroups(): Promise<{ groups: GroupOverview[] }>
   deleteGroups(groupIds: string[]): Promise<DeleteGroupsResult[]>
   describeGroups(groupIds: string[]): Promise<GroupDescriptions>


### PR DESCRIPTION
`validateOnly` defauilts to `false` in `createTopic()`, `createPartitions()` and `alterConfigs()`, but the types for the latter make it required.

This PR fixes types to reflect the code correctly.

Documented here:
https://github.com/tulios/kafkajs/blob/55b0b416308b9e597a5a6b97b0a6fd6b846255dc/src/admin/index.js#L672

Setting the default to false here:
https://github.com/tulios/kafkajs/blob/55b0b416308b9e597a5a6b97b0a6fd6b846255dc/src/admin/index.js#L744