### PR TITLE
fix: Multiple kakfa consumer with the same groupId and different topics

### DIFF
--- a/src/consumer/assigners/roundRobinAssigner/index.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.js
@@ -37,28 +37,47 @@ module.exports = ({ cluster }) => ({
    *                   ]
    */
   async assign({ members, topics }) {
-    const membersCount = members.length
     const sortedMembers = members.map(({ memberId }) => memberId).sort()
     const assignment = {}
 
-    const topicsPartitions = topics.flatMap(topic => {
+    // Decode per-member topic subscriptions from member metadata
+    const memberSubscriptions = {}
+    for (const { memberId, memberMetadata } of members) {
+      if (memberMetadata) {
+        try {
+          const decoded = MemberMetadata.decode(memberMetadata)
+          if (decoded.topics && decoded.topics.length > 0) {
+            memberSubscriptions[memberId] = decoded.topics
+            continue
+          }
+        } catch (e) {}
+      }
+      // Fallback: member is treated as subscribed to all topics
+      memberSubscriptions[memberId] = topics
+    }
+
+    for (const topic of topics) {
+      const eligibleMembers = sortedMembers.filter(memberId =>
+        memberSubscriptions[memberId].includes(topic)
+      )
+
+      if (eligibleMembers.length === 0) continue
+
       const partitionMetadata = cluster.findTopicPartitionMetadata(topic)
-      return partitionMetadata.map(m => ({ topic: topic, partitionId: m.partitionId }))
-    })
+      partitionMetadata.forEach((m, i) => {
+        const assignee = eligibleMembers[i % eligibleMembers.length]
 
-    topicsPartitions.forEach((topicPartition, i) => {
-      const assignee = sortedMembers[i % membersCount]
+        if (!assignment[assignee]) {
+          assignment[assignee] = Object.create(null)
+        }
 
-      if (!assignment[assignee]) {
-        assignment[assignee] = Object.create(null)
-      }
+        if (!assignment[assignee][topic]) {
+          assignment[assignee][topic] = []
+        }
 
-      if (!assignment[assignee][topicPartition.topic]) {
-        assignment[assignee][topicPartition.topic] = []
-      }
-
-      assignment[assignee][topicPartition.topic].push(topicPartition.partitionId)
-    })
+        assignment[assignee][topic].push(m.partitionId)
+      })
+    }
 
     return Object.keys(assignment).map(memberId => ({
       memberId,

--- a/src/consumer/assigners/roundRobinAssigner/index.spec.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.spec.js
@@ -37,7 +37,7 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [0, 4, 8, 12],
-              'topic-B': [2],
+              'topic-B': [0, 4],
             },
           }),
         },
@@ -47,7 +47,7 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [1, 5, 9, 13],
-              'topic-B': [3],
+              'topic-B': [1],
             },
           }),
         },
@@ -57,7 +57,7 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [2, 6, 10],
-              'topic-B': [0, 4],
+              'topic-B': [2],
             },
           }),
         },
@@ -67,7 +67,66 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [3, 7, 11],
+              'topic-B': [3],
+            },
+          }),
+        },
+      ])
+    })
+
+    test('assign topic-partitions only to members subscribed to that topic', async () => {
+      metadata['topic-A'] = Array(4)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      metadata['topic-B'] = Array(3)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      metadata['topic-C'] = Array(2)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      const members = [
+        {
+          memberId: 'member-1',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-A', 'topic-B'],
+          }),
+        },
+        {
+          memberId: 'member-2',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-B', 'topic-C'],
+          }),
+        },
+      ]
+
+      const assignment = await assigner.assign({
+        members,
+        topics: ['topic-A', 'topic-B', 'topic-C'],
+      })
+
+      expect(assignment).toEqual([
+        {
+          memberId: 'member-1',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [0, 1, 2, 3],
+              'topic-B': [0, 2],
+            },
+          }),
+        },
+        {
+          memberId: 'member-2',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
               'topic-B': [1],
+              'topic-C': [0, 1],
             },
           }),
         },

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -11,7 +11,7 @@ const SubscriptionState = require('./subscriptionState')
 const {
   events: { GROUP_JOIN, HEARTBEAT, CONNECT, RECEIVED_UNSUBSCRIBED_TOPICS },
 } = require('./instrumentationEvents')
-const { MemberAssignment } = require('./assignerProtocol')
+const { MemberAssignment, MemberMetadata } = require('./assignerProtocol')
 const {
   KafkaJSError,
   KafkaJSNonRetriableError,
@@ -216,8 +216,28 @@ module.exports = class ConsumerGroup {
         )
       }
 
+      // Decode member metadata to find the union of all topics across the group,
+      // so the leader can load metadata and assign partitions for topics it may
+      // not be subscribed to itself (see https://github.com/tulios/kafkajs/issues/1040)
+      const allTopics = [
+        ...new Set(
+          members.flatMap(member => {
+            if (member.memberMetadata) {
+              try {
+                const decoded = MemberMetadata.decode(member.memberMetadata)
+                if (decoded.topics && decoded.topics.length > 0) {
+                  return decoded.topics
+                }
+              } catch (e) {}
+            }
+            return topicsSubscribed
+          })
+        ),
+      ]
+
+      await this.cluster.addMultipleTargetTopics(allTopics)
       await this.cluster.refreshMetadata()
-      assignment = await assigner.assign({ members, topics: topicsSubscribed })
+      assignment = await assigner.assign({ members, topics: allTopics })
 
       this.logger.debug('Group assignment', {
         groupId,


### PR DESCRIPTION
This pull request updates the round-robin partition assignment logic to ensure that topic partitions are only assigned to consumer group members who are actually subscribed to those topics. It also updates the group leader to consider the union of all subscribed topics across the group when loading metadata, addressing cases where the leader may not be subscribed to all topics itself. The test suite is expanded to cover these scenarios.

**Partition assignment logic improvements:**

* The `assign` method in `roundRobinAssigner` now decodes each member's topic subscriptions from their metadata and only assigns partitions for a topic to members who are subscribed to that topic. Members who do not specify subscriptions are treated as subscribed to all topics.
* The group leader in `ConsumerGroup` now computes the union of all topics subscribed to by any member, ensuring metadata is loaded for all relevant topics, not just those the leader is subscribed to.

**Test coverage enhancements:**

* The round-robin assigner tests are updated and expanded to verify that partitions are only assigned to subscribed members, including a new test case for mixed topic subscriptions. [[1]](diffhunk://#diff-31660322216e51adfedf8005c58ff6331a2dad6e48e958c32db81ae10af25fc6L40-R40) [[2]](diffhunk://#diff-31660322216e51adfedf8005c58ff6331a2dad6e48e958c32db81ae10af25fc6L50-R50) [[3]](diffhunk://#diff-31660322216e51adfedf8005c58ff6331a2dad6e48e958c32db81ae10af25fc6L60-R60) [[4]](diffhunk://#diff-31660322216e51adfedf8005c58ff6331a2dad6e48e958c32db81ae10af25fc6R70-R129)

**Other changes:**

* The `MemberMetadata` import is added to `consumerGroup.js` to enable decoding member subscriptions.


This PR is to solve the issue: https://github.com/tulios/kafkajs/issues/1040