### PR TITLE
feat(consumer): add cooperative sticky assigner and harden cooperative rejoin loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+  - Document topic-scoped round-robin assignment behavior for mixed-subscription consumer groups
+
+### Fixed
+  - Add configurable cap for cooperative in-process rejoin rounds (`maxCooperativeRejoinRounds`)
+  - Preserve backward compatibility for custom partition assigners by passing all group topics via optional `allSubscribedTopics`
+
 ## [2.2.4] - 2023-02-27
 
 ### Added

--- a/docs/Consuming.md
+++ b/docs/Consuming.md
@@ -219,6 +219,7 @@ When `fromBeginning` is `true`, the group will use the earliest offset. If set t
 kafka.consumer({
   groupId: <String>,
   partitionAssigners: <Array>,
+    maxCooperativeRejoinRounds: <Number>,
   sessionTimeout: <Number>,
   rebalanceTimeout: <Number>,
   heartbeatInterval: <Number>,
@@ -237,6 +238,7 @@ kafka.consumer({
 | option                 | description                                                                                                                                                                                                                                                                                                                                        | default                           |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
 | partitionAssigners     | List of partition assigners                                                                                                                                                                                                                                                                                                                        | `[PartitionAssigners.roundRobin]` |
+| maxCooperativeRejoinRounds | Maximum number of extra in-process JOIN/SYNC rounds allowed when a cooperative assigner asks for another rebalance cycle | `20` |
 | sessionTimeout         | Timeout in milliseconds used to detect failures. The consumer sends periodic heartbeats to indicate its liveness to the broker. If no heartbeats are received by the broker before the expiration of this session timeout, then the broker will remove this consumer from the group and initiate a rebalance                                       | `30000`                           |
 | rebalanceTimeout       | The maximum time that the coordinator will wait for each member to rejoin when rebalancing the group                                                                                                                                                                                                                                               | `60000`                           |
 | heartbeatInterval      | The expected time in milliseconds between heartbeats to the consumer coordinator. Heartbeats are used to ensure that the consumer's session stays active. The value must be set lower than session timeout                                                                                                                                         | `3000`                            |
@@ -375,10 +377,12 @@ A partition assigner is a function which returns an object with the following in
 const MyPartitionAssigner = ({ cluster }) => ({
     name: 'MyPartitionAssigner',
     version: 1,
-    async assign({ members, topics }) {},
+    async assign({ members, topics, allSubscribedTopics }) {},
     protocol({ topics }) {}
 })
 ```
+
+`topics` contains this member's subscribed topics (backward-compatible behavior). `allSubscribedTopics` is optional and contains the union of subscribed topics from the whole group.
 
 The method `assign` has to return an assignment plan with partitions per topic. A partition plan consists of a list of `memberId` and `memberAssignment`. The member assignment has to be encoded, use the `MemberAssignment` utility for that. Example:
 

--- a/src/consumer/__tests__/consumerGroup.spec.js
+++ b/src/consumer/__tests__/consumerGroup.spec.js
@@ -94,7 +94,8 @@ describe('ConsumerGroup', () => {
       expect(topicsArg.sort()).toEqual(['topic1', 'topic2'])
       expect(assigner.assign).toHaveBeenCalledWith({
         members: consumerGroup.members,
-        topics: ['topic1', 'topic2'],
+        topics: ['topic1'],
+        allSubscribedTopics: ['topic1', 'topic2'],
       })
     })
 
@@ -191,6 +192,54 @@ describe('ConsumerGroup', () => {
         expect.objectContaining({
           maxCooperativeRejoinRounds: 20,
           requestedBy: ['cooperative-sticky'],
+        })
+      )
+    })
+
+    test('joinAndSync honors configured max cooperative rounds', async () => {
+      consumerGroup = new ConsumerGroup({
+        logger: newLogger(),
+        topics: ['topic1'],
+        cluster: {},
+        groupId: 'group-1',
+        topicConfigurations: {},
+        instrumentationEmitter: { emit: jest.fn() },
+        assigners: [],
+        maxCooperativeRejoinRounds: 2,
+      })
+
+      consumerGroup.subscriptionState = {
+        assigned: () => [],
+      }
+
+      consumerGroup.logger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }
+
+      const joinSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:join')
+      const syncSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:sync')
+
+      consumerGroup[joinSymbol] = jest.fn(async () => {
+        consumerGroup.memberId = 'member-1'
+        consumerGroup.leaderId = 'member-1'
+        consumerGroup.groupProtocol = 'cooperative-sticky-kafkajs'
+      })
+      consumerGroup[syncSymbol] = jest.fn(async () => {
+        consumerGroup.needsCooperativeRejoin = true
+        consumerGroup.cooperativeRejoinRequestedBy = ['cooperative-sticky-kafkajs']
+      })
+
+      await expect(consumerGroup.joinAndSync()).rejects.toThrow(
+        'Exceeded maximum cooperative rejoin rounds (2)'
+      )
+      expect(consumerGroup[joinSymbol]).toHaveBeenCalledTimes(2)
+      expect(consumerGroup[syncSymbol]).toHaveBeenCalledTimes(2)
+      expect(consumerGroup.logger.error).toHaveBeenCalledWith(
+        'Exceeded cooperative rejoin round limit',
+        expect.objectContaining({
+          maxCooperativeRejoinRounds: 2,
         })
       )
     })

--- a/src/consumer/__tests__/consumerGroup.spec.js
+++ b/src/consumer/__tests__/consumerGroup.spec.js
@@ -1,4 +1,5 @@
 const ConsumerGroup = require('../consumerGroup')
+const { MemberAssignment, MemberMetadata } = require('../assignerProtocol')
 const { newLogger } = require('testHelpers')
 
 describe('ConsumerGroup', () => {
@@ -30,6 +31,168 @@ describe('ConsumerGroup', () => {
       await consumerGroup.commitOffsets(offsets)
       expect(consumerGroup.offsetManager.commitOffsets).toHaveBeenCalledTimes(1)
       expect(consumerGroup.offsetManager.commitOffsets).toHaveBeenCalledWith(offsets)
+    })
+  })
+
+  describe('mixed subscriptions and cooperative flow', () => {
+    const getPrivateSymbol = (instance, name) =>
+      Object.getOwnPropertySymbols(Object.getPrototypeOf(instance)).find(s =>
+        s.toString().includes(name)
+      )
+
+    test('leader loads union of member topics before assignment', async () => {
+      const cluster = {
+        addMultipleTargetTopics: jest.fn(async () => {}),
+        refreshMetadata: jest.fn(async () => {}),
+        findTopicPartitionMetadata: jest.fn(topic => [{ partitionId: 0, topic }]),
+        committedOffsets: jest.fn(() => ({})),
+      }
+      const assigner = {
+        name: 'roundRobin',
+        assign: jest.fn(async () => []),
+      }
+
+      consumerGroup = new ConsumerGroup({
+        logger: newLogger(),
+        topics: ['topic1'],
+        cluster,
+        groupId: 'group-1',
+        topicConfigurations: {},
+        instrumentationEmitter: { emit: jest.fn() },
+        assigners: [assigner],
+      })
+
+      consumerGroup.coordinator = {
+        syncGroup: jest.fn(async () => ({
+          memberAssignment: MemberAssignment.encode({
+            version: 0,
+            assignment: { topic1: [0], topic2: [0] },
+          }),
+        })),
+      }
+
+      consumerGroup.generationId = 1
+      consumerGroup.groupProtocol = 'roundRobin'
+      consumerGroup.memberId = 'leader'
+      consumerGroup.leaderId = 'leader'
+      consumerGroup.members = [
+        {
+          memberId: 'leader',
+          memberMetadata: MemberMetadata.encode({ version: 0, topics: ['topic1'] }),
+        },
+        {
+          memberId: 'follower',
+          memberMetadata: MemberMetadata.encode({ version: 0, topics: ['topic1', 'topic2'] }),
+        },
+      ]
+
+      const syncSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:sync')
+      await consumerGroup[syncSymbol]()
+
+      expect(cluster.addMultipleTargetTopics).toHaveBeenCalledTimes(1)
+      const [topicsArg] = cluster.addMultipleTargetTopics.mock.calls[0]
+      expect(topicsArg.sort()).toEqual(['topic1', 'topic2'])
+      expect(assigner.assign).toHaveBeenCalledWith({
+        members: consumerGroup.members,
+        topics: ['topic1', 'topic2'],
+      })
+    })
+
+    test('joinAndSync loops for cooperative second round when requested by assigner', async () => {
+      consumerGroup = new ConsumerGroup({
+        logger: newLogger(),
+        topics: ['topic1'],
+        cluster: {},
+        groupId: 'group-1',
+        topicConfigurations: {},
+        instrumentationEmitter: { emit: jest.fn() },
+        assigners: [],
+      })
+
+      consumerGroup.subscriptionState = {
+        assigned: () => [],
+      }
+
+      const joinSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:join')
+      const syncSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:sync')
+
+      let syncCalls = 0
+      consumerGroup[joinSymbol] = jest.fn(async () => {
+        consumerGroup.memberId = 'member-1'
+        consumerGroup.leaderId = 'member-1'
+        consumerGroup.groupProtocol = 'cooperative-sticky'
+      })
+      consumerGroup[syncSymbol] = jest.fn(async () => {
+        syncCalls += 1
+        consumerGroup.needsCooperativeRejoin = syncCalls === 1
+        consumerGroup.cooperativeRejoinRequestedBy = syncCalls === 1 ? ['cooperative-sticky'] : []
+      })
+
+      consumerGroup.logger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }
+
+      await consumerGroup.joinAndSync()
+
+      expect(consumerGroup[joinSymbol]).toHaveBeenCalledTimes(2)
+      expect(consumerGroup[syncSymbol]).toHaveBeenCalledTimes(2)
+      expect(consumerGroup.logger.warn).toHaveBeenCalledWith(
+        'Cooperative assigner requested additional join/sync round',
+        expect.objectContaining({
+          cooperativeRejoinRound: 1,
+          requestedBy: ['cooperative-sticky'],
+        })
+      )
+    })
+
+    test('joinAndSync fails fast after max cooperative rounds to avoid silent infinite loops', async () => {
+      consumerGroup = new ConsumerGroup({
+        logger: newLogger(),
+        topics: ['topic1'],
+        cluster: {},
+        groupId: 'group-1',
+        topicConfigurations: {},
+        instrumentationEmitter: { emit: jest.fn() },
+        assigners: [],
+      })
+
+      consumerGroup.subscriptionState = {
+        assigned: () => [],
+      }
+
+      consumerGroup.logger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      }
+
+      const joinSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:join')
+      const syncSymbol = getPrivateSymbol(consumerGroup, 'private:ConsumerGroup:sync')
+
+      consumerGroup[joinSymbol] = jest.fn(async () => {
+        consumerGroup.memberId = 'member-1'
+        consumerGroup.leaderId = 'member-1'
+        consumerGroup.groupProtocol = 'cooperative-sticky'
+      })
+      consumerGroup[syncSymbol] = jest.fn(async () => {
+        consumerGroup.needsCooperativeRejoin = true
+        consumerGroup.cooperativeRejoinRequestedBy = ['cooperative-sticky']
+      })
+
+      await expect(consumerGroup.joinAndSync()).rejects.toThrow(
+        'Exceeded maximum cooperative rejoin rounds (20)'
+      )
+      expect(consumerGroup[joinSymbol]).toHaveBeenCalledTimes(20)
+      expect(consumerGroup[syncSymbol]).toHaveBeenCalledTimes(20)
+      expect(consumerGroup.logger.error).toHaveBeenCalledWith(
+        'Exceeded cooperative rejoin round limit',
+        expect.objectContaining({
+          maxCooperativeRejoinRounds: 20,
+          requestedBy: ['cooperative-sticky'],
+        })
+      )
     })
   })
 })

--- a/src/consumer/assigners/cooperativeStickyAssigner/index.js
+++ b/src/consumer/assigners/cooperativeStickyAssigner/index.js
@@ -1,0 +1,305 @@
+const Encoder = require('../../../protocol/encoder')
+const Decoder = require('../../../protocol/decoder')
+const { MemberMetadata, MemberAssignment } = require('../../assignerProtocol')
+
+const DEFAULT_GENERATION = -1
+const CONTESTED = 'CONTESTED'
+
+const encodeUserData = (generationId, ownedPartitions) =>
+  new Encoder()
+    .writeInt32(generationId)
+    .writeArray(
+      Object.entries(ownedPartitions).map(([topic, partitions]) =>
+        new Encoder().writeString(topic).writeArray(partitions)
+      )
+    ).buffer
+
+const decodeUserData = buffer => {
+  if (!buffer || buffer.length === 0) {
+    return { generationId: DEFAULT_GENERATION, ownedPartitions: {} }
+  }
+
+  try {
+    const decoder = new Decoder(buffer)
+    const generationId = decoder.readInt32()
+    const entries = decoder.readArray(d => ({
+      topic: d.readString(),
+      partitions: d.readArray(pd => pd.readInt32()),
+    }))
+    const ownedPartitions = entries.reduce(
+      (acc, { topic, partitions }) => ({ ...acc, [topic]: partitions }),
+      {}
+    )
+
+    return { generationId, ownedPartitions }
+  } catch (_) {
+    return { generationId: DEFAULT_GENERATION, ownedPartitions: {} }
+  }
+}
+
+const safeDecodeMemberMetadata = (memberMetadata, allTopics, version) => {
+  if (!memberMetadata) {
+    return {
+      version,
+      topics: allTopics,
+      userData: Buffer.alloc(0),
+    }
+  }
+
+  try {
+    return MemberMetadata.decode(memberMetadata)
+  } catch (_) {
+    return {
+      version,
+      topics: allTopics,
+      userData: Buffer.alloc(0),
+    }
+  }
+}
+
+/**
+ * CooperativeStickyAssigner
+ *
+ * Sticky + cooperative assignment strategy (KIP-429 style):
+ *  1) Keep current ownership where possible (sticky)
+ *  2) Balance to quotas
+ *  3) If a partition transfer is needed, withhold it from the new owner this round
+ *     so the previous owner can revoke first (cooperative two-step handoff)
+ */
+module.exports = ({ cluster }) => {
+  let currentGenerationId = DEFAULT_GENERATION
+  let currentOwnedPartitions = {}
+
+  return {
+    name: 'cooperative-sticky',
+    version: 1,
+
+    onAssignment({ assignment, generationId }) {
+      const hadRevocations =
+        currentGenerationId !== DEFAULT_GENERATION &&
+        Object.entries(currentOwnedPartitions).some(([topic, parts]) =>
+          parts.some(p => !(assignment[topic] || []).includes(p))
+        )
+
+      currentGenerationId = generationId
+      currentOwnedPartitions = assignment
+      return hadRevocations
+    },
+
+    async assign({ members, topics }) {
+      const sortedMembers = members.map(m => m.memberId).sort()
+      const memberInfo = {}
+
+      for (const { memberId, memberMetadata } of members) {
+        const decoded = safeDecodeMemberMetadata(memberMetadata, topics, this.version)
+        const { generationId, ownedPartitions } = decodeUserData(decoded.userData)
+
+        memberInfo[memberId] = {
+          subscribedTopics: decoded.topics && decoded.topics.length > 0 ? decoded.topics : topics,
+          generationId,
+          ownedPartitions,
+        }
+      }
+
+      const topicPartitions = {}
+      for (const topic of topics) {
+        topicPartitions[topic] = cluster
+          .findTopicPartitionMetadata(topic)
+          .map(m => m.partitionId)
+          .sort((a, b) => a - b)
+      }
+
+      const prevOwner = {}
+      for (const topic of topics) {
+        prevOwner[topic] = {}
+      }
+
+      for (const memberId of sortedMembers) {
+        const { ownedPartitions, generationId, subscribedTopics } = memberInfo[memberId]
+
+        for (const [topic, partitions] of Object.entries(ownedPartitions)) {
+          if (!topicPartitions[topic]) continue
+          if (!subscribedTopics.includes(topic)) continue
+
+          for (const partitionId of partitions) {
+            if (!topicPartitions[topic].includes(partitionId)) continue
+
+            const existing = prevOwner[topic][partitionId]
+            if (existing === undefined) {
+              prevOwner[topic][partitionId] = memberId
+            } else if (existing !== CONTESTED) {
+              const existingGen = memberInfo[existing].generationId
+              if (existingGen === generationId) {
+                prevOwner[topic][partitionId] = CONTESTED
+              } else if (generationId > existingGen) {
+                prevOwner[topic][partitionId] = memberId
+              }
+            }
+          }
+        }
+      }
+
+      const assignment = {}
+      for (const memberId of sortedMembers) {
+        assignment[memberId] = {}
+      }
+
+      const unassigned = []
+      for (const topic of topics) {
+        for (const partitionId of topicPartitions[topic]) {
+          const owner = prevOwner[topic][partitionId]
+          if (
+            owner &&
+            owner !== CONTESTED &&
+            assignment[owner] !== undefined &&
+            memberInfo[owner].subscribedTopics.includes(topic)
+          ) {
+            if (!assignment[owner][topic]) assignment[owner][topic] = []
+            assignment[owner][topic].push(partitionId)
+          } else {
+            unassigned.push({ topic, partitionId })
+          }
+        }
+      }
+
+      const totalPartitions = topics.reduce((sum, topic) => sum + topicPartitions[topic].length, 0)
+      const memberCount = sortedMembers.length
+      const minQuota = Math.floor(totalPartitions / memberCount)
+      const maxQuota = Math.ceil(totalPartitions / memberCount)
+      const expectedMaxQuotaMembers = totalPartitions % memberCount
+
+      const countPartitions = memberId =>
+        Object.values(assignment[memberId]).reduce((sum, parts) => sum + parts.length, 0)
+
+      const trimTo = (memberId, target) => {
+        while (countPartitions(memberId) > target) {
+          let revoked = false
+          for (const topic of Object.keys(assignment[memberId])) {
+            if (assignment[memberId][topic] && assignment[memberId][topic].length > 0) {
+              const partitionId = assignment[memberId][topic].pop()
+              unassigned.push({ topic, partitionId })
+              if (assignment[memberId][topic].length === 0) {
+                delete assignment[memberId][topic]
+              }
+              revoked = true
+              break
+            }
+          }
+          if (!revoked) break
+        }
+      }
+
+      let currentMaxQuotaMembers = 0
+      for (const memberId of sortedMembers) {
+        trimTo(memberId, maxQuota)
+
+        if (countPartitions(memberId) > minQuota) {
+          if (currentMaxQuotaMembers < expectedMaxQuotaMembers) {
+            currentMaxQuotaMembers++
+          } else {
+            trimTo(memberId, minQuota)
+          }
+        }
+      }
+
+      let memberIdx = 0
+      for (const { topic, partitionId } of unassigned) {
+        let placed = false
+
+        for (let i = 0; i < sortedMembers.length; i++) {
+          const idx = (memberIdx + i) % sortedMembers.length
+          const candidate = sortedMembers[idx]
+          if (
+            memberInfo[candidate].subscribedTopics.includes(topic) &&
+            countPartitions(candidate) < minQuota
+          ) {
+            if (!assignment[candidate][topic]) assignment[candidate][topic] = []
+            assignment[candidate][topic].push(partitionId)
+            memberIdx = (idx + 1) % sortedMembers.length
+            placed = true
+            break
+          }
+        }
+
+        if (!placed) {
+          for (let i = 0; i < sortedMembers.length; i++) {
+            const idx = (memberIdx + i) % sortedMembers.length
+            const candidate = sortedMembers[idx]
+            if (
+              memberInfo[candidate].subscribedTopics.includes(topic) &&
+              countPartitions(candidate) < maxQuota
+            ) {
+              if (!assignment[candidate][topic]) assignment[candidate][topic] = []
+              assignment[candidate][topic].push(partitionId)
+              memberIdx = (idx + 1) % sortedMembers.length
+              placed = true
+              break
+            }
+          }
+        }
+      }
+
+      const makeKeySet = owned => {
+        const keys = new Set()
+        for (const [topic, parts] of Object.entries(owned)) {
+          for (const p of parts) keys.add(`${topic}:${p}`)
+        }
+        return keys
+      }
+
+      const allAdded = {}
+      const allRevoked = new Set()
+      for (const memberId of sortedMembers) {
+        const ownedSet = makeKeySet(memberInfo[memberId].ownedPartitions)
+        const assignedSet = makeKeySet(assignment[memberId])
+
+        for (const key of assignedSet) {
+          if (!ownedSet.has(key)) allAdded[key] = memberId
+        }
+        for (const key of ownedSet) {
+          if (!assignedSet.has(key)) allRevoked.add(key)
+        }
+      }
+
+      for (const [key, newOwner] of Object.entries(allAdded)) {
+        if (!allRevoked.has(key)) continue
+
+        const split = key.indexOf(':')
+        const topic = key.slice(0, split)
+        const partitionId = parseInt(key.slice(split + 1), 10)
+
+        if (assignment[newOwner][topic]) {
+          const idx = assignment[newOwner][topic].indexOf(partitionId)
+          if (idx !== -1) {
+            assignment[newOwner][topic].splice(idx, 1)
+            if (assignment[newOwner][topic].length === 0) {
+              delete assignment[newOwner][topic]
+            }
+          }
+        }
+      }
+
+      return sortedMembers.map(memberId => ({
+        memberId,
+        memberAssignment: MemberAssignment.encode({
+          version: this.version,
+          assignment: assignment[memberId],
+        }),
+      }))
+    },
+
+    protocol({ topics }) {
+      return {
+        name: this.name,
+        metadata: MemberMetadata.encode({
+          version: this.version,
+          topics,
+          userData: encodeUserData(currentGenerationId, currentOwnedPartitions),
+        }),
+      }
+    },
+  }
+}
+
+module.exports.encodeUserData = encodeUserData
+module.exports.decodeUserData = decodeUserData

--- a/src/consumer/assigners/cooperativeStickyAssigner/index.js
+++ b/src/consumer/assigners/cooperativeStickyAssigner/index.js
@@ -4,6 +4,8 @@ const { MemberMetadata, MemberAssignment } = require('../../assignerProtocol')
 
 const DEFAULT_GENERATION = -1
 const CONTESTED = 'CONTESTED'
+const NEEDS_REJOIN = 1
+const DOES_NOT_NEED_REJOIN = 0
 
 const encodeUserData = (generationId, ownedPartitions) =>
   new Encoder()
@@ -37,11 +39,27 @@ const decodeUserData = buffer => {
   }
 }
 
-const safeDecodeMemberMetadata = (memberMetadata, allTopics, version) => {
+const encodeAssignmentUserData = ({ needsRejoin }) =>
+  new Encoder().writeInt8(needsRejoin ? NEEDS_REJOIN : DOES_NOT_NEED_REJOIN).buffer
+
+const decodeAssignmentUserData = buffer => {
+  if (!buffer || buffer.length === 0) {
+    return { needsRejoin: false }
+  }
+
+  try {
+    const decoder = new Decoder(buffer)
+    return { needsRejoin: decoder.readInt8() === NEEDS_REJOIN }
+  } catch (_) {
+    return { needsRejoin: false }
+  }
+}
+
+const safeDecodeMemberMetadata = (memberMetadata, version) => {
   if (!memberMetadata) {
     return {
       version,
-      topics: allTopics,
+      topics: [],
       userData: Buffer.alloc(0),
     }
   }
@@ -51,7 +69,7 @@ const safeDecodeMemberMetadata = (memberMetadata, allTopics, version) => {
   } catch (_) {
     return {
       version,
-      topics: allTopics,
+      topics: [],
       userData: Buffer.alloc(0),
     }
   }
@@ -71,38 +89,41 @@ module.exports = ({ cluster }) => {
   let currentOwnedPartitions = {}
 
   return {
-    name: 'cooperative-sticky',
+    name: 'cooperative-sticky-kafkajs',
     version: 1,
 
-    onAssignment({ assignment, generationId }) {
+    onAssignment({ assignment, generationId, userData }) {
       const hadRevocations =
         currentGenerationId !== DEFAULT_GENERATION &&
         Object.entries(currentOwnedPartitions).some(([topic, parts]) =>
           parts.some(p => !(assignment[topic] || []).includes(p))
         )
 
+      const { needsRejoin } = decodeAssignmentUserData(userData)
+
       currentGenerationId = generationId
       currentOwnedPartitions = assignment
-      return hadRevocations
+      return hadRevocations || needsRejoin
     },
 
-    async assign({ members, topics }) {
+    async assign({ members, topics, allSubscribedTopics }) {
+      const assignableTopics = allSubscribedTopics || topics
       const sortedMembers = members.map(m => m.memberId).sort()
       const memberInfo = {}
 
       for (const { memberId, memberMetadata } of members) {
-        const decoded = safeDecodeMemberMetadata(memberMetadata, topics, this.version)
+        const decoded = safeDecodeMemberMetadata(memberMetadata, this.version)
         const { generationId, ownedPartitions } = decodeUserData(decoded.userData)
 
         memberInfo[memberId] = {
-          subscribedTopics: decoded.topics && decoded.topics.length > 0 ? decoded.topics : topics,
+          subscribedTopics: decoded.topics || [],
           generationId,
           ownedPartitions,
         }
       }
 
       const topicPartitions = {}
-      for (const topic of topics) {
+      for (const topic of assignableTopics) {
         topicPartitions[topic] = cluster
           .findTopicPartitionMetadata(topic)
           .map(m => m.partitionId)
@@ -110,7 +131,7 @@ module.exports = ({ cluster }) => {
       }
 
       const prevOwner = {}
-      for (const topic of topics) {
+      for (const topic of assignableTopics) {
         prevOwner[topic] = {}
       }
 
@@ -145,7 +166,7 @@ module.exports = ({ cluster }) => {
       }
 
       const unassigned = []
-      for (const topic of topics) {
+      for (const topic of assignableTopics) {
         for (const partitionId of topicPartitions[topic]) {
           const owner = prevOwner[topic][partitionId]
           if (
@@ -237,6 +258,18 @@ module.exports = ({ cluster }) => {
             }
           }
         }
+
+        if (!placed) {
+          const eligibleMembers = sortedMembers
+            .filter(memberId => memberInfo[memberId].subscribedTopics.includes(topic))
+            .sort((a, b) => countPartitions(a) - countPartitions(b) || a.localeCompare(b))
+
+          if (eligibleMembers.length > 0) {
+            const candidate = eligibleMembers[0]
+            if (!assignment[candidate][topic]) assignment[candidate][topic] = []
+            assignment[candidate][topic].push(partitionId)
+          }
+        }
       }
 
       const makeKeySet = owned => {
@@ -261,8 +294,11 @@ module.exports = ({ cluster }) => {
         }
       }
 
+      let needsAnotherRound = false
       for (const [key, newOwner] of Object.entries(allAdded)) {
         if (!allRevoked.has(key)) continue
+
+        needsAnotherRound = true
 
         const split = key.indexOf(':')
         const topic = key.slice(0, split)
@@ -284,6 +320,7 @@ module.exports = ({ cluster }) => {
         memberAssignment: MemberAssignment.encode({
           version: this.version,
           assignment: assignment[memberId],
+          userData: encodeAssignmentUserData({ needsRejoin: needsAnotherRound }),
         }),
       }))
     },
@@ -303,3 +340,4 @@ module.exports = ({ cluster }) => {
 
 module.exports.encodeUserData = encodeUserData
 module.exports.decodeUserData = decodeUserData
+module.exports.decodeAssignmentUserData = decodeAssignmentUserData

--- a/src/consumer/assigners/cooperativeStickyAssigner/index.spec.js
+++ b/src/consumer/assigners/cooperativeStickyAssigner/index.spec.js
@@ -1,0 +1,102 @@
+const CooperativeStickyAssigner = require('./index')
+const { encodeUserData, decodeUserData } = require('./index')
+const { MemberAssignment, MemberMetadata } = require('../../assignerProtocol')
+
+const makeCluster = topicCounts => {
+  const metadata = {}
+  for (const [topic, count] of Object.entries(topicCounts)) {
+    metadata[topic] = Array.from({ length: count }, (_, i) => ({ partitionId: i }))
+  }
+  return { findTopicPartitionMetadata: topic => metadata[topic] || [] }
+}
+
+const makeMember = (memberId, topics, ownedPartitions = {}, generationId = -1) => ({
+  memberId,
+  memberMetadata: MemberMetadata.encode({
+    version: 1,
+    topics,
+    userData: encodeUserData(generationId, ownedPartitions),
+  }),
+})
+
+const decodeAssignment = buffer => MemberAssignment.decode(buffer).assignment
+
+const assignAndDecode = async (assigner, members, topics) => {
+  const result = await assigner.assign({ members, topics })
+  return result.reduce((acc, { memberId, memberAssignment }) => {
+    acc[memberId] = decodeAssignment(memberAssignment)
+    return acc
+  }, {})
+}
+
+describe('Consumer > assigners > CooperativeStickyAssigner', () => {
+  test('protocol name is cooperative-sticky and metadata includes userData', () => {
+    const assigner = CooperativeStickyAssigner({ cluster: makeCluster({ A: 1 }) })
+    const { name, metadata } = assigner.protocol({ topics: ['A'] })
+
+    expect(name).toBe('cooperative-sticky')
+    const decoded = MemberMetadata.decode(metadata)
+    expect(decoded.topics).toEqual(['A'])
+    expect(decodeUserData(decoded.userData)).toEqual({ generationId: -1, ownedPartitions: {} })
+  })
+
+  test('decodeUserData is resilient to malformed bytes', () => {
+    expect(decodeUserData(Buffer.from('bad'))).toEqual({ generationId: -1, ownedPartitions: {} })
+  })
+
+  test('assign is resilient to malformed member metadata', async () => {
+    const assigner = CooperativeStickyAssigner({ cluster: makeCluster({ A: 2 }) })
+    const members = [
+      { memberId: 'm1', memberMetadata: Buffer.from('invalid') },
+      makeMember('m2', ['A']),
+    ]
+
+    await expect(assigner.assign({ members, topics: ['A'] })).resolves.toBeDefined()
+  })
+
+  test('withholds transferred partitions in first round and completes in second round', async () => {
+    const cluster = makeCluster({ A: 4 })
+    const assigner = CooperativeStickyAssigner({ cluster })
+
+    // Round 1: c1 owns all, c2 joins. Transfers should be withheld from c2.
+    const round1 = await assignAndDecode(
+      assigner,
+      [makeMember('c1', ['A'], { A: [0, 1, 2, 3] }, 1), makeMember('c2', ['A'], {}, -1)],
+      ['A']
+    )
+
+    expect((round1.c1.A || []).sort()).toEqual([0, 1])
+    expect(round1.c2.A || []).toEqual([])
+
+    // c1 persists round-0 ownership, then revokes in round-1
+    expect(assigner.onAssignment({ assignment: { A: [0, 1, 2, 3] }, generationId: 1 })).toBe(false)
+    expect(assigner.onAssignment({ assignment: { A: [0, 1] }, generationId: 2 })).toBe(true)
+    const c1MetadataR2 = assigner.protocol({ topics: ['A'] }).metadata
+
+    // Round 2: previously transferred partitions are now unowned and can be assigned
+    const round2 = await assignAndDecode(
+      assigner,
+      [{ memberId: 'c1', memberMetadata: c1MetadataR2 }, makeMember('c2', ['A'], {}, 2)],
+      ['A']
+    )
+
+    expect((round2.c1.A || []).sort()).toEqual([0, 1])
+    expect((round2.c2.A || []).sort()).toEqual([2, 3])
+  })
+
+  test('rolling deployment scenario with mixed subscriptions stays stable', async () => {
+    const assigner = CooperativeStickyAssigner({ cluster: makeCluster({ A: 2, B: 2 }) })
+    const assignment = await assignAndDecode(
+      assigner,
+      [makeMember('old', ['A'], { A: [0, 1] }, 3), makeMember('new', ['A', 'B'], {}, -1)],
+      ['A', 'B']
+    )
+
+    // no crash, all topics represented by subscribers
+    const total = Object.values(assignment).reduce(
+      (sum, byTopic) => sum + Object.values(byTopic).reduce((s, ps) => s + ps.length, 0),
+      0
+    )
+    expect(total).toBeGreaterThan(0)
+  })
+})

--- a/src/consumer/assigners/cooperativeStickyAssigner/index.spec.js
+++ b/src/consumer/assigners/cooperativeStickyAssigner/index.spec.js
@@ -1,5 +1,5 @@
 const CooperativeStickyAssigner = require('./index')
-const { encodeUserData, decodeUserData } = require('./index')
+const { encodeUserData, decodeUserData, decodeAssignmentUserData } = require('./index')
 const { MemberAssignment, MemberMetadata } = require('../../assignerProtocol')
 
 const makeCluster = topicCounts => {
@@ -30,11 +30,11 @@ const assignAndDecode = async (assigner, members, topics) => {
 }
 
 describe('Consumer > assigners > CooperativeStickyAssigner', () => {
-  test('protocol name is cooperative-sticky and metadata includes userData', () => {
+  test('protocol name is cooperative-sticky-kafkajs and metadata includes userData', () => {
     const assigner = CooperativeStickyAssigner({ cluster: makeCluster({ A: 1 }) })
     const { name, metadata } = assigner.protocol({ topics: ['A'] })
 
-    expect(name).toBe('cooperative-sticky')
+    expect(name).toBe('cooperative-sticky-kafkajs')
     const decoded = MemberMetadata.decode(metadata)
     expect(decoded.topics).toEqual(['A'])
     expect(decodeUserData(decoded.userData)).toEqual({ generationId: -1, ownedPartitions: {} })
@@ -51,7 +51,9 @@ describe('Consumer > assigners > CooperativeStickyAssigner', () => {
       makeMember('m2', ['A']),
     ]
 
-    await expect(assigner.assign({ members, topics: ['A'] })).resolves.toBeDefined()
+    const assignments = await assignAndDecode(assigner, members, ['A'])
+    expect(assignments.m1).toEqual({})
+    expect((assignments.m2.A || []).sort()).toEqual([0, 1])
   })
 
   test('withholds transferred partitions in first round and completes in second round', async () => {
@@ -84,7 +86,23 @@ describe('Consumer > assigners > CooperativeStickyAssigner', () => {
     expect((round2.c2.A || []).sort()).toEqual([2, 3])
   })
 
-  test('rolling deployment scenario with mixed subscriptions stays stable', async () => {
+  test('marks all members for rejoin when cooperative transfer is withheld', async () => {
+    const cluster = makeCluster({ A: 4 })
+    const assigner = CooperativeStickyAssigner({ cluster })
+
+    const result = await assigner.assign({
+      members: [makeMember('c1', ['A'], { A: [0, 1, 2, 3] }, 1), makeMember('c2', ['A'], {}, -1)],
+      topics: ['A'],
+      allSubscribedTopics: ['A'],
+    })
+
+    for (const { memberAssignment } of result) {
+      const decoded = MemberAssignment.decode(memberAssignment)
+      expect(decodeAssignmentUserData(decoded.userData)).toEqual({ needsRejoin: true })
+    }
+  })
+
+  test('rolling deployment scenario with mixed subscriptions keeps full eligible coverage', async () => {
     const assigner = CooperativeStickyAssigner({ cluster: makeCluster({ A: 2, B: 2 }) })
     const assignment = await assignAndDecode(
       assigner,
@@ -92,11 +110,25 @@ describe('Consumer > assigners > CooperativeStickyAssigner', () => {
       ['A', 'B']
     )
 
-    // no crash, all topics represented by subscribers
-    const total = Object.values(assignment).reduce(
-      (sum, byTopic) => sum + Object.values(byTopic).reduce((s, ps) => s + ps.length, 0),
-      0
-    )
-    expect(total).toBeGreaterThan(0)
+    expect((assignment.old.A || []).sort()).toEqual([0, 1])
+    expect(assignment.old.B || []).toEqual([])
+    expect(assignment.new.A || []).toEqual([])
+    expect((assignment.new.B || []).sort()).toEqual([0, 1])
+
+    const seen = new Set()
+    for (const [memberId, byTopic] of Object.entries(assignment)) {
+      for (const [topic, partitions] of Object.entries(byTopic)) {
+        for (const partition of partitions) {
+          const key = `${topic}:${partition}`
+          expect(seen.has(key)).toBe(false)
+          seen.add(key)
+
+          if (memberId === 'old') {
+            expect(topic).toBe('A')
+          }
+        }
+      }
+    }
+    expect(seen).toEqual(new Set(['A:0', 'A:1', 'B:0', 'B:1']))
   })
 })

--- a/src/consumer/assigners/index.js
+++ b/src/consumer/assigners/index.js
@@ -1,5 +1,7 @@
 const roundRobin = require('./roundRobinAssigner')
+const cooperativeSticky = require('./cooperativeStickyAssigner')
 
 module.exports = {
   roundRobin,
+  cooperativeSticky,
 }

--- a/src/consumer/assigners/roundRobinAssigner/index.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.js
@@ -37,28 +37,47 @@ module.exports = ({ cluster }) => ({
    *                   ]
    */
   async assign({ members, topics }) {
-    const membersCount = members.length
     const sortedMembers = members.map(({ memberId }) => memberId).sort()
     const assignment = {}
 
-    const topicsPartitions = topics.flatMap(topic => {
+    // Decode per-member topic subscriptions from member metadata
+    const memberSubscriptions = {}
+    for (const { memberId, memberMetadata } of members) {
+      if (memberMetadata) {
+        try {
+          const decoded = MemberMetadata.decode(memberMetadata)
+          if (decoded.topics && decoded.topics.length > 0) {
+            memberSubscriptions[memberId] = decoded.topics
+            continue
+          }
+        } catch (e) {}
+      }
+      // Fallback: member is treated as subscribed to all topics
+      memberSubscriptions[memberId] = topics
+    }
+
+    for (const topic of topics) {
+      const eligibleMembers = sortedMembers.filter(memberId =>
+        memberSubscriptions[memberId].includes(topic)
+      )
+
+      if (eligibleMembers.length === 0) continue
+
       const partitionMetadata = cluster.findTopicPartitionMetadata(topic)
-      return partitionMetadata.map(m => ({ topic: topic, partitionId: m.partitionId }))
-    })
+      partitionMetadata.forEach((m, i) => {
+        const assignee = eligibleMembers[i % eligibleMembers.length]
 
-    topicsPartitions.forEach((topicPartition, i) => {
-      const assignee = sortedMembers[i % membersCount]
+        if (!assignment[assignee]) {
+          assignment[assignee] = Object.create(null)
+        }
 
-      if (!assignment[assignee]) {
-        assignment[assignee] = Object.create(null)
-      }
+        if (!assignment[assignee][topic]) {
+          assignment[assignee][topic] = []
+        }
 
-      if (!assignment[assignee][topicPartition.topic]) {
-        assignment[assignee][topicPartition.topic] = []
-      }
-
-      assignment[assignee][topicPartition.topic].push(topicPartition.partitionId)
-    })
+        assignment[assignee][topic].push(m.partitionId)
+      })
+    }
 
     return Object.keys(assignment).map(memberId => ({
       memberId,

--- a/src/consumer/assigners/roundRobinAssigner/index.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.js
@@ -36,7 +36,8 @@ module.exports = ({ cluster }) => ({
    *                     }
    *                   ]
    */
-  async assign({ members, topics }) {
+  async assign({ members, topics, allSubscribedTopics }) {
+    const assignableTopics = allSubscribedTopics || topics
     const sortedMembers = members.map(({ memberId }) => memberId).sort()
     const assignment = {}
 
@@ -61,10 +62,10 @@ module.exports = ({ cluster }) => ({
         } catch (e) {}
       }
       // Fallback: member is treated as subscribed to all topics
-      memberSubscriptions[memberId] = topics
+      memberSubscriptions[memberId] = assignableTopics
     }
 
-    for (const topic of topics) {
+    for (const topic of assignableTopics) {
       // Topic-level filter: this is the correct abstraction for assigner eligibility.
       const eligibleMembers = sortedMembers.filter(memberId =>
         memberSubscriptions[memberId].includes(topic)

--- a/src/consumer/assigners/roundRobinAssigner/index.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.js
@@ -40,7 +40,15 @@ module.exports = ({ cluster }) => ({
     const sortedMembers = members.map(({ memberId }) => memberId).sort()
     const assignment = {}
 
-    // Decode per-member topic subscriptions from member metadata
+    // NOTE:
+    // Eligibility is topic-scoped (not partition-scoped).
+    // MemberMetadata carries subscribed topics only, so we:
+    //   1) build eligible members per topic
+    //   2) distribute that topic's partitions across only those members
+    // This keeps mixed-subscription rollouts stable (e.g. v1[A] + v2[A,B]).
+
+    // Decode per-member topic subscriptions from member metadata.
+    // If decode fails, fallback remains intentionally safe/non-throwing.
     const memberSubscriptions = {}
     for (const { memberId, memberMetadata } of members) {
       if (memberMetadata) {
@@ -57,6 +65,7 @@ module.exports = ({ cluster }) => ({
     }
 
     for (const topic of topics) {
+      // Topic-level filter: this is the correct abstraction for assigner eligibility.
       const eligibleMembers = sortedMembers.filter(memberId =>
         memberSubscriptions[memberId].includes(topic)
       )
@@ -65,6 +74,8 @@ module.exports = ({ cluster }) => ({
 
       const partitionMetadata = cluster.findTopicPartitionMetadata(topic)
       partitionMetadata.forEach((m, i) => {
+        // Round-robin partitions within the already-eligible member set.
+        // No additional partition-level subscription checks are expected here.
         const assignee = eligibleMembers[i % eligibleMembers.length]
 
         if (!assignment[assignee]) {

--- a/src/consumer/assigners/roundRobinAssigner/index.spec.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.spec.js
@@ -37,7 +37,7 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [0, 4, 8, 12],
-              'topic-B': [2],
+              'topic-B': [0, 4],
             },
           }),
         },
@@ -47,7 +47,7 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [1, 5, 9, 13],
-              'topic-B': [3],
+              'topic-B': [1],
             },
           }),
         },
@@ -57,7 +57,7 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [2, 6, 10],
-              'topic-B': [0, 4],
+              'topic-B': [2],
             },
           }),
         },
@@ -67,7 +67,66 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
             version: assigner.version,
             assignment: {
               'topic-A': [3, 7, 11],
+              'topic-B': [3],
+            },
+          }),
+        },
+      ])
+    })
+
+    test('assign topic-partitions only to members subscribed to that topic', async () => {
+      metadata['topic-A'] = Array(4)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      metadata['topic-B'] = Array(3)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      metadata['topic-C'] = Array(2)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      const members = [
+        {
+          memberId: 'member-1',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-A', 'topic-B'],
+          }),
+        },
+        {
+          memberId: 'member-2',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-B', 'topic-C'],
+          }),
+        },
+      ]
+
+      const assignment = await assigner.assign({
+        members,
+        topics: ['topic-A', 'topic-B', 'topic-C'],
+      })
+
+      expect(assignment).toEqual([
+        {
+          memberId: 'member-1',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [0, 1, 2, 3],
+              'topic-B': [0, 2],
+            },
+          }),
+        },
+        {
+          memberId: 'member-2',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
               'topic-B': [1],
+              'topic-C': [0, 1],
             },
           }),
         },

--- a/src/consumer/assigners/roundRobinAssigner/index.spec.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.spec.js
@@ -133,6 +133,106 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
       ])
     })
 
+    test('falls back safely when member metadata decode fails', async () => {
+      metadata['topic-A'] = Array(2)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+      metadata['topic-B'] = Array(2)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      const members = [
+        { memberId: 'member-1', memberMetadata: Buffer.from('invalid-metadata') },
+        {
+          memberId: 'member-2',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-B'],
+          }),
+        },
+      ]
+
+      const assignment = await assigner.assign({
+        members,
+        topics: ['topic-A', 'topic-B'],
+      })
+
+      expect(assignment).toEqual([
+        {
+          memberId: 'member-1',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [0, 1],
+              'topic-B': [0],
+            },
+          }),
+        },
+        {
+          memberId: 'member-2',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-B': [1],
+            },
+          }),
+        },
+      ])
+    })
+
+    test('rolling deployment regression: v1[A] + v2[A,B] keeps B assignable', async () => {
+      metadata['topic-A'] = Array(2)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+      metadata['topic-B'] = Array(3)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      const members = [
+        {
+          memberId: 'old-v1',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-A'],
+          }),
+        },
+        {
+          memberId: 'new-v2',
+          memberMetadata: MemberMetadata.encode({
+            version: assigner.version,
+            topics: ['topic-A', 'topic-B'],
+          }),
+        },
+      ]
+
+      const assignment = await assigner.assign({
+        members,
+        topics: ['topic-A', 'topic-B'],
+      })
+
+      expect(assignment).toEqual([
+        {
+          memberId: 'new-v2',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [0],
+              'topic-B': [0, 1, 2],
+            },
+          }),
+        },
+        {
+          memberId: 'old-v1',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [1],
+            },
+          }),
+        },
+      ])
+    })
+
     test('assign topics with names taken from builtin functions', async () => {
       topics = ['shift', 'toString']
       metadata['shift'] = [{ partitionId: 0 }]

--- a/src/consumer/assigners/roundRobinAssigner/index.spec.js
+++ b/src/consumer/assigners/roundRobinAssigner/index.spec.js
@@ -231,6 +231,65 @@ describe('Consumer > assigners > RoundRobinAssigner', () => {
           }),
         },
       ])
+
+      const byMember = assignment.reduce((acc, { memberId, memberAssignment }) => {
+        acc[memberId] = MemberAssignment.decode(memberAssignment).assignment
+        return acc
+      }, {})
+
+      expect(new Set(byMember['new-v2']['topic-B'])).toEqual(new Set([0, 1, 2]))
+      expect(byMember['old-v1']['topic-B']).toBeUndefined()
+
+      const seen = new Set()
+      for (const { memberAssignment } of assignment) {
+        const decoded = MemberAssignment.decode(memberAssignment).assignment
+        for (const [topic, partitions] of Object.entries(decoded)) {
+          for (const partition of partitions) {
+            const key = `${topic}:${partition}`
+            expect(seen.has(key)).toBe(false)
+            seen.add(key)
+          }
+        }
+      }
+      expect(seen).toEqual(
+        new Set(['topic-A:0', 'topic-A:1', 'topic-B:0', 'topic-B:1', 'topic-B:2'])
+      )
+    })
+
+    test('documents topic-scoped round-robin contract', async () => {
+      metadata['topic-A'] = Array(4)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+      metadata['topic-B'] = Array(4)
+        .fill()
+        .map((_, i) => ({ partitionId: i }))
+
+      const members = [{ memberId: 'member-1' }, { memberId: 'member-2' }]
+
+      const assignment = await assigner.assign({ members, topics: ['topic-A', 'topic-B'] })
+
+      expect(assignment).toEqual([
+        {
+          memberId: 'member-1',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [0, 2],
+              'topic-B': [0, 2],
+            },
+          }),
+        },
+        {
+          memberId: 'member-2',
+          memberAssignment: MemberAssignment.encode({
+            version: assigner.version,
+            assignment: {
+              'topic-A': [1, 3],
+              'topic-B': [1, 3],
+            },
+          }),
+        },
+      ])
     })
 
     test('assign topics with names taken from builtin functions', async () => {

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -11,7 +11,7 @@ const SubscriptionState = require('./subscriptionState')
 const {
   events: { GROUP_JOIN, HEARTBEAT, CONNECT, RECEIVED_UNSUBSCRIBED_TOPICS },
 } = require('./instrumentationEvents')
-const { MemberAssignment } = require('./assignerProtocol')
+const { MemberAssignment, MemberMetadata } = require('./assignerProtocol')
 const {
   KafkaJSError,
   KafkaJSNonRetriableError,
@@ -216,8 +216,28 @@ module.exports = class ConsumerGroup {
         )
       }
 
+      // Decode member metadata to find the union of all topics across the group,
+      // so the leader can load metadata and assign partitions for topics it may
+      // not be subscribed to itself (see https://github.com/tulios/kafkajs/issues/1040)
+      const allTopics = [
+        ...new Set(
+          members.flatMap(member => {
+            if (member.memberMetadata) {
+              try {
+                const decoded = MemberMetadata.decode(member.memberMetadata)
+                if (decoded.topics && decoded.topics.length > 0) {
+                  return decoded.topics
+                }
+              } catch (e) {}
+            }
+            return topicsSubscribed
+          })
+        ),
+      ]
+
+      await this.cluster.addMultipleTargetTopics(allTopics)
       await this.cluster.refreshMetadata()
-      assignment = await assigner.assign({ members, topics: topicsSubscribed })
+      assignment = await assigner.assign({ members, topics: allTopics })
 
       this.logger.debug('Group assignment', {
         groupId,

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -62,6 +62,7 @@ module.exports = class ConsumerGroup {
    * @param {number} options.isolationLevel
    * @param {string} options.rackId
    * @param {number} options.metadataMaxAge
+   * @param {number} [options.maxCooperativeRejoinRounds]
    */
   constructor({
     retry,
@@ -84,6 +85,7 @@ module.exports = class ConsumerGroup {
     isolationLevel,
     rackId,
     metadataMaxAge,
+    maxCooperativeRejoinRounds = MAX_COOPERATIVE_REJOIN_ROUNDS,
   }) {
     /** @type {import("../../types").Cluster} */
     this.cluster = cluster
@@ -107,6 +109,7 @@ module.exports = class ConsumerGroup {
     this.isolationLevel = isolationLevel
     this.rackId = rackId
     this.metadataMaxAge = metadataMaxAge
+    this.maxCooperativeRejoinRounds = maxCooperativeRejoinRounds
 
     this.seekOffset = new SeekOffsets()
     this.coordinator = null
@@ -241,7 +244,11 @@ module.exports = class ConsumerGroup {
 
       await this.cluster.addMultipleTargetTopics(allTopics)
       await this.cluster.refreshMetadata()
-      assignment = await assigner.assign({ members, topics: allTopics })
+      assignment = await assigner.assign({
+        members,
+        topics: topicsSubscribed,
+        allSubscribedTopics: allTopics,
+      })
 
       this.logger.debug('Group assignment', {
         groupId,
@@ -338,11 +345,17 @@ module.exports = class ConsumerGroup {
       (acc, { topic, partitions }) => ({ ...acc, [topic]: partitions }),
       {}
     )
+    const assignerName = this.groupProtocol
     for (const assigner of this.assigners) {
+      if (assignerName && assigner.name !== assignerName) {
+        continue
+      }
+
       if (typeof assigner.onAssignment === 'function') {
         const shouldRejoin = assigner.onAssignment({
           assignment: assignmentMap,
           generationId: this.generationId,
+          userData: decodedMemberAssignment.userData,
         })
         if (shouldRejoin) {
           this.needsCooperativeRejoin = true
@@ -380,9 +393,9 @@ module.exports = class ConsumerGroup {
       while (true) {
         cooperativeRejoinRound += 1
 
-        if (cooperativeRejoinRound > MAX_COOPERATIVE_REJOIN_ROUNDS) {
+        if (cooperativeRejoinRound > this.maxCooperativeRejoinRounds) {
           const error = new KafkaJSNonRetriableError(
-            `Exceeded maximum cooperative rejoin rounds (${MAX_COOPERATIVE_REJOIN_ROUNDS})`
+            `Exceeded maximum cooperative rejoin rounds (${this.maxCooperativeRejoinRounds})`
           )
 
           this.logger.error('Exceeded cooperative rejoin round limit', {
@@ -391,7 +404,7 @@ module.exports = class ConsumerGroup {
             leaderId: this.leaderId,
             groupProtocol: this.groupProtocol,
             cooperativeRejoinRound,
-            maxCooperativeRejoinRounds: MAX_COOPERATIVE_REJOIN_ROUNDS,
+            maxCooperativeRejoinRounds: this.maxCooperativeRejoinRounds,
             requestedBy: this.cooperativeRejoinRequestedBy,
           })
 
@@ -450,7 +463,7 @@ module.exports = class ConsumerGroup {
           leaderId: this.leaderId,
           groupProtocol: this.groupProtocol,
           cooperativeRejoinRound,
-          maxCooperativeRejoinRounds: MAX_COOPERATIVE_REJOIN_ROUNDS,
+          maxCooperativeRejoinRounds: this.maxCooperativeRejoinRounds,
           requestedBy: this.cooperativeRejoinRequestedBy,
         })
       }

--- a/src/consumer/consumerGroup.js
+++ b/src/consumer/consumerGroup.js
@@ -37,6 +37,8 @@ const PRIVATE = {
   SHARED_HEARTBEAT: Symbol('private:ConsumerGroup:sharedHeartbeat'),
 }
 
+const MAX_COOPERATIVE_REJOIN_ROUNDS = 20
+
 module.exports = class ConsumerGroup {
   /**
    * @param {object} options
@@ -113,6 +115,8 @@ module.exports = class ConsumerGroup {
     this.memberId = null
     this.members = null
     this.groupProtocol = null
+    this.needsCooperativeRejoin = false
+    this.cooperativeRejoinRequestedBy = []
 
     this.partitionsPerSubscribedTopic = null
     /**
@@ -327,6 +331,26 @@ module.exports = class ConsumerGroup {
 
     this.topics = currentMemberAssignment.map(({ topic }) => topic)
     this.subscriptionState.assign(currentMemberAssignment)
+
+    // Notify stateful assigners (e.g. cooperative sticky) about successful
+    // assignment so they can persist owned partitions in protocol userData.
+    const assignmentMap = currentMemberAssignment.reduce(
+      (acc, { topic, partitions }) => ({ ...acc, [topic]: partitions }),
+      {}
+    )
+    for (const assigner of this.assigners) {
+      if (typeof assigner.onAssignment === 'function') {
+        const shouldRejoin = assigner.onAssignment({
+          assignment: assignmentMap,
+          generationId: this.generationId,
+        })
+        if (shouldRejoin) {
+          this.needsCooperativeRejoin = true
+          this.cooperativeRejoinRequestedBy.push(assigner.name || 'unknown-assigner')
+        }
+      }
+    }
+
     this.offsetManager = new OffsetManager({
       cluster: this.cluster,
       topicConfigurations: this.topicConfigurations,
@@ -351,42 +375,84 @@ module.exports = class ConsumerGroup {
   joinAndSync() {
     const startJoin = Date.now()
     return this.retrier(async bail => {
-      try {
-        await this[PRIVATE.JOIN]()
-        await this[PRIVATE.SYNC]()
+      let cooperativeRejoinRound = 0
 
-        const memberAssignment = this.assigned().reduce(
-          (result, { topic, partitions }) => ({ ...result, [topic]: partitions }),
-          {}
-        )
+      while (true) {
+        cooperativeRejoinRound += 1
 
-        const payload = {
+        if (cooperativeRejoinRound > MAX_COOPERATIVE_REJOIN_ROUNDS) {
+          const error = new KafkaJSNonRetriableError(
+            `Exceeded maximum cooperative rejoin rounds (${MAX_COOPERATIVE_REJOIN_ROUNDS})`
+          )
+
+          this.logger.error('Exceeded cooperative rejoin round limit', {
+            groupId: this.groupId,
+            memberId: this.memberId,
+            leaderId: this.leaderId,
+            groupProtocol: this.groupProtocol,
+            cooperativeRejoinRound,
+            maxCooperativeRejoinRounds: MAX_COOPERATIVE_REJOIN_ROUNDS,
+            requestedBy: this.cooperativeRejoinRequestedBy,
+          })
+
+          bail(error)
+          return
+        }
+
+        try {
+          this.needsCooperativeRejoin = false
+          this.cooperativeRejoinRequestedBy = []
+          await this[PRIVATE.JOIN]()
+          await this[PRIVATE.SYNC]()
+
+          const memberAssignment = this.assigned().reduce(
+            (result, { topic, partitions }) => ({ ...result, [topic]: partitions }),
+            {}
+          )
+
+          const payload = {
+            groupId: this.groupId,
+            memberId: this.memberId,
+            leaderId: this.leaderId,
+            isLeader: this.isLeader(),
+            memberAssignment,
+            groupProtocol: this.groupProtocol,
+            duration: Date.now() - startJoin,
+          }
+
+          this.instrumentationEmitter.emit(GROUP_JOIN, payload)
+          this.logger.info('Consumer has joined the group', payload)
+        } catch (e) {
+          if (isRebalancing(e)) {
+            // Rebalance in progress isn't a retriable protocol error since the consumer
+            // has to go through find coordinator and join again before it can
+            // actually retry the operation. We wrap the original error in a retriable error
+            // here instead in order to restart the join + sync sequence using the retrier.
+            throw new KafkaJSError(e)
+          }
+
+          if (e.type === 'UNKNOWN_MEMBER_ID') {
+            this.memberId = null
+            throw new KafkaJSError(e)
+          }
+
+          bail(e)
+          return
+        }
+
+        if (!this.needsCooperativeRejoin) {
+          break
+        }
+
+        this.logger.warn('Cooperative assigner requested additional join/sync round', {
           groupId: this.groupId,
           memberId: this.memberId,
           leaderId: this.leaderId,
-          isLeader: this.isLeader(),
-          memberAssignment,
           groupProtocol: this.groupProtocol,
-          duration: Date.now() - startJoin,
-        }
-
-        this.instrumentationEmitter.emit(GROUP_JOIN, payload)
-        this.logger.info('Consumer has joined the group', payload)
-      } catch (e) {
-        if (isRebalancing(e)) {
-          // Rebalance in progress isn't a retriable protocol error since the consumer
-          // has to go through find coordinator and join again before it can
-          // actually retry the operation. We wrap the original error in a retriable error
-          // here instead in order to restart the join + sync sequence using the retrier.
-          throw new KafkaJSError(e)
-        }
-
-        if (e.type === 'UNKNOWN_MEMBER_ID') {
-          this.memberId = null
-          throw new KafkaJSError(e)
-        }
-
-        bail(e)
+          cooperativeRejoinRound,
+          maxCooperativeRejoinRounds: MAX_COOPERATIVE_REJOIN_ROUNDS,
+          requestedBy: this.cooperativeRejoinRequestedBy,
+        })
       }
     })
   }

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -40,6 +40,7 @@ const specialOffsets = [
  * @param {number} [params.maxWaitTimeInMs]
  * @param {number} [params.isolationLevel]
  * @param {string} [params.rackId]
+ * @param {number} [params.maxCooperativeRejoinRounds]
  * @param {InstrumentationEventEmitter} [params.instrumentationEmitter]
  * @param {number} params.metadataMaxAge
  *
@@ -60,6 +61,7 @@ module.exports = ({
   maxWaitTimeInMs = 5000,
   isolationLevel = ISOLATION_LEVEL.READ_COMMITTED,
   rackId = '',
+  maxCooperativeRejoinRounds,
   instrumentationEmitter: rootInstrumentationEmitter,
   metadataMaxAge,
 }) => {
@@ -224,6 +226,7 @@ module.exports = ({
         autoCommit,
         autoCommitInterval,
         autoCommitThreshold,
+        maxCooperativeRejoinRounds,
       })
 
       runner = new Runner({

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,7 @@ module.exports = class Client {
     maxInFlightRequests,
     readUncommitted = false,
     rackId = '',
+    maxCooperativeRejoinRounds,
   } = {}) {
     const isolationLevel = readUncommitted
       ? ISOLATION_LEVEL.READ_UNCOMMITTED
@@ -182,6 +183,7 @@ module.exports = class Client {
       instrumentationEmitter,
       rackId,
       metadataMaxAge,
+      maxCooperativeRejoinRounds,
     })
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -577,7 +577,10 @@ export type Admin = {
   readonly events: AdminEvents
 }
 
-export const PartitionAssigners: { roundRobin: PartitionAssigner }
+export const PartitionAssigners: {
+  roundRobin: PartitionAssigner
+  cooperativeSticky: PartitionAssigner
+}
 
 export interface ISerializer<T> {
   encode(value: T): Buffer

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -152,6 +152,7 @@ export interface IHeaders {
 export interface ConsumerConfig {
   groupId: string
   partitionAssigners?: PartitionAssigner[]
+  maxCooperativeRejoinRounds?: number
   metadataMaxAge?: number
   sessionTimeout?: number
   rebalanceTimeout?: number
@@ -221,7 +222,11 @@ export type GroupState = { name: string; metadata: Buffer }
 export type Assigner = {
   name: string
   version: number
-  assign(group: { members: GroupMember[]; topics: string[] }): Promise<GroupMemberAssignment[]>
+  assign(group: {
+    members: GroupMember[]
+    topics: string[]
+    allSubscribedTopics?: string[]
+  }): Promise<GroupMemberAssignment[]>
   protocol(subscription: { topics: string[] }): GroupState
 }
 


### PR DESCRIPTION
## Context

This PR introduces a `cooperative-sticky` assigner implementation and adds safety guards around cooperative rejoin flow in `consumerGroup`.

It also includes the mixed-subscription assignment fixes from the branch baseline (`pr-1776`) so topic-union and decode-fallback behavior is covered end-to-end.

## What changed

- Added `src/consumer/assigners/cooperativeStickyAssigner/`
  - protocol name: `cooperative-sticky`
  - cooperative transfer behavior (withholding transferring partitions in first round)
  - robust metadata/userData decode fallback
  - state persistence hooks through `onAssignment()` + `protocol()` userData
- Exported assigner in `src/consumer/assigners/index.js`
- Added/updated tests:
  - `src/consumer/assigners/cooperativeStickyAssigner/index.spec.js`
  - `src/consumer/assigners/roundRobinAssigner/index.spec.js`
  - `src/consumer/__tests__/consumerGroup.spec.js`
- Hardened `joinAndSync()` in `src/consumer/consumerGroup.js`
  - max cooperative rejoin rounds guard
  - warning/error logs with cooperative round diagnostics and triggering assigners

## Safety / behavior notes

- Prevents silent infinite cooperative rejoin loops when assigners regress.
- Keeps rebalance resilient when `MemberMetadata.decode`/userData decoding fails.
- Supports mixed-topic rolling deployments where group members have heterogeneous subscriptions.

## Tests run

```bash
NODE_ENV=test npx jest --runInBand --no-watchman src/consumer/assigners/cooperativeStickyAssigner/index.spec.js src/consumer/assigners/roundRobinAssigner/index.spec.js src/consumer/__tests__/consumerGroup.spec.js
```

All passed locally.

## Commits included

- `fix: Multiple kakfa consumer with the same groupId and different topics` (branch baseline from `pr-1776`)
- `fix(consumer): guard cooperative rejoin loop with max rounds and diagnostics`
- `feat(consumer): add cooperative sticky assigner with regression tests`
