### PR TITLE
fix max call stack error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,8 +69,8 @@ jobs:
         displayName: should skip tests
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn install
         displayName: yarn install
-      - bash: test $SKIP_TESTS && echo "Skipped!" || docker-compose -f ${COMPOSE_FILE} pull
-        displayName: docker-compose pull
+      - bash: test $SKIP_TESTS && echo "Skipped!" || docker compose -f ${COMPOSE_FILE} pull
+        displayName: docker compose pull
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn test:group:broker:ci
         displayName: test
       - task: PublishTestResults@2
@@ -94,8 +94,8 @@ jobs:
         displayName: should skip tests
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn install
         displayName: yarn install
-      - bash: test $SKIP_TESTS && echo "Skipped!" || docker-compose -f ${COMPOSE_FILE} pull
-        displayName: docker-compose pull
+      - bash: test $SKIP_TESTS && echo "Skipped!" || docker compose -f ${COMPOSE_FILE} pull
+        displayName: docker compose pull
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn test:group:admin:ci
         displayName: test
       - task: PublishTestResults@2
@@ -119,8 +119,8 @@ jobs:
         displayName: should skip tests
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn install
         displayName: yarn install
-      - bash: test $SKIP_TESTS && echo "Skipped!" || docker-compose -f ${COMPOSE_FILE} pull
-        displayName: docker-compose pull
+      - bash: test $SKIP_TESTS && echo "Skipped!" || docker compose -f ${COMPOSE_FILE} pull
+        displayName: docker compose pull
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn test:group:producer:ci
         displayName: test
       - task: PublishTestResults@2
@@ -144,8 +144,8 @@ jobs:
         displayName: should skip tests
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn install
         displayName: yarn install
-      - bash: test $SKIP_TESTS && echo "Skipped!" || docker-compose -f ${COMPOSE_FILE} pull
-        displayName: docker-compose pull
+      - bash: test $SKIP_TESTS && echo "Skipped!" || docker compose -f ${COMPOSE_FILE} pull
+        displayName: docker compose pull
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn test:group:consumer:ci
         displayName: test
         env:
@@ -171,8 +171,8 @@ jobs:
         displayName: should skip tests
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn install
         displayName: yarn install
-      - bash: test $SKIP_TESTS && echo "Skipped!" || docker-compose -f ${COMPOSE_FILE} pull
-        displayName: docker-compose pull
+      - bash: test $SKIP_TESTS && echo "Skipped!" || docker compose -f ${COMPOSE_FILE} pull
+        displayName: docker compose pull
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn test:group:others:ci
         displayName: test
       - task: PublishTestResults@2
@@ -199,8 +199,8 @@ jobs:
         displayName: should skip tests
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn install
         displayName: yarn install
-      - bash: test $SKIP_TESTS && echo "Skipped!" || docker-compose -f ${COMPOSE_FILE} pull
-        displayName: docker-compose pull
+      - bash: test $SKIP_TESTS && echo "Skipped!" || docker compose -f ${COMPOSE_FILE} pull
+        displayName: docker compose pull
       - bash: test $SKIP_TESTS && echo "Skipped!" || yarn test:group:oauthbearer:ci
         displayName: test
       - task: PublishTestResults@2

--- a/scripts/dockerComposeUp.sh
+++ b/scripts/dockerComposeUp.sh
@@ -3,7 +3,7 @@
 COMPOSE_FILE=${COMPOSE_FILE:="docker-compose.2_4.yml"}
 
 echo "Running compose file: ${COMPOSE_FILE}:"
-docker-compose -f "${COMPOSE_FILE}" up --force-recreate -d
+docker compose -f "${COMPOSE_FILE}" up --force-recreate -d
 if [ -z ${NO_LOGS} ]; then
-  docker-compose -f "${COMPOSE_FILE}" logs -f
+  docker compose -f "${COMPOSE_FILE}" logs -f
 fi

