### PR TITLE
Fix: prevent negative timeout in scheduleCheckPendingRequests

### DIFF
--- a/src/network/requestQueue/index.js
+++ b/src/network/requestQueue/index.js
@@ -315,7 +315,7 @@ module.exports = class RequestQueue extends EventEmitter {
         scheduleAt = scheduleAt > 0 ? scheduleAt : CHECK_PENDING_REQUESTS_INTERVAL
       }
       // Prevent negative or invalid delays
-      scheduleAt = Math.max(0, scheduleAt || 0);
+      scheduleAt = Math.max(1, scheduleAt || 1)
       this.throttleCheckTimeoutId = setTimeout(() => {
         this.throttleCheckTimeoutId = null
         this.checkPendingRequests()

--- a/src/network/requestQueue/index.js
+++ b/src/network/requestQueue/index.js
@@ -314,6 +314,8 @@ module.exports = class RequestQueue extends EventEmitter {
       if (this.pending.length > 0) {
         scheduleAt = scheduleAt > 0 ? scheduleAt : CHECK_PENDING_REQUESTS_INTERVAL
       }
+      // Prevent negative or invalid delays
+      scheduleAt = Math.max(0, scheduleAt || 0);
       this.throttleCheckTimeoutId = setTimeout(() => {
         this.throttleCheckTimeoutId = null
         this.checkPendingRequests()


### PR DESCRIPTION
This pull request addresses Issue #1751, which logs the warning: TimeoutNegativeWarning