### PR TITLE
feat: skip acquiring lock if new new target topics

### DIFF
--- a/src/cluster/__tests__/addMultipleTargetTopics.spec.js
+++ b/src/cluster/__tests__/addMultipleTargetTopics.spec.js
@@ -42,4 +42,15 @@ describe('Cluster > addMultipleTargetTopics', () => {
     await cluster.addMultipleTargetTopics([topic1])
     expect(cluster.refreshMetadata).toHaveBeenCalledTimes(2)
   })
+
+  test('does not try to acquire lock if there are no new target topics', async () => {
+    cluster.mutatingTargetTopics.acquire = jest.fn()
+    const topic1 = `topic-${secureRandom()}`
+    const topic2 = `topic-${secureRandom()}`
+
+    await cluster.addMultipleTargetTopics([topic1, topic2])
+    await cluster.addMultipleTargetTopics([topic1])
+
+    expect(cluster.mutatingTargetTopics.acquire).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -214,7 +214,8 @@ module.exports = class Cluster {
    * @return {Promise}
    */
   async addMultipleTargetTopics(topics) {
-    if (this.targetTopics.isSupersetOf(new Set(topics))) {
+    const noNewTopics = topics.every(topic => this.targetTopics.has(topic))
+    if (noNewTopics) {
       return
     }
 

--- a/src/cluster/index.js
+++ b/src/cluster/index.js
@@ -214,6 +214,10 @@ module.exports = class Cluster {
    * @return {Promise}
    */
   async addMultipleTargetTopics(topics) {
+    if (this.targetTopics.isSupersetOf(new Set(topics))) {
+      return
+    }
+
     await this.mutatingTargetTopics.acquire()
 
     try {


### PR DESCRIPTION
Skips the process of acquiring the `mutatingTargetTopics` lock when running `cluster.addMultipleTargetTopics`, since the whole process is unnecessary if the target topics have not changed.