--- a/scripts/testWithKafka.sh
+++ b/scripts/testWithKafka.sh
@@ -3,7 +3,7 @@
 testCommand="$1"
 extraArgs="$2"
 
-export COMPOSE_FILE=${COMPOSE_FILE:="docker-compose.2_4.yml"}
+export COMPOSE_FILE=${COMPOSE_FILE:="docker compose.2_4.yml"}
 export KAFKAJS_DEBUG_PROTOCOL_BUFFERS=${KAFKAJS_DEBUG_PROTOCOL_BUFFERS:=1}
 
 find_container_id() {
@@ -16,7 +16,7 @@ find_container_id() {
 }
 
 quit() {
-  docker-compose -f "${COMPOSE_FILE}" down --remove-orphans
+  docker compose -f "${COMPOSE_FILE}" down --remove-orphans
   exit 1
 }
 
@@ -51,6 +51,6 @@ TEST_EXIT=$?
 echo
 
 if [ -z ${DO_NOT_STOP} ]; then
-  docker-compose -f "${COMPOSE_FILE}" down --remove-orphans
+  docker compose -f "${COMPOSE_FILE}" down --remove-orphans
 fi
 exit ${TEST_EXIT}

--- a/scripts/testWithKafka.sh
+++ b/scripts/testWithKafka.sh
@@ -3,7 +3,7 @@
 testCommand="$1"
 extraArgs="$2"
 
-export COMPOSE_FILE=${COMPOSE_FILE:="docker compose.2_4.yml"}
+export COMPOSE_FILE=${COMPOSE_FILE:="docker-compose.2_4.yml"}
 export KAFKAJS_DEBUG_PROTOCOL_BUFFERS=${KAFKAJS_DEBUG_PROTOCOL_BUFFERS:=1}
 
 find_container_id() {

--- a/scripts/waitForKafka.js
+++ b/scripts/waitForKafka.js
@@ -64,7 +64,7 @@ waitForNode(kafka3ContainerId)
 console.log('\nAll nodes up:')
 console.log(
   execa
-    .commandSync(`docker-compose -f ${process.env.COMPOSE_FILE} ps`, { shell: true })
+    .commandSync(`docker compose -f ${process.env.COMPOSE_FILE} ps`, { shell: true })
     .stdout.toString('utf-8')
 )
 

--- a/src/protocol/requests/fetch/v4/decodeMessages.js
+++ b/src/protocol/requests/fetch/v4/decodeMessages.js
@@ -25,7 +25,9 @@ const decodeMessages = async decoder => {
     while (messagesDecoder.canReadBytes(RECORD_BATCH_OVERHEAD)) {
       try {
         const recordBatch = await RecordBatchDecoder(messagesDecoder)
-        records.push(...recordBatch.records)
+        for(let i = 0; i < recordBatch.records.length; i++) {
+          records.push(recordBatch.records[i])
+        }
       } catch (e) {
         // The tail of the record batches can have incomplete records
         // due to how maxBytes works. See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-FetchAPI

--- a/src/protocol/requests/fetch/v4/decodeMessages.js
+++ b/src/protocol/requests/fetch/v4/decodeMessages.js
@@ -25,7 +25,7 @@ const decodeMessages = async decoder => {
     while (messagesDecoder.canReadBytes(RECORD_BATCH_OVERHEAD)) {
       try {
         const recordBatch = await RecordBatchDecoder(messagesDecoder)
-        for(let i = 0; i < recordBatch.records.length; i++) {
+        for (let i = 0; i < recordBatch.records.length; i++) {
           records.push(recordBatch.records[i])
         }
       } catch (e) {


### PR DESCRIPTION
how to reproduce the issue:
read a batch large enough which  can cause arg overflow.  tested on 10MB  batch size.
"source=Consumer, event=Crash: KafkaJSNonRetriableError: Maximum call stack size exceeded